### PR TITLE
add test where server sends connection: close

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -67,6 +67,7 @@ extension HTTPClientTests {
             ("testWorksWhenServerClosesConnectionAfterReceivingRequest", testWorksWhenServerClosesConnectionAfterReceivingRequest),
             ("testSubsequentRequestsWorkWithServerSendingConnectionClose", testSubsequentRequestsWorkWithServerSendingConnectionClose),
             ("testSubsequentRequestsWorkWithServerAlternatingBetweenKeepAliveAndClose", testSubsequentRequestsWorkWithServerAlternatingBetweenKeepAliveAndClose),
+            ("testRepeatedRequestsWorkWhenServerAlwaysCloses", testRepeatedRequestsWorkWhenServerAlwaysCloses),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -900,4 +900,40 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNil(response?.body)
         }
     }
+
+    func testRepeatedRequestsWorkWhenServerAlwaysCloses() {
+        let web = NIOHTTP1TestServer(group: self.group)
+        defer {
+            XCTAssertNoThrow(try web.stop())
+        }
+
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.group))
+        defer {
+            XCTAssertNoThrow(try httpClient.syncShutdown())
+        }
+
+        for _ in 0..<10 {
+            let result = httpClient.get(url: "http://localhost:\(web.serverPort)/foo")
+            XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
+                                                        method: .GET,
+                                                        uri: "/foo",
+                                                        headers: HTTPHeaders([("Host", "localhost"),
+                                                                              // The following line can be removed once
+                                                                              // we have a connection pool.
+                                                                              ("Connection", "close"),
+                                                                              ("Content-Length", "0")]))),
+                                            try web.readInbound()))
+            XCTAssertNoThrow(XCTAssertEqual(.end(nil),
+                                            try web.readInbound()))
+            XCTAssertNoThrow(try web.writeOutbound(.head(.init(version: .init(major: 1, minor: 1),
+                                                               status: .ok,
+                                                               headers: HTTPHeaders([("CoNnEcTiOn", "cLoSe")])))))
+            XCTAssertNoThrow(try web.writeOutbound(.end(nil)))
+
+            var response: HTTPClient.Response?
+            XCTAssertNoThrow(response = try result.wait())
+            XCTAssertEqual(.ok, response?.status)
+            XCTAssertNil(response?.body)
+        }
+    }
 }


### PR DESCRIPTION
Motivation:

We need a test that we can handle servers that repeatedly send
connection: closes.

Modification:

Add a unit test that always makes the server send connection: close.

Result:

More test coverage.