### PR TITLE
EventLoop preference overhaul

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
     ],
     targets: [

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -26,11 +26,13 @@ extension HTTPClientInternalTests {
     static var allTests: [(String, (HTTPClientInternalTests) -> () throws -> Void)] {
         return [
             ("testHTTPPartsHandler", testHTTPPartsHandler),
+            ("testBadHTTPRequest", testBadHTTPRequest),
             ("testHTTPPartsHandlerMultiBody", testHTTPPartsHandlerMultiBody),
             ("testProxyStreaming", testProxyStreaming),
             ("testProxyStreamingFailure", testProxyStreamingFailure),
             ("testUploadStreamingBackpressure", testUploadStreamingBackpressure),
             ("testRequestURITrailingSlash", testRequestURITrailingSlash),
+            ("testChannelAndDelegateOnDifferentEventLoops", testChannelAndDelegateOnDifferentEventLoops),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -40,7 +40,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
 
     func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         self.state = .head(head)
-        return (self.backpressureEventLoop ?? task.currentEventLoop).makeSucceededFuture(())
+        return (self.backpressureEventLoop ?? task.eventLoop).makeSucceededFuture(())
     }
 
     func didReceiveBodyPart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
@@ -54,7 +54,7 @@ class TestHTTPDelegate: HTTPClientResponseDelegate {
         default:
             preconditionFailure("expecting head or body")
         }
-        return (self.backpressureEventLoop ?? task.currentEventLoop).makeSucceededFuture(())
+        return (self.backpressureEventLoop ?? task.eventLoop).makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws {}
@@ -70,7 +70,7 @@ class CountingDelegate: HTTPClientResponseDelegate {
         if str?.starts(with: "id:") ?? false {
             self.count += 1
         }
-        return task.currentEventLoop.makeSucceededFuture(())
+        return task.eventLoop.makeSucceededFuture(())
     }
 
     func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Int {
@@ -314,6 +314,9 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 return
             }
         case .body(let body):
+            if self.resps.isEmpty {
+                return
+            }
             var response = self.resps.removeFirst()
             response.add(body)
             self.resps.prepend(response)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -543,8 +543,8 @@ class HTTPClientTests: XCTestCase {
             }
 
             func didReceiveHead(task: HTTPClient.Task<Bool>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
-                self.result = task.currentEventLoop === self.eventLoop
-                return task.currentEventLoop.makeSucceededFuture(())
+                self.result = task.eventLoop === self.eventLoop
+                return task.eventLoop.makeSucceededFuture(())
             }
 
             func didFinishRequest(task: HTTPClient.Task<Bool>) throws -> Bool {
@@ -555,12 +555,12 @@ class HTTPClientTests: XCTestCase {
         let eventLoop = eventLoopGroup.next()
         let delegate = EventLoopValidatingDelegate(eventLoop: eventLoop)
         var request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/get")
-        var response = try httpClient.execute(request: request, delegate: delegate, eventLoop: .prefers(eventLoop)).wait()
+        var response = try httpClient.execute(request: request, delegate: delegate, eventLoop: .delegate(on: eventLoop)).wait()
         XCTAssertEqual(true, response)
 
         // redirect
         request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/redirect/302")
-        response = try httpClient.execute(request: request, delegate: delegate, eventLoop: .prefers(eventLoop)).wait()
+        response = try httpClient.execute(request: request, delegate: delegate, eventLoop: .delegate(on: eventLoop)).wait()
         XCTAssertEqual(true, response)
     }
 }


### PR DESCRIPTION
Motivation:

With #96 we changed `HTTPClient.Task`'s `eventLoop` property to be `currentEventLoop` because we anticipated that it might change because of the connection pool work that's ongoing.
That however made the programming model rather hard because the user didn't get any guarantee anymore on which `EventLoop` the delegate would run.
With this patch, we're bringing `eventLoop` back which is the `EventLoop` the delegate will run on. Note that it's not necessarily the `EventLoop` the `Channel` will run on. If the user requires those to be the same, the can request that with `EventLoopPreference.delegateAndChannel(on: eventLoop)` rather than `.indifferent` or `.delegate(on: eventLoop)`

Modification:

Let the user select between:

- `.indifferent`: I don't care about the `EventLoop`
- `.delegate(on: eventLoop)`: I want the delegate to be called on `eventLoop` and I would _prefer_ the `Channel` to be on `eventLoop` too but I'm happy if not
- `.delegateAndChannel(on: eventLoop)`: I want `Channel` and delegate to live on `eventLoop`

Result:

- Happier users because the programming model is easier
- fixes #100 