### PR TITLE
Close idle pool connections

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -228,11 +228,9 @@ final class ConnectionPool {
         func removeIdleConnectionHandlersForLease() -> EventLoopFuture<Connection> {
             return self.channel.eventLoop.flatSubmit {
                 self.removeHandler(IdleStateHandler.self).flatMap { () -> EventLoopFuture<Bool> in
-                    self.channel.pipeline.handler(type: IdlePoolConnectionHandler.self).flatMap { idleHandler -> EventLoopFuture<Bool> in
-
-                        self.channel.pipeline.removeHandler(idleHandler).flatMapError { error in
-                            fatalError("\(error)")
-                            return self.channel.eventLoop.makeSucceededFuture(())
+                    self.channel.pipeline.handler(type: IdlePoolConnectionHandler.self).flatMap { idleHandler in
+                        self.channel.pipeline.removeHandler(idleHandler).flatMapError { _ in
+                            self.channel.eventLoop.makeSucceededFuture(())
                         }.map {
                             idleHandler.timeoutClosed.load()
                         }

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -235,6 +235,8 @@ final class ConnectionPool {
                             idleHandler.timeoutClosed.load()
                         }
                     }.flatMapError { error in
+                        // These handlers are only added on connection release, they are not added
+                        // when a connection is made to be instantly leased, so we ignore this error
                         if let channelError = error as? ChannelPipelineError, channelError == .notFound {
                             return self.channel.eventLoop.makeSucceededFuture(!self.channel.isActive)
                         } else {

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -232,7 +232,7 @@ final class ConnectionPool {
                         self.channel.pipeline.removeHandler(idleHandler).flatMapError { _ in
                             self.channel.eventLoop.makeSucceededFuture(())
                         }.map {
-                            idleHandler.timeoutClosed.load()
+                            idleHandler.timeoutClosed.load() || !self.channel.isActive
                         }
                     }.flatMapError { error in
                         // These handlers are only added on connection release, they are not added

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -224,6 +224,22 @@ final class ConnectionPool {
         fileprivate var closePromise: EventLoopPromise<Void>
 
         var closeFuture: EventLoopFuture<Void>
+
+        func removeIdleConnectionHandlersForLease() -> EventLoopFuture<Connection> {
+            return self.channel.eventLoop.flatSubmit {
+                self.removeHandler(IdleStateHandler.self).flatMap {
+                    self.removeHandler(IdlePoolConnectionHandler.self)
+                }.flatMap {
+                    if self.channel.isActive {
+                        return self.channel.eventLoop.makeSucceededFuture(self)
+                    } else {
+                        return self.channel.eventLoop.makeFailedFuture(IdleCloseError())
+                    }
+                }
+            }
+        }
+
+        struct IdleCloseError: Error {}
     }
 
     /// A connection provider of `HTTP/1.1` connections with a given `Key` (host, scheme, port)
@@ -294,7 +310,14 @@ final class ConnectionPool {
             let action = self.stateLock.withLock { self.state.connectionAction(for: preference) }
             switch action {
             case .leaseConnection(let connection):
-                return connection.channel.eventLoop.makeSucceededFuture(connection)
+                return connection.removeIdleConnectionHandlersForLease().flatMapError { _ in
+                    connection.closeFuture.flatMap { // We ensure close actions are run first
+                        let defaultEventLoop = self.stateLock.withLock {
+                            self.state.defaultEventLoop
+                        }
+                        return self.makeConnection(on: preference.bestEventLoop ?? defaultEventLoop)
+                    }
+                }
             case .makeConnection(let eventLoop):
                 return self.makeConnection(on: eventLoop)
             case .leaseFutureConnection(let futureConnection):
@@ -454,7 +477,7 @@ final class ConnectionPool {
 
         fileprivate struct State {
             /// The default `EventLoop` to use for this `HTTP1ConnectionProvider`
-            private let defaultEventLoop: EventLoop
+            let defaultEventLoop: EventLoop
 
             /// The maximum number of connections to a certain (host, scheme, port) tuple.
             private let maximumConcurrentConnections: Int = 8
@@ -477,7 +500,11 @@ final class ConnectionPool {
 
             fileprivate var activity: Activity = .opened
 
-            fileprivate var pending: Int = 0
+            fileprivate var pending: Int = 0 {
+                didSet {
+                    assert(self.pending >= 0)
+                }
+            }
 
             private let parentPool: ConnectionPool
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -305,7 +305,7 @@ public class HTTPClient {
             redirectHandler = nil
         }
 
-        let task = Task<Delegate.Response>(eventLoop: taskEL)
+        let task = Task<Delegate.Response>(eventLoop: taskEL, poolingTimeout: self.configuration.poolingTimeout)
         self.stateLock.withLock {
             self.tasks[task.id] = task
         }
@@ -321,17 +321,18 @@ public class HTTPClient {
 
         connection.flatMap { connection -> EventLoopFuture<Void> in
             let channel = connection.channel
-            let addedFuture: EventLoopFuture<Void>
 
-            switch self.configuration.decompression {
-            case .disabled:
-                addedFuture = channel.eventLoop.makeSucceededFuture(())
-            case .enabled(let limit):
-                let decompressHandler = NIOHTTPResponseDecompressor(limit: limit)
-                addedFuture = channel.pipeline.addHandler(decompressHandler)
-            }
-
-            return addedFuture.flatMap {
+            return connection.removeHandler(IdleStateHandler.self).flatMap {
+                connection.removeHandler(IdlePoolConnectionHandler.self)
+            }.flatMap {
+                switch self.configuration.decompression {
+                case .disabled:
+                    return channel.eventLoop.makeSucceededFuture(())
+                case .enabled(let limit):
+                    let decompressHandler = NIOHTTPResponseDecompressor(limit: limit)
+                    return channel.pipeline.addHandler(decompressHandler)
+                }
+            }.flatMap {
                 if let timeout = self.resolve(timeout: self.configuration.timeout.read, deadline: deadline) {
                     return channel.pipeline.addHandler(IdleStateHandler(readTimeout: timeout))
                 } else {
@@ -408,6 +409,8 @@ public class HTTPClient {
         public var redirectConfiguration: RedirectConfiguration
         /// Default client timeout, defaults to no timeouts.
         public var timeout: Timeout
+        /// Timeout of pooled connections
+        public var poolingTimeout: TimeAmount?
         /// Upstream proxy, defaults to no proxy.
         public var proxy: Proxy?
         /// Enables automatic body decompression. Supported algorithms are gzip and deflate.
@@ -418,12 +421,47 @@ public class HTTPClient {
         public init(tlsConfiguration: TLSConfiguration? = nil,
                     redirectConfiguration: RedirectConfiguration? = nil,
                     timeout: Timeout = Timeout(),
+                    poolingTimeout: TimeAmount,
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled) {
             self.tlsConfiguration = tlsConfiguration
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
             self.timeout = timeout
+            self.poolingTimeout = poolingTimeout
+            self.proxy = proxy
+            self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
+            self.decompression = decompression
+        }
+
+        public init(tlsConfiguration: TLSConfiguration? = nil,
+                    redirectConfiguration: RedirectConfiguration? = nil,
+                    timeout: Timeout = Timeout(),
+                    proxy: Proxy? = nil,
+                    ignoreUncleanSSLShutdown: Bool = false,
+                    decompression: Decompression = .disabled) {
+            self.init(
+                tlsConfiguration: tlsConfiguration,
+                redirectConfiguration: redirectConfiguration,
+                timeout: timeout,
+                poolingTimeout: .seconds(60),
+                proxy: proxy,
+                ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
+                decompression: decompression
+            )
+        }
+
+        public init(certificateVerification: CertificateVerification,
+                    redirectConfiguration: RedirectConfiguration? = nil,
+                    timeout: Timeout = Timeout(),
+                    poolingTimeout: TimeAmount = .seconds(60),
+                    proxy: Proxy? = nil,
+                    ignoreUncleanSSLShutdown: Bool = false,
+                    decompression: Decompression = .disabled) {
+            self.tlsConfiguration = TLSConfiguration.forClient(certificateVerification: certificateVerification)
+            self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
+            self.timeout = timeout
+            self.poolingTimeout = poolingTimeout
             self.proxy = proxy
             self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
             self.decompression = decompression
@@ -435,12 +473,15 @@ public class HTTPClient {
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled) {
-            self.tlsConfiguration = TLSConfiguration.forClient(certificateVerification: certificateVerification)
-            self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
-            self.timeout = timeout
-            self.proxy = proxy
-            self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
-            self.decompression = decompression
+            self.init(
+                certificateVerification: certificateVerification,
+                redirectConfiguration: redirectConfiguration,
+                timeout: timeout,
+                poolingTimeout: .seconds(60),
+                proxy: proxy,
+                ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
+                decompression: decompression
+            )
         }
     }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -305,7 +305,7 @@ public class HTTPClient {
             redirectHandler = nil
         }
 
-        let task = Task<Delegate.Response>(eventLoop: taskEL, poolingTimeout: self.configuration.poolingTimeout)
+        let task = Task<Delegate.Response>(eventLoop: taskEL, poolingTimeout: self.configuration.maximumAllowedIdleTimeInConnectionPool)
         self.stateLock.withLock {
             self.tasks[task.id] = task
         }
@@ -410,7 +410,7 @@ public class HTTPClient {
         /// Default client timeout, defaults to no timeouts.
         public var timeout: Timeout
         /// Timeout of pooled connections
-        public var poolingTimeout: TimeAmount?
+        public var maximumAllowedIdleTimeInConnectionPool: TimeAmount?
         /// Upstream proxy, defaults to no proxy.
         public var proxy: Proxy?
         /// Enables automatic body decompression. Supported algorithms are gzip and deflate.
@@ -421,14 +421,14 @@ public class HTTPClient {
         public init(tlsConfiguration: TLSConfiguration? = nil,
                     redirectConfiguration: RedirectConfiguration? = nil,
                     timeout: Timeout = Timeout(),
-                    poolingTimeout: TimeAmount,
+                    maximumAllowedIdleTimeInConnectionPool: TimeAmount,
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled) {
             self.tlsConfiguration = tlsConfiguration
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
             self.timeout = timeout
-            self.poolingTimeout = poolingTimeout
+            self.maximumAllowedIdleTimeInConnectionPool = maximumAllowedIdleTimeInConnectionPool
             self.proxy = proxy
             self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
             self.decompression = decompression
@@ -444,7 +444,7 @@ public class HTTPClient {
                 tlsConfiguration: tlsConfiguration,
                 redirectConfiguration: redirectConfiguration,
                 timeout: timeout,
-                poolingTimeout: .seconds(60),
+                maximumAllowedIdleTimeInConnectionPool: .seconds(60),
                 proxy: proxy,
                 ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                 decompression: decompression
@@ -454,14 +454,14 @@ public class HTTPClient {
         public init(certificateVerification: CertificateVerification,
                     redirectConfiguration: RedirectConfiguration? = nil,
                     timeout: Timeout = Timeout(),
-                    poolingTimeout: TimeAmount = .seconds(60),
+                    maximumAllowedIdleTimeInConnectionPool: TimeAmount = .seconds(60),
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled) {
             self.tlsConfiguration = TLSConfiguration.forClient(certificateVerification: certificateVerification)
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
             self.timeout = timeout
-            self.poolingTimeout = poolingTimeout
+            self.maximumAllowedIdleTimeInConnectionPool = maximumAllowedIdleTimeInConnectionPool
             self.proxy = proxy
             self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
             self.decompression = decompression
@@ -477,7 +477,7 @@ public class HTTPClient {
                 certificateVerification: certificateVerification,
                 redirectConfiguration: redirectConfiguration,
                 timeout: timeout,
-                poolingTimeout: .seconds(60),
+                maximumAllowedIdleTimeInConnectionPool: .seconds(60),
                 proxy: proxy,
                 ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                 decompression: decompression

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -531,6 +531,19 @@ public class HTTPClient {
         public static func delegateAndChannel(on eventLoop: EventLoop) -> EventLoopPreference {
             return EventLoopPreference(.delegateAndChannel(on: eventLoop))
         }
+
+        var bestEventLoop: EventLoop? {
+            switch self.preference {
+            case .delegate(on: let el):
+                return el
+            case .delegateAndChannel(on: let el):
+                return el
+            case .testOnly_exact(channelOn: let el, delegateOn: _):
+                return el
+            case .indifferent:
+                return nil
+            }
+        }
     }
 
     /// Specifies decompression settings.

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -1029,6 +1029,8 @@ class IdlePoolConnectionHandler: ChannelInboundHandler, RemovableChannelHandler 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
         if let idleEvent = event as? IdleStateHandler.IdleStateEvent, idleEvent == .write {
             context.close(promise: nil)
+        } else {
+            context.fireUserInboundEventTriggered(event)
         }
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -34,6 +34,7 @@ extension HTTPClientInternalTests {
             ("testRequestURITrailingSlash", testRequestURITrailingSlash),
             ("testChannelAndDelegateOnDifferentEventLoops", testChannelAndDelegateOnDifferentEventLoops),
             ("testResponseConnectionCloseGet", testResponseConnectionCloseGet),
+            ("testWeNoticeRemoteClosuresEvenWhenConnectionIsIdleInPool", testWeNoticeRemoteClosuresEvenWhenConnectionIsIdleInPool),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -36,6 +36,7 @@ extension HTTPClientInternalTests {
             ("testResponseConnectionCloseGet", testResponseConnectionCloseGet),
             ("testWeNoticeRemoteClosuresEvenWhenConnectionIsIdleInPool", testWeNoticeRemoteClosuresEvenWhenConnectionIsIdleInPool),
             ("testWeTolerateConnectionsGoingAwayWhilstPoolIsShuttingDown", testWeTolerateConnectionsGoingAwayWhilstPoolIsShuttingDown),
+            ("testRaceBetweenAsynchronousCloseAndChannelUsabilityDetection", testRaceBetweenAsynchronousCloseAndChannelUsabilityDetection),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -707,13 +707,14 @@ class HTTPClientInternalTests: XCTestCase {
         // The Channel should still be active though because we delayed the close through our handler above.
         XCTAssertTrue(channel.isActive)
 
+        doActualCloseNowPromise.succeed(())
         // When asking for a connection again, we should _not_ get the same one back because we did most of the close,
         // similar to what the SSLHandler would do.
         XCTAssertNoThrow(try maybeConnection = client.pool.getConnection(for: req,
                                                                          preference: .indifferent,
                                                                          on: client.eventLoopGroup.next(),
                                                                          deadline: nil).wait())
-        doActualCloseNowPromise.succeed(())
+
         guard let connection2 = maybeConnection else {
             XCTFail("couldn't get second connection")
             return

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -93,6 +93,7 @@ extension HTTPClientTests {
             ("testUDSSocketAndPath", testUDSSocketAndPath),
             ("testUseExistingConnectionOnDifferentEL", testUseExistingConnectionOnDifferentEL),
             ("testWeRecoverFromServerThatClosesTheConnectionOnUs", testWeRecoverFromServerThatClosesTheConnectionOnUs),
+            ("testPoolClosesIdleConnections", testPoolClosesIdleConnections),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -92,6 +92,7 @@ extension HTTPClientTests {
             ("testUDSBasic", testUDSBasic),
             ("testUDSSocketAndPath", testUDSSocketAndPath),
             ("testUseExistingConnectionOnDifferentEL", testUseExistingConnectionOnDifferentEL),
+            ("testWeRecoverFromServerThatClosesTheConnectionOnUs", testWeRecoverFromServerThatClosesTheConnectionOnUs),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -94,6 +94,7 @@ extension HTTPClientTests {
             ("testUseExistingConnectionOnDifferentEL", testUseExistingConnectionOnDifferentEL),
             ("testWeRecoverFromServerThatClosesTheConnectionOnUs", testWeRecoverFromServerThatClosesTheConnectionOnUs),
             ("testPoolClosesIdleConnections", testPoolClosesIdleConnections),
+            ("testRacePoolIdleConnectionsAndGet", testRacePoolIdleConnectionsAndGet),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1634,14 +1634,13 @@ class HTTPClientTests: XCTestCase {
 
     func testPoolClosesIdleConnections() {
         let httpBin = HTTPBin()
-        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(poolingTimeout: .seconds(1)))
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(poolingTimeout: .milliseconds(100)))
         defer {
             XCTAssertNoThrow(try httpBin.shutdown())
             XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
         }
         XCTAssertNoThrow(try httpClient.get(url: "http://localhost:\(httpBin.port)/get").wait())
-        XCTAssertEqual(httpBin.activeConnections, 1)
-        Thread.sleep(forTimeInterval: 2)
+        Thread.sleep(forTimeInterval: 0.2)
         XCTAssertEqual(httpBin.activeConnections, 0)
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1634,7 +1634,7 @@ class HTTPClientTests: XCTestCase {
 
     func testPoolClosesIdleConnections() {
         let httpBin = HTTPBin()
-        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(poolingTimeout: .milliseconds(100)))
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(maximumAllowedIdleTimeInConnectionPool: .milliseconds(100)))
         defer {
             XCTAssertNoThrow(try httpBin.shutdown())
             XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
@@ -1646,7 +1646,7 @@ class HTTPClientTests: XCTestCase {
 
     func testRacePoolIdleConnectionsAndGet() {
         let httpBin = HTTPBin()
-        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(poolingTimeout: .milliseconds(10)))
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(maximumAllowedIdleTimeInConnectionPool: .milliseconds(10)))
         defer {
             XCTAssertNoThrow(try httpBin.shutdown())
             XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1643,4 +1643,17 @@ class HTTPClientTests: XCTestCase {
         Thread.sleep(forTimeInterval: 0.2)
         XCTAssertEqual(httpBin.activeConnections, 0)
     }
+
+    func testRacePoolIdleConnectionsAndGet() {
+        let httpBin = HTTPBin()
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew, configuration: .init(poolingTimeout: .milliseconds(10)))
+        defer {
+            XCTAssertNoThrow(try httpBin.shutdown())
+            XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
+        }
+        for _ in 1...500 {
+            XCTAssertNoThrow(try httpClient.get(url: "http://localhost:\(httpBin.port)/get").wait())
+            Thread.sleep(forTimeInterval: 0.01 + .random(in: -0.05...0.05))
+        }
+    }
 }


### PR DESCRIPTION
Motivation: Pooled connections should close at some point (see #168)

Changes:
- Add new `maximumAllowedIdleTimeInConnectionPool ` property to `HTTPClient.Configuration`, its default value is currently `.seconds(60)`, and it can be set to `nil` if one wishes to disable this timeout.
- Add relevant unit test
- Closes #168