### PR TITLE
update copyrights note

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+## Legal
+
+By submitting a pull request, you represent that you have the right to license
+your contribution to Apple and the community, and agree by submitting the patch
+that your contributions are licensed under the Apache 2.0 license (see
+`LICENSE.txt`).
+
+
+## How to submit a bug report
+
+Please ensure to specify the following:
+
+* AsyncHTTPClient commit hash
+* Contextual information (e.g. what you were trying to achieve with AsyncHTTPClient)
+* Simplest possible steps to reproduce
+  * More complex the steps are, lower the priority will be.
+  * A pull request with failing test case is preferred, but it's just fine to paste the test case into the issue description.
+* Anything that might be relevant in your opinion, such as:
+  * Swift version or the output of `swift --version`
+  * OS version and the output of `uname -a`
+  * Network configuration
+
+
+### Example
+
+```
+AsyncHTTPClient commit hash: 22ec043dc9d24bb011b47ece4f9ee97ee5be2757
+
+Context:
+While load testing my program written with AsyncHTTPClient, I noticed
+that one file descriptor is leaked per request.
+
+Steps to reproduce:
+1. ...
+2. ...
+3. ...
+4. ...
+
+$ swift --version
+Swift version 4.0.2 (swift-4.0.2-RELEASE)
+Target: x86_64-unknown-linux-gnu
+
+Operating system: Ubuntu Linux 16.04 64-bit
+
+$ uname -a
+Linux beefy.machine 4.4.0-101-generic #124-Ubuntu SMP Fri Nov 10 18:29:59 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
+
+My system has IPv6 disabled.
+```
+
+## Writing a Patch
+
+A good AsyncHTTPClient patch is:
+
+1. Concise, and contains as few changes as needed to achieve the end result.
+2. Tested, ensuring that any tests provided failed before the patch and pass after it.
+3. Documented, adding API documentation as needed to cover new functions and properties.
+4. Accompanied by a great commit message, using our commit message template.
+
+### Commit Message Template
+
+We require that your commit messages match our template. The easiest way to do that is to get git to help you by explicitly using the template. To do that, `cd` to the root of our repository and run:
+
+    git config commit.template dev/git.commit.template
+
+### Make sure Tests work on Linux
+
+AsyncHTTPClient uses XCTest to run tests on both macOS and Linux. While the macOS version of XCTest is able to use the Objective-C runtime to discover tests at execution time, the Linux version is not.
+For this reason, whenever you add new tests **you have to run a script** that generates the hooks needed to run those tests on Linux, or our CI will complain that the tests are not all present on Linux. To do this, merely execute `ruby ./scripts/generate_linux_tests.rb` at the root of the package and check the changes it made.
+
+## How to contribute your work
+
+Please open a pull request at https://github.com/swift-server/async-http-client. Make sure the CI passes, and then wait for code review.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -7,14 +7,23 @@ needs to be listed here.
 
 ## COPYRIGHT HOLDERS
 
-- Swift Server Working Group
+- Apple Inc. (all contributors with '@apple.com')
 
 ### Contributors
 
+- Andrew Lees <32634907+Andrew-Lees11@users.noreply.github.com>
 - Artem Redkin <aredkin@apple.com>
+- George Barnett <gbarnett@apple.com>
 - Ian Partridge <i.partridge@uk.ibm.com>
+- Joe Smith <yasumoto7@gmail.com>
+- Johannes Weiss <johannesweiss@apple.com>
+- Ludovic Dewailly <me@ldewailly.com>
 - Tanner <me@tanner.xyz>
+- Tobias <t089@users.noreply.github.com>
+- Trevör <adtrevor@users.noreply.github.com>
 - tomer doron <tomer@apple.com>
+- tomer doron <tomerd@apple.com>
+- vkill <vkill.net@gmail.com>
 
 **Updating this list**
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPClientProxyHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/RequestValidation.swift
+++ b/Sources/AsyncHTTPClient/RequestValidation.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/scripts/check_no_api_breakages.sh
+++ b/scripts/check_no_api_breakages.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the AsyncHTTPClient open source project
 ##
-## Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+## Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/scripts/generate_contributors_list.sh
+++ b/scripts/generate_contributors_list.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the AsyncHTTPClient open source project
 ##
-## Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+## Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -27,7 +27,7 @@ cat > "$here/../CONTRIBUTORS.txt" <<- EOF
 
 	## COPYRIGHT HOLDERS
 
-	- Swift Server Working Group (all contributors with '@apple.com')
+	- Apple Inc. (all contributors with '@apple.com')
 
 	### Contributors
 

--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the AsyncHTTPClient open source project
 ##
-## Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+## Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information

--- a/scripts/generate_linux_tests.rb
+++ b/scripts/generate_linux_tests.rb
@@ -36,7 +36,7 @@ def header(fileName)
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/scripts/sanity.sh
+++ b/scripts/sanity.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the AsyncHTTPClient open source project
 ##
-## Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+## Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -58,7 +58,7 @@ for language in swift-or-c bash dtrace; do
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -77,7 +77,7 @@ EOF
 ##
 ## This source file is part of the AsyncHTTPClient open source project
 ##
-## Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+## Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -96,7 +96,7 @@ EOF
  *
  *  This source file is part of the AsyncHTTPClient open source project
  *
- *  Copyright (c) 2018-2019 Swift Server Working Group and the AsyncHTTPClient project authors
+ *  Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
  *  Licensed under Apache License v2.0
  *
  *  See LICENSE.txt for license information


### PR DESCRIPTION
motivation: the Swift Server Workgroup is not a legal entity and cannot hold copyrights. with this change, code authors continue and retain their copyrights under the apache license and previous copyrights note, but Apple steps up instead of the workgroup which has no legal status

changes:
* update header files to say "Apple Inc. and the AsyncHTTPClient project authors" instead of "Swift Server Workgroup and the AsyncHTTPClient project authors"
* update validation scripts to check for the correct header
* add CONTRIBUTING.md file to explain how to make contributions and include a legal notice about licensing the contribution to Apple and the project
* regenerate CONTRIBUTORS.md to refelct most recent contributions