### PR TITLE
add a parallel test case

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -61,6 +61,7 @@ extension HTTPClientTests {
             ("testDecompressionLimit", testDecompressionLimit),
             ("testLoopDetectionRedirectLimit", testLoopDetectionRedirectLimit),
             ("testCountRedirectLimit", testCountRedirectLimit),
+            ("testMultipleConcurrentRequests", testMultipleConcurrentRequests),
             ("testWorksWith500Error", testWorksWith500Error),
             ("testWorksWithHTTP10Response", testWorksWithHTTP10Response),
             ("testWorksWhenServerClosesConnectionAfterReceivingRequest", testWorksWhenServerClosesConnectionAfterReceivingRequest),


### PR DESCRIPTION
Motivation:

It's important to also have a test case where async-http-client is
actually used to do multiple parallel requests on multiple workers.

Modification:

Add a test where 5 workers are doing 100 requests each.

Result:

Better test coverage.