### PR TITLE
Remove spaces in range operators

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -8,5 +8,6 @@
 --patternlet inline
 --stripunusedargs unnamed-only
 --comments ignore
+--ranges nospace
 
 # rules

--- a/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
@@ -96,7 +96,7 @@ internal final class HTTPClientProxyHandler: ChannelDuplexHandler, RemovableChan
             switch res {
             case .head(let head):
                 switch head.status.code {
-                case 200 ..< 300:
+                case 200..<300:
                     // Any 2xx (Successful) response indicates that the sender (and all
                     // inbound proxies) will switch to tunnel mode immediately after the
                     // blank line that concludes the successful response's header section

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -299,7 +299,7 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 return
             case "/events/10/1": // TODO: parse path
                 context.write(wrapOutboundOut(.head(HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok))), promise: nil)
-                for i in 0 ..< 10 {
+                for i in 0..<10 {
                     let msg = "id: \(i)"
                     var buf = context.channel.allocator.buffer(capacity: msg.count)
                     buf.writeString(msg)


### PR DESCRIPTION
This is a question of preference, but it looks like the most commonly used format for ranges in Swift projects is what can [be found in the Swift Book](https://docs.swift.org/swift-book/LanguageGuide/BasicOperators.html) where there is no space between the values and range operators, for instance: `case 200..<300:` contrary to the current `case 200 ..< 300`.

What do you think? 🙂 

