### PR TITLE
refactor proxy configuration

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -279,7 +279,7 @@ public class HTTPClient {
         }
     }
 
-    private func resolveAddress(request: Request, proxy: Proxy?) -> (host: String, port: Int) {
+    private func resolveAddress(request: Request, proxy: Configuration.Proxy?) -> (host: String, port: Int) {
         switch self.configuration.proxy {
         case .none:
             return (request.host, request.port)

--- a/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
@@ -24,11 +24,19 @@ import NIOHTTP1
 /// If a `TLSConfiguration` is used in conjunction with `HTTPClientProxy`,
 /// TLS will be established _after_ successful proxy, between your client
 /// and the destination server.
-public extension HTTPClient {
+public extension HTTPClient.Configuration {
+    /// Proxy server configuration
     struct Proxy {
-        internal let host: String
-        internal let port: Int
+        /// Specifies Proxy server host.
+        public var host: String
+        /// Specifies Proxy server port.
+        public var port: Int
 
+        /// Create proxy.
+        ///
+        /// - parameters:
+        ///     - host: proxy server host.
+        ///     - port: proxy server port.
         public static func server(host: String, port: Int) -> Proxy {
             return .init(host: host, port: port)
         }

--- a/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
@@ -15,17 +15,17 @@
 import NIO
 import NIOHTTP1
 
-/// Specifies the remote address of an HTTP proxy.
-///
-/// Adding an `HTTPClientProxy` to your client's `HTTPClient.Configuration`
-/// will cause requests to be passed through the specified proxy using the
-/// HTTP `CONNECT` method.
-///
-/// If a `TLSConfiguration` is used in conjunction with `HTTPClientProxy`,
-/// TLS will be established _after_ successful proxy, between your client
-/// and the destination server.
 public extension HTTPClient.Configuration {
     /// Proxy server configuration
+    /// Specifies the remote address of an HTTP proxy.
+    ///
+    /// Adding an `Proxy` to your client's `HTTPClient.Configuration`
+    /// will cause requests to be passed through the specified proxy using the
+    /// HTTP `CONNECT` method.
+    ///
+    /// If a `TLSConfiguration` is used in conjunction with `HTTPClient.Configuration.Proxy`,
+    /// TLS will be established _after_ successful proxy, between your client
+    /// and the destination server.
     struct Proxy {
         /// Specifies Proxy server host.
         public var host: String


### PR DESCRIPTION
motivation: make proxy configuration follow same convention as other configuration

changes:
* nest Proxy under HTTPClient.Configuration instad of top level HTTPClient
* make host and port public and mutable, following convention of other configuration objects in this library
* add some API docs