### PR TITLE
use 3 EventLoops for tests

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -164,7 +164,7 @@ enum TemporaryFileHelpers {
 }
 
 internal final class HTTPBin {
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 3)
     let serverChannel: Channel
     let isShutdown: NIOAtomic<Bool> = .makeAtomic(value: false)
     var connectionCount: NIOAtomic<Int> = .makeAtomic(value: 0)
@@ -569,7 +569,7 @@ final class CountActiveConnectionsHandler: ChannelInboundHandler {
 }
 
 internal class HttpBinForSSLUncleanShutdown {
-    let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: 3)
     let serverChannel: Channel
 
     var port: Int {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -29,7 +29,7 @@ class HTTPClientTests: XCTestCase {
 
     override func setUp() {
         XCTAssertNil(self.group)
-        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.group = MultiThreadedEventLoopGroup(numberOfThreads: 3)
     }
 
     override func tearDown() {


### PR DESCRIPTION
3 makes it less likely that correlated Channels share an EventLoop so it
should shake out more threading bugs...