### PR TITLE
fix README: fixed a couple of documentation mistakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The code snippet below illustrates how to make a simple GET request to a remote 
 
 Please note that the example will spawn a new `EventLoopGroup` which will _create fresh threads_ which is a very costly operation. In a real-world application that uses [SwiftNIO](https://github.com/apple/swift-nio) for other parts of your application (for example a web server), please prefer `eventLoopGroupProvider: .shared(myExistingEventLoopGroup)` to share the `EventLoopGroup` used by AsyncHTTPClient with other parts of your application.
 
-If your application does not use SwiftNIO yet, it is acceptable to use `eventLoopGroupProvider: .createNew` but please make sure to share the returned `HTTPClient` instance throughout your whole application. Do not create a large number of `HTTPClient` instances with `eventLoopGroupProvider: .createNew`, this is very wasteful and might exhaust the resources of your calling program.
+If your application does not use SwiftNIO yet, it is acceptable to use `eventLoopGroupProvider: .createNew` but please make sure to share the returned `HTTPClient` instance throughout your whole application. Do not create a large number of `HTTPClient` instances with `eventLoopGroupProvider: .createNew`, this is very wasteful and might exhaust the resources of your program.
 
 ```swift
 import AsyncHTTPClient


### PR DESCRIPTION
- README suggested that you should shut down the client in a `defer` block right after calling `get` which will not actually work because the `get` is asynchronous so returns before it's done
- README said that if you share the `EventLoop` you don't need to shut down the `HTTPClient` which is not true
- README didn't make it clear that using `HTTPClient(eventLoopGroupProvider: .createNew)` is an acceptable thing to write in many places but it's really resource inefficient