### PR TITLE
Don't add default Connection header if it exists

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -448,7 +448,9 @@ internal class TaskHandler<T: HTTPClientResponseDelegate>: ChannelInboundHandler
             headers.add(name: "Host", value: request.host)
         }
 
-        headers.add(name: "Connection", value: "close")
+        if !request.headers.contains(name: "Connection") {
+            headers.add(name: "Connection", value: "close")
+        }
 
         do {
             try headers.validate(body: request.body)


### PR DESCRIPTION
Hi there,

The `NIOSSL.NIOSSLError.uncleanShutdown` was happened when I post `https://accounts.google.com/o/oauth2/token` using the following code, because the `Connection: close` header was automatic added.
```swift
// main.swift

import AsyncHTTPClient
import NIO

let eventLoop = MultiThreadedEventLoopGroup(numberOfThreads: 1).next()
let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoop))

try httpClient.post(url: "https://accounts.google.com/o/oauth2/token", body: .string("")).flatMap { response -> EventLoopFuture<()> in
    print(response.status)
    return eventLoop.makeSucceededFuture(())
}.flatMapError { error in
    // NIOSSL.NIOSSLError.uncleanShutdown happened
    print(error)
    return eventLoop.makeFailedFuture(error)
}.wait()
```

So, I think we should not add it if user provide Connection header. In this case, user can make request by `try HTTPClient.Request(url: "https://accounts.google.com/o/oauth2/token", method: .POST, headers: .init([("Connection", "keep-alive")]), body: .string(""))`.

Please review it, thx.

