### PR TITLE
actually use 16.04 on 16.04 builds

### DIFF
--- a/docker/docker-compose.1604.51.yaml
+++ b/docker/docker-compose.1604.51.yaml
@@ -6,7 +6,7 @@ services:
     image: async-http-client:16.04-5.1
     build:
       args:
-        ubuntu_version: "bionic"
+        ubuntu_version: "xenial"
         swift_version: "5.1.3"
 
   test:


### PR DESCRIPTION
motivation: 16.04 docker-compose setup was pulling 18.04 by mistake

changes: use xenial instead of bionic