### PR TITLE
Add init to HTTPClient.Response

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -179,6 +179,20 @@ extension HTTPClient {
         public var headers: HTTPHeaders
         /// Response body.
         public var body: ByteBuffer?
+        
+        /// Create HTTP `Response`.
+        ///
+        /// - parameters:
+        ///     - host: Remote host of the request.
+        ///     - status: Response HTTP status.
+        ///     - headers: Reponse HTTP headers.
+        ///     - body: Response body.
+        public init(host: String, status: HTTPResponseStatus, headers: HTTPHeaders, body: ByteBuffer?) {
+            self.host = host
+            self.status = status
+            self.headers = headers
+            self.body = body
+        }
     }
 }
 

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -179,7 +179,7 @@ extension HTTPClient {
         public var headers: HTTPHeaders
         /// Response body.
         public var body: ByteBuffer?
-        
+
         /// Create HTTP `Response`.
         ///
         /// - parameters:


### PR DESCRIPTION
Hi there,

I want custom `ResponseAccumulator` delegate like https://github.com/swift-server/async-http-client/pull/74#issuecomment-518506014 , so can we public init function for `HTTPClient.Response`? please review it if we can.
