### PR TITLE
Pass HTTPTask to HTTPResponseDelegate methods

### DIFF
--- a/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
+++ b/Sources/NIOHTTPClient/SwiftNIOHTTP.swift
@@ -147,6 +147,8 @@ public class HTTPClient {
             redirectHandler = nil
         }
 
+        let task = HTTPTask(future: promise.futureResult)
+
         var bootstrap = ClientBootstrap(group: group)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
             .channelInitializer { channel in
@@ -159,15 +161,13 @@ public class HTTPClient {
                     return channel.eventLoop.makeSucceededFuture(())
                 }
             }.flatMap {
-                channel.pipeline.addHandler(HTTPTaskHandler(delegate: delegate, promise: promise, redirectHandler: redirectHandler))
+                channel.pipeline.addHandler(HTTPTaskHandler(task: task, delegate: delegate, promise: promise, redirectHandler: redirectHandler))
             }
         }
 
         if let connectTimeout = timeout.connect {
             bootstrap = bootstrap.connectTimeout(connectTimeout)
         }
-
-        let task = HTTPTask(future: promise.futureResult)
 
         bootstrap.connect(host: request.host, port: request.port)
             .map { channel in

--- a/Sources/NIOHTTPClient/Utils.swift
+++ b/Sources/NIOHTTPClient/Utils.swift
@@ -25,27 +25,27 @@ public class HandlingHTTPResponseDelegate<T>: HTTPResponseDelegate {
     var handleError: ((Error) -> Void)?
     var handleEnd: (() throws -> T)?
 
-    public func didTransmitRequestBody() {}
+    public func didTransmitRequestBody(task: HTTPTask<T>) {}
 
-    public func didReceiveHead(_ head: HTTPResponseHead) {
+    public func didReceiveHead(task: HTTPTask<T>, _ head: HTTPResponseHead) {
         if let handler = handleHead {
             handler(head)
         }
     }
 
-    public func didReceivePart(_ buffer: ByteBuffer) {
+    public func didReceivePart(task: HTTPTask<T>, _ buffer: ByteBuffer) {
         if let handler = handleBody {
             handler(buffer)
         }
     }
 
-    public func didReceiveError(_ error: Error) {
+    public func didReceiveError(task: HTTPTask<T>, _ error: Error) {
         if let handler = handleError {
             handler(error)
         }
     }
 
-    public func didFinishRequest() throws -> T {
+    public func didFinishRequest(task: HTTPTask<T>) throws -> T {
         if let handler = handleEnd {
             return try handler()
         }

--- a/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/NIOHTTPClientTests/HTTPClientTestUtils.swift
@@ -23,11 +23,11 @@ class TestHTTPDelegate: HTTPResponseDelegate {
 
     var state = HTTPResponseAccumulator.State.idle
 
-    func didReceiveHead(_ head: HTTPResponseHead) {
+    func didReceiveHead(task: HTTPTask<Response>, _ head: HTTPResponseHead) {
         self.state = .head(head)
     }
 
-    func didReceivePart(_ buffer: ByteBuffer) {
+    func didReceivePart(task: HTTPTask<Response>, _ buffer: ByteBuffer) {
         switch self.state {
         case .head(let head):
             self.state = .body(head, buffer)
@@ -40,7 +40,7 @@ class TestHTTPDelegate: HTTPResponseDelegate {
         }
     }
 
-    func didFinishRequest() throws {}
+    func didFinishRequest(task: HTTPTask<Response>) throws {}
 }
 
 class CountingDelegate: HTTPResponseDelegate {
@@ -48,7 +48,7 @@ class CountingDelegate: HTTPResponseDelegate {
 
     var count = 0
 
-    func didReceivePart(_ buffer: ByteBuffer) {
+    func didReceivePart(task: HTTPTask<Response>, _ buffer: ByteBuffer) {
         var buffer = buffer
         let str = buffer.readString(length: buffer.readableBytes)
         if str?.starts(with: "id:") ?? false {
@@ -56,7 +56,7 @@ class CountingDelegate: HTTPResponseDelegate {
         }
     }
 
-    func didFinishRequest() throws -> Int {
+    func didFinishRequest(task: HTTPTask<Response>) throws -> Int {
         return self.count
     }
 }

--- a/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
+++ b/Tests/NIOHTTPClientTests/SwiftNIOHTTPTests.swift
@@ -34,9 +34,11 @@ class SwiftHTTPTests: XCTestCase {
     func testHTTPPartsHandler() throws {
         let channel = EmbeddedChannel()
         let recorder = RecordingHandler<HTTPClientResponsePart, HTTPClientRequestPart>()
+        let promise: EventLoopPromise<Void> = channel.eventLoop.makePromise()
+        let task = HTTPTask(future: promise.futureResult)
 
         try channel.pipeline.addHandler(recorder).wait()
-        try channel.pipeline.addHandler(HTTPTaskHandler(delegate: TestHTTPDelegate(), promise: channel.eventLoop.makePromise(), redirectHandler: nil)).wait()
+        try channel.pipeline.addHandler(HTTPTaskHandler(task: task, delegate: TestHTTPDelegate(), promise: promise, redirectHandler: nil)).wait()
 
         var request = try HTTPRequest(url: "http://localhost/get")
         request.headers.add(name: "X-Test-Header", value: "X-Test-Value")
@@ -60,7 +62,9 @@ class SwiftHTTPTests: XCTestCase {
     func testHTTPPartsHandlerMultiBody() throws {
         let channel = EmbeddedChannel()
         let delegate = TestHTTPDelegate()
-        let handler = HTTPTaskHandler(delegate: delegate, promise: channel.eventLoop.makePromise(), redirectHandler: nil)
+        let promise: EventLoopPromise<Void> = channel.eventLoop.makePromise()
+        let task = HTTPTask(future: promise.futureResult)
+        let handler = HTTPTaskHandler(task: task, delegate: delegate, promise: promise, redirectHandler: nil)
 
         try channel.pipeline.addHandler(handler).wait()
 


### PR DESCRIPTION
Currently the `HTTPResponseDelegate` has no access to the `HTTPTask`. This means that cancellation is not supported if a request is being streamed via the delegate.

Solve this by storing a reference to the `HTTPTask` in the `HTTPTaskHandler`, so it can pass the task through as it call the delegate methods.

Fixes #9.