### PR TITLE
fix: length calculation of .string `HTTPBody`

### DIFF
--- a/Sources/NIOHTTPClient/HTTPHandler.swift
+++ b/Sources/NIOHTTPClient/HTTPHandler.swift
@@ -60,7 +60,7 @@ public enum HTTPBody : Equatable {
         case .data(let data):
             return data.count
         case .string(let string):
-            return string.count
+            return string.utf8.count
         }
     }
 }
@@ -342,7 +342,7 @@ class HTTPTaskHandler<T: HTTPResponseDelegate> : ChannelInboundHandler, ChannelO
                 buffer.writeBytes(data)
                 part = HTTPClientRequestPart.body(.byteBuffer(buffer))
             case .string(let string):
-                var buffer = context.channel.allocator.buffer(capacity: string.count)
+                var buffer = context.channel.allocator.buffer(capacity: string.utf8.count)
                 buffer.writeString(string)
                 part = HTTPClientRequestPart.body(.byteBuffer(buffer))
             }


### PR DESCRIPTION
Currently, if an `HTTPBody` is set to .string, the length is calculated as
string.count. In Swift, this is the number of extended grapheme clusters, not
the UTF8 byte count. Instead, we should use the count of the UTF8View, as the
bytes will be transmitted in this encoding.