### PR TITLE
Make public class public constructable

### DIFF
--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -32,7 +32,7 @@ public final class HTTPClientCopyingDelegate: HTTPClientResponseDelegate {
 
     let chunkHandler: (ByteBuffer) -> EventLoopFuture<Void>
 
-    init(chunkHandler: @escaping (ByteBuffer) -> EventLoopFuture<Void>) {
+    public init(chunkHandler: @escaping (ByteBuffer) -> EventLoopFuture<Void>) {
         self.chunkHandler = chunkHandler
     }
 


### PR DESCRIPTION
`HTTPClientCopyingDelegate` meant to be public, hence make the initializer public.