### PR TITLE
add support for redirect limits

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -433,7 +433,13 @@ extension HTTPClient.Configuration {
     public enum RedirectPolicy {
         /// Redirects are not followed.
         case disallow
-        /// Redirects are followed with a specified limit. Cycle detection reqiures that all visited URL's are kept in memory.
+        /// Redirects are followed with a specified limit.
+        ///
+        /// - parameters:
+        ///     - max: The maximum number of allowed redirects.
+        ///     - allowCycles: Whether cycles are allowed.
+        ///
+        /// - warning: Cycle detection will keep all visited URLs in memory which means a malicious server could use this as a denial-of-service vector.
         case allow(max: Int, allowCycles: Bool)
     }
 }

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -486,6 +486,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case contentLengthMissing
         case proxyAuthenticationRequired
         case redirectLimitReached
+        case redirectCycleDetected
     }
 
     private var code: Code
@@ -526,4 +527,6 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     public static let proxyAuthenticationRequired = HTTPClientError(code: .proxyAuthenticationRequired)
     /// Redirect Limit reached.
     public static let redirectLimitReached = HTTPClientError(code: .redirectLimitReached)
+    /// Redirect Cycle detected.
+    public static let redirectCycleDetected = HTTPClientError(code: .redirectCycleDetected)
 }

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -787,9 +787,9 @@ extension TaskHandler: ChannelDuplexHandler {
 // MARK: - RedirectHandler
 
 internal struct RedirectHandler<ResponseType> {
-    let limit: HTTPClient.Configuration.RedirectLimit.Next
+    let state: HTTPClient.Configuration.RedirectPolicy.State
     let request: HTTPClient.Request
-    let execute: (HTTPClient.Request, HTTPClient.Configuration.RedirectLimit.Next) -> HTTPClient.Task<ResponseType>
+    let execute: (HTTPClient.Request, HTTPClient.Configuration.RedirectPolicy.State) -> HTTPClient.Task<ResponseType>
 
     func redirectTarget(status: HTTPResponseStatus, headers: HTTPHeaders) -> URL? {
         switch status {
@@ -819,22 +819,20 @@ internal struct RedirectHandler<ResponseType> {
     }
 
     func redirect(status: HTTPResponseStatus, to redirectURL: URL, promise: EventLoopPromise<ResponseType>) {
-        let nextLimit: HTTPClient.Configuration.RedirectLimit.Next
-        switch self.limit {
-        case .none:
-            nextLimit = .none
-        case .count(let left):
-            guard left > 0 else {
+        var newState = self.state
+        guard newState.count > 0 else {
+            return promise.fail(HTTPClientError.redirectLimitReached)
+        }
+
+        newState.count -= 1
+
+        if var visited = newState.visited {
+            guard !visited.contains(redirectURL) else {
                 return promise.fail(HTTPClientError.redirectLimitReached)
             }
-            nextLimit = .count(left: left - 1)
-        case .loop(let visited):
-            if visited.contains(redirectURL) {
-                return promise.fail(HTTPClientError.redirectLimitReached)
-            }
-            var visited = visited
+
             visited.insert(redirectURL)
-            nextLimit = .loop(visited: visited)
+            newState.visited = visited
         }
 
         let originalRequest = self.request
@@ -866,7 +864,7 @@ internal struct RedirectHandler<ResponseType> {
 
         do {
             let newRequest = try HTTPClient.Request(url: redirectURL, method: method, headers: headers, body: body)
-            return self.execute(newRequest, nextLimit).futureResult.cascade(to: promise)
+            return self.execute(newRequest, newState).futureResult.cascade(to: promise)
         } catch {
             return promise.fail(error)
         }

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -824,7 +824,7 @@ internal struct RedirectHandler<ResponseType> {
         case .none:
             nextLimit = .none
         case .count(let left):
-            if left == 0 {
+            guard left > 0 else {
                 return promise.fail(HTTPClientError.redirectLimitReached)
             }
             nextLimit = .count(left: left - 1)

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -837,7 +837,7 @@ internal struct RedirectHandler<ResponseType> {
 
             if var visited = state.visited {
                 guard !visited.contains(redirectURL) else {
-                    return promise.fail(HTTPClientError.redirectLimitReached)
+                    return promise.fail(HTTPClientError.redirectCycleDetected)
                 }
 
                 visited.insert(redirectURL)

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -456,7 +456,7 @@ extension HTTPClient {
         public let eventLoop: EventLoop
 
         let promise: EventLoopPromise<Response>
-        private var channel: Channel?
+        var channel: Channel?
         private var cancelled: Bool
         private let lock: Lock
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -242,6 +242,7 @@ class HTTPClientInternalTests: XCTestCase {
         // At this point all other bytes should be delivered.
         XCTAssertEqual(delegate.reads, 4)
     }
+
     func testRequestURITrailingSlash() throws {
         let request1 = try Request(url: "https://someserver.com:8888/some/path?foo=bar#ref")
         XCTAssertEqual(request1.url.uri, "/some/path?foo=bar")

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -273,6 +273,16 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 headers.add(name: "Location", value: "http://127.0.0.1:\(port)/echohostheader")
                 self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
                 return
+            case "/redirect/infinite1":
+                var headers = HTTPHeaders()
+                headers.add(name: "Location", value: "/redirect/infinite2")
+                self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
+                return
+            case "/redirect/infinite2":
+                var headers = HTTPHeaders()
+                headers.add(name: "Location", value: "/redirect/infinite1")
+                self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
+                return
             // Since this String is taken from URL.path, the percent encoding has been removed
             case "/percent encoded":
                 if req.method != .GET {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -305,7 +305,7 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 context.close(promise: nil)
                 return
             case "/custom":
-                context.write(wrapOutboundOut(.head(HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok))), promise: nil)
+                context.writeAndFlush(wrapOutboundOut(.head(HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok))), promise: nil)
                 return
             case "/events/10/1": // TODO: parse path
                 context.write(wrapOutboundOut(.head(HTTPResponseHead(version: HTTPVersion(major: 1, minor: 1), status: .ok))), promise: nil)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -57,6 +57,8 @@ extension HTTPClientTests {
             ("testWrongContentLengthForSSLUncleanShutdown", testWrongContentLengthForSSLUncleanShutdown),
             ("testWrongContentLengthWithIgnoreErrorForSSLUncleanShutdown", testWrongContentLengthWithIgnoreErrorForSSLUncleanShutdown),
             ("testEventLoopArgument", testEventLoopArgument),
+            ("testLoopDetectionRedirectLimit", testLoopDetectionRedirectLimit),
+            ("testCountRedirectLimit", testCountRedirectLimit),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -574,7 +574,7 @@ class HTTPClientTests: XCTestCase {
         }
 
         XCTAssertThrowsError(try httpClient.get(url: "https://localhost:\(httpBin.port)/redirect/infinite1").wait(), "Should fail with redirect limit") { error in
-            XCTAssertEqual(error as! HTTPClientError, HTTPClientError.redirectLimitReached)
+            XCTAssertEqual(error as! HTTPClientError, HTTPClientError.redirectCycleDetected)
         }
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -130,7 +130,7 @@ class HTTPClientTests: XCTestCase {
         let httpBin = HTTPBin(ssl: false)
         let httpsBin = HTTPBin(ssl: true)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, followRedirects: .enabled(limit: .none)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 10, allowCycles: true)))
 
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
@@ -148,7 +148,7 @@ class HTTPClientTests: XCTestCase {
     func testHttpHostRedirect() throws {
         let httpBin = HTTPBin(ssl: false)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, followRedirects: .enabled(limit: .none)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 10, allowCycles: true)))
 
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
@@ -525,7 +525,7 @@ class HTTPClientTests: XCTestCase {
         let httpBin = HTTPBin()
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 5)
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup),
-                                    configuration: HTTPClient.Configuration(followRedirects: .enabled(limit: .none)))
+                                    configuration: HTTPClient.Configuration(redirects: .allow(max: 10, allowCycles: true)))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
@@ -567,7 +567,7 @@ class HTTPClientTests: XCTestCase {
     func testLoopDetectionRedirectLimit() throws {
         let httpBin = HTTPBin(ssl: true)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, followRedirects: .enabled(limit: .detectLoop)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 5, allowCycles: false)))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try httpBin.shutdown())
@@ -581,7 +581,7 @@ class HTTPClientTests: XCTestCase {
     func testCountRedirectLimit() throws {
         let httpBin = HTTPBin(ssl: true)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, followRedirects: .enabled(limit: .count(5))))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 5, allowCycles: true)))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try httpBin.shutdown())

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -130,7 +130,7 @@ class HTTPClientTests: XCTestCase {
         let httpBin = HTTPBin(ssl: false)
         let httpsBin = HTTPBin(ssl: true)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 10, allowCycles: true)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirectConfiguration: .follow(max: 10, allowCycles: true)))
 
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
@@ -148,7 +148,7 @@ class HTTPClientTests: XCTestCase {
     func testHttpHostRedirect() throws {
         let httpBin = HTTPBin(ssl: false)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 10, allowCycles: true)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirectConfiguration: .follow(max: 10, allowCycles: true)))
 
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
@@ -525,7 +525,7 @@ class HTTPClientTests: XCTestCase {
         let httpBin = HTTPBin()
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 5)
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(eventLoopGroup),
-                                    configuration: HTTPClient.Configuration(redirects: .allow(max: 10, allowCycles: true)))
+                                    configuration: HTTPClient.Configuration(redirectConfiguration: .follow(max: 10, allowCycles: true)))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
@@ -567,7 +567,7 @@ class HTTPClientTests: XCTestCase {
     func testLoopDetectionRedirectLimit() throws {
         let httpBin = HTTPBin(ssl: true)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 5, allowCycles: false)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirectConfiguration: .follow(max: 5, allowCycles: false)))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try httpBin.shutdown())
@@ -581,7 +581,7 @@ class HTTPClientTests: XCTestCase {
     func testCountRedirectLimit() throws {
         let httpBin = HTTPBin(ssl: true)
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew,
-                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirects: .allow(max: 5, allowCycles: true)))
+                                    configuration: HTTPClient.Configuration(certificateVerification: .none, redirectConfiguration: .follow(max: 5, allowCycles: true)))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try httpBin.shutdown())


### PR DESCRIPTION
This PR adds support for 2 types of redirect limits - one that detects loops (by keeping history of all visited URL's for a single request), and one that just counts the number of redirects.

fixes #76