### PR TITLE
update docs generation script to work better with selinux

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -52,7 +52,11 @@ if ! command -v jazzy > /dev/null; then
   gem install jazzy --no-ri --no-rdoc
 fi
 
-module_switcher="docs/$version/README.md"
+jazzy_dir="$root_path/.build/jazzy"
+rm -rf "$jazzy_dir"
+mkdir -p "$jazzy_dir"
+
+module_switcher="$jazzy_dir/README.md"
 jazzy_args=(--clean
             --author 'AsyncHTTPClient team'
             --readme "$module_switcher"
@@ -74,7 +78,9 @@ EOF
 
 tmp=`mktemp -d`
 for module in "${modules[@]}"; do
-  args=("${jazzy_args[@]}"  --output "$tmp/docs/$version/$module" --docset-path "$tmp/docset/$version/$module" --module "$module")
+  args=("${jazzy_args[@]}"  --output "$jazzy_dir/docs/$version/$module" --docset-path "$jazzy_dir/docset/$version/$module"
+        --module "$module" --module-version $version
+        --root-url "https://swift-server.github.io/async-http-client/docs/$version/$module/")
   if [[ -f "$root_path/.build/sourcekitten/$module.json" ]]; then
     args+=(--sourcekitten-sourcefile "$root_path/.build/sourcekitten/$module.json")
   fi
@@ -82,13 +88,14 @@ for module in "${modules[@]}"; do
 done
 
 # push to github pages
-if [[ $CI == true ]]; then
+if [[ $PUSH == true ]]; then
   BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
   GIT_AUTHOR=$(git --no-pager show -s --format='%an <%ae>' HEAD)
   git fetch origin +gh-pages:gh-pages
   git checkout gh-pages
-  rm -rf "docs"
-  cp -r "$tmp/docs" .
+  rm -rf "docs/$version"
+  rm -rf "docs/current"
+  cp -r "$jazzy_dir/docs/$version" docs/
   cp -r "docs/$version" docs/current
   git add --all docs
   echo '<html><head><meta http-equiv="refresh" content="0; url=docs/current/AsyncHTTPClient/index.html" /></head></html>' > index.html


### PR DESCRIPTION
motivation: docs scripts is broken on selinux due to restriction on ssh-agent

changes:
* change the jazzy workspace to a directory accessible by the CI node so we can push from the agent instead of from the docker container
* dont remove older docs when pushing new ones
* add version information and source links