### PR TITLE
add a public init to StreamWriter

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -26,6 +26,14 @@ extension HTTPClient {
         public struct StreamWriter {
             let closure: (IOData) -> EventLoopFuture<Void>
 
+            /// Create new StreamWriter
+            ///
+            /// - parameters:
+            ///     - closure: function that will be called to write actual bytes to the channel.
+            public init(closure: @escaping (IOData) -> EventLoopFuture<Void>) {
+                self.closure = closure
+            }
+
             /// Write data to server.
             ///
             /// - parameters:


### PR DESCRIPTION
Closes #158 by adding a public init to `StreamWriter`

Motivation:
Even though `StreamWriter` is public, its init is not, that makes using it in tests impossible.

Modifications:
add public `init` to `StreamWriter`

Result:
`StreamWriter` can no be instantiated by the clients of the library