### PR TITLE
add extra test case

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -92,6 +92,7 @@ extension HTTPClientTests {
             ("testUDSBasic", testUDSBasic),
             ("testUDSSocketAndPath", testUDSSocketAndPath),
             ("testUseExistingConnectionOnDifferentEL", testUseExistingConnectionOnDifferentEL),
+            ("testWeRecoverFromServerThatClosesTheConnectionOnUs", testWeRecoverFromServerThatClosesTheConnectionOnUs),
         ]
     }
 }


### PR DESCRIPTION
Motivation:

I wasn't sure if we tested that we would successfully recover from
a server that sometimes closes the connection on us.

Modification:

Added a test case where we do three requests: First one succeeds,
second one gets a close from the server, third one succeeds again.
So we're testing that although AsyncHTTPClient doesn't auto-retry, the
user can just retry again.

Result:

More test coverage.