### PR TITLE
Make sure that event loop of task is the same as event loop of channel

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -123,7 +123,7 @@ public class HTTPClient {
 
         let task = Task<T.Response>(eventLoop: eventLoop)
 
-        var bootstrap = ClientBootstrap(group: self.eventLoopGroup)
+        var bootstrap = ClientBootstrap(group: eventLoop)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
             .channelInitializer { channel in
                 let encoder = HTTPRequestEncoder()

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -271,6 +271,7 @@ extension HTTPClient {
         }
 
         func setChannel(_ channel: Channel) -> Channel {
+            precondition(self.eventLoop === channel.eventLoop, "Channel must use same event loop as this task.")
             return self.lock.withLock {
                 self.channel = channel
                 return channel

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -27,6 +27,7 @@ extension HTTPClientTests {
         return [
             ("testRequestURI", testRequestURI),
             ("testGet", testGet),
+            ("testGetWithSharedEventLoopGroup", testGetWithSharedEventLoopGroup),
             ("testPost", testPost),
             ("testGetHttps", testGetHttps),
             ("testPostHttps", testPostHttps),


### PR DESCRIPTION
As discussed in #54, currently if using a shared event loop group object to create a `HTTPClient`, the `eventLoop` property of the `Channel` will most likely not be the same as the `eventLoop` property of the `Task`. This can lead to a precondition failure, when the task delegate hops to the the task`s event loop.

This patch makes sure that both the task and the connection (channel) share the same event loop instance.

It also add a precondition on `Task.setChannel(_:)` to verify that the channel uses the same event loop as the task.

The provided test would trigger the `precondition` failure if the event loops would not match.