### PR TITLE
some lets in Requests were vars by accident

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -139,11 +139,11 @@ extension HTTPClient {
         }
 
         /// Request HTTP method, defaults to `GET`.
-        public var method: HTTPMethod
+        public let method: HTTPMethod
         /// Remote URL.
-        public var url: URL
+        public let url: URL
         /// Remote HTTP scheme, resolved from `URL`.
-        public var scheme: String
+        public let scheme: String
         /// Remote host, resolved from `URL`.
         public let host: String
         /// Request custom HTTP Headers, defaults to no headers.


### PR DESCRIPTION
Motivation:

Generally, most members in `struct`s should be `var` but in this particular case, `let` makes more sense (for now) because there are other properties (like `kind`) that are generated from things like host/port/scheme. If we allow `scheme` to become `var`, then we would need to update `kind` when changed, however that wasn't done.

Also, the `var` functionality wasn't tested and therefore we should restore the behaviour of 1.0.1 which was to store them as `let`s.

Modification:

make the `method`, `url`, and `scheme` members of `Request` a `let`.

Result:

Harder to make an illegal `Request` value.