### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ Package.resolved
 *.xcodeproj
 DerivedData
 .DS_Store
+.swiftpm/


### PR DESCRIPTION
Ignore `.swiftpm/` since there is currently no need to share the settings of the IDEs stored in `.swiftpm/`