### PR TITLE
enable tsan and improve docker security

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: async-http-client:16.04-5.1
+    build:
+      args:
+        ubuntu_version: "bionic"
+        swift_version: "5.1.3"
+
+  test:
+    image: async-http-client:16.04-5.1
+    environment:
+      - SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: async-http-client:16.04-5.1

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,8 +16,11 @@ services:
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh
-      - ..:/code
+      - ..:/code:z
     working_dir: /code
+    cap_drop:
+      - CAP_NET_RAW
+      - CAP_NET_BIND_SERVICE
 
   sanity:
     <<: *common


### PR DESCRIPTION
motivation: more secured ci setup

changes:
* enable :z selinux flag on bind mounts so we can enable selinux on ci
* drop potentially exploitable capabilities from docker-compose
* create a 16.04 docker-compose setup so we can run tsan in ci (broken on 18.04)