### PR TITLE
test that connection close whilst idle works

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -34,6 +34,7 @@ extension HTTPClientInternalTests {
             ("testRequestURITrailingSlash", testRequestURITrailingSlash),
             ("testChannelAndDelegateOnDifferentEventLoops", testChannelAndDelegateOnDifferentEventLoops),
             ("testResponseConnectionCloseGet", testResponseConnectionCloseGet),
+            ("testWeNoticeRemoteClosuresEvenWhenConnectionIsIdleInPool", testWeNoticeRemoteClosuresEvenWhenConnectionIsIdleInPool),
         ]
     }
 }


### PR DESCRIPTION
Motivation:

I wasn't sure if we actually properly observed an idle connection
suddenly closing. Ideally, if an idle connection just goes away, we just
want to remove it from the connection pool (which is what happens).

Modification:

Add a test that verifies idle connections that get closed from the
server don't get reused in the pool.

Result:

Better test coverage for more complicated scenarios.