### PR TITLE
require secure NIO version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.13.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.4.1"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
     ],


### PR DESCRIPTION
This is not strictly necessary because `swift package update` will fix the issue anyway but I think it's always good style to have the `Package.swift` require a secure version.

- https://nvd.nist.gov/vuln/detail/CVE-2019-15605
- https://forums.swift.org/t/swiftnio-security-releases-2-13-1-and-1-14-2/33671