### PR TITLE
Add @discardableResult to HTTPHandler setChannel method

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -403,6 +403,7 @@ extension HTTPClient {
             }
         }
 
+        @discardableResult
         func setChannel(_ channel: Channel) -> Channel {
             precondition(self.eventLoop === channel.eventLoop, "Channel must use same event loop as this task.")
             return self.lock.withLock {


### PR DESCRIPTION
The only place where this method is currently called uses its return
value, but that's specific to the context where it's used (inside of
chained calls to map/flatMap). Future uses might not always need to use
the return value since it is the same as what's passed as the method
argument.