### PR TITLE
Support NIO Transport Services

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.10.1"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.0.0")
+        .package(url: "https://github.com/Yasumoto/swift-nio.git", .branch("yasumoto-client-bootstrap-protocol")),
+        .package(url: "https://github.com/Yasumoto/swift-nio-ssl.git", .branch("master")),
+        .package(url: "https://github.com/Yasumoto/swift-nio-extras.git", .branch("master")),
+        .package(url: "https://github.com/Yasumoto/swift-nio-transport-services", .branch("yasumoto-ClientTransportBootstrap"))
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -24,11 +24,12 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.10.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services", from: "1.0.0")
     ],
     targets: [
         .target(
             name: "AsyncHTTPClient",
-            dependencies: ["NIO", "NIOHTTP1", "NIOSSL", "NIOConcurrencyHelpers", "NIOHTTPCompression", "NIOFoundationCompat"]
+            dependencies: ["NIO", "NIOHTTP1", "NIOSSL", "NIOTransportServices", "NIOConcurrencyHelpers", "NIOHTTPCompression", "NIOFoundationCompat"]
         ),
         .testTarget(
             name: "AsyncHTTPClientTests",

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -18,6 +18,10 @@ import NIOConcurrencyHelpers
 import NIOHTTP1
 import NIOHTTPCompression
 import NIOSSL
+#if canImport(Network)
+import Network
+import NIOTransportServices
+#endif
 
 /// HTTPClient class provides API for request execution.
 ///
@@ -61,7 +65,15 @@ public class HTTPClient {
         case .shared(let group):
             self.eventLoopGroup = group
         case .createNew:
-            self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+            #if canImport(Network)
+                if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+                    self.eventLoopGroup = NIOTSEventLoopGroup()
+                } else {
+                    self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+                }
+            #else
+                self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            #endif
         }
         self.configuration = configuration
     }


### PR DESCRIPTION
This is the investigation for https://github.com/swift-server/async-http-client/issues/127

This builds on https://github.com/apple/swift-nio/pull/1253 and https://github.com/apple/swift-nio-transport-services/pull/65, mostly motivated by https://github.com/swift-aws/aws-sdk-swift-core/pull/141.

Caveats:

1. I wasn't able to see how to support `ChannelOptions.maxMessagesPerRead`; we'll need this to make sure we don't block in `testUploadStreamingBackpressure`.
2. As mentioned in https://github.com/apple/swift-nio/issues/674, we're really pushing back on our users to _always_ use `NIOTSEventLoopGroup` if it's available. We should likely also add a check if we're passed in a `.shared()` EventLoop that we use the corresponding bootstrap, but figured I'd post this up here for an initial review first.