### PR TITLE
ResponseAccumulator is now public

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -241,7 +241,7 @@ extension HTTPClient {
     }
 }
 
-internal class ResponseAccumulator: HTTPClientResponseDelegate {
+public class ResponseAccumulator: HTTPClientResponseDelegate {
     public typealias Response = HTTPClient.Response
 
     enum State {
@@ -255,11 +255,11 @@ internal class ResponseAccumulator: HTTPClientResponseDelegate {
     var state = State.idle
     let request: HTTPClient.Request
 
-    init(request: HTTPClient.Request) {
+    public init(request: HTTPClient.Request) {
         self.request = request
     }
 
-    func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
+    public func didReceiveHead(task: HTTPClient.Task<Response>, _ head: HTTPResponseHead) -> EventLoopFuture<Void> {
         switch self.state {
         case .idle:
             self.state = .head(head)
@@ -275,7 +275,7 @@ internal class ResponseAccumulator: HTTPClientResponseDelegate {
         return task.eventLoop.makeSucceededFuture(())
     }
 
-    func didReceiveBodyPart(task: HTTPClient.Task<Response>, _ part: ByteBuffer) -> EventLoopFuture<Void> {
+    public func didReceiveBodyPart(task: HTTPClient.Task<Response>, _ part: ByteBuffer) -> EventLoopFuture<Void> {
         switch self.state {
         case .idle:
             preconditionFailure("no head received before body")
@@ -293,11 +293,11 @@ internal class ResponseAccumulator: HTTPClientResponseDelegate {
         return task.eventLoop.makeSucceededFuture(())
     }
 
-    func didReceiveError(task: HTTPClient.Task<Response>, _ error: Error) {
+    public func didReceiveError(task: HTTPClient.Task<Response>, _ error: Error) {
         self.state = .error(error)
     }
 
-    func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Response {
+    public func didFinishRequest(task: HTTPClient.Task<Response>) throws -> Response {
         switch self.state {
         case .idle:
             preconditionFailure("no head received before end")


### PR DESCRIPTION
As discussed in #128. We make the ResponseAccumulator public to give developers an easy time to create a Task. With the ResponseAccumulator the developer using this does not have to worry, about implementing the HTTPClientResponseDelegate all by himself.