### PR TITLE
Remove parts of #139 relying on the Network framework

### DIFF
--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -15,31 +15,17 @@
 import NIO
 import NIOHTTP1
 
-#if canImport(Network)
-    import Network
+internal extension String {
+    var isIPAddress: Bool {
+        var ipv4Addr = in_addr()
+        var ipv6Addr = in6_addr()
 
-    internal extension String {
-        var isIPAddress: Bool {
-            if IPv4Address(self) != nil || IPv6Address(self) != nil {
-                return true
-            }
-            return false
+        return self.withCString { ptr in
+            inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
+                inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
         }
     }
-
-#else
-    internal extension String {
-        var isIPAddress: Bool {
-            var ipv4Addr = in_addr()
-            var ipv6Addr = in6_addr()
-
-            return self.withCString { ptr in
-                inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
-                    inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
-            }
-        }
-    }
-#endif
+}
 
 public final class HTTPClientCopyingDelegate: HTTPClientResponseDelegate {
     public typealias Response = Void


### PR DESCRIPTION
**Fixed issue:**
The #139 bug fix is unfortunately not compatible with older (< macOS 10.14) Apple platforms versions where the `Network` framework didn't have the `IPv4Address` and `IPv6Address` types yet.

**Solution:**
Use the UNIX implementation across all platforms to avoid unnecessary
complexity introduced by platform specific implementations.

**Alternative solutions:**
Runtime OS version checks dispatching the calls to the right implementation could also work but seem unnecessarily complicated compared to simply using the UNIX version everywhere.