### PR TITLE
add version to response

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -225,6 +225,8 @@ extension HTTPClient {
         public var host: String
         /// Response HTTP status.
         public var status: HTTPResponseStatus
+        /// Response HTTP version.
+        public var version: HTTPVersion
         /// Reponse HTTP headers.
         public var headers: HTTPHeaders
         /// Response body.
@@ -237,11 +239,12 @@ extension HTTPClient {
         ///     - status: Response HTTP status.
         ///     - headers: Reponse HTTP headers.
         ///     - body: Response body.
-        public init(host: String, status: HTTPResponseStatus, headers: HTTPHeaders, body: ByteBuffer?) {
+        public init(host: String, status: HTTPResponseStatus, version: HTTPVersion, headers: HTTPHeaders, body: ByteBuffer?) {
             self.host = host
             self.status = status
             self.headers = headers
             self.body = body
+            self.version = version
         }
     }
 
@@ -342,9 +345,9 @@ public class ResponseAccumulator: HTTPClientResponseDelegate {
         case .idle:
             preconditionFailure("no head received before end")
         case .head(let head):
-            return Response(host: self.request.host, status: head.status, headers: head.headers, body: nil)
+            return Response(host: self.request.host, status: head.status, version: head.version, headers: head.headers, body: nil)
         case .body(let head, let body):
-            return Response(host: self.request.host, status: head.status, headers: head.headers, body: body)
+            return Response(host: self.request.host, status: head.status, version: head.version, headers: head.headers, body: body)
         case .end:
             preconditionFailure("request already processed")
         case .error(let error):

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -239,12 +239,29 @@ extension HTTPClient {
         ///     - status: Response HTTP status.
         ///     - headers: Reponse HTTP headers.
         ///     - body: Response body.
+        @available(*, deprecated, message: "please use init(host:status:version:headers:body:) instead")
+        public init(host: String, status: HTTPResponseStatus, headers: HTTPHeaders, body: ByteBuffer?) {
+            self.host = host
+            self.status = status
+            self.version = HTTPVersion(major: 1, minor: 1)
+            self.headers = headers
+            self.body = body
+        }
+
+        /// Create HTTP `Response`.
+        ///
+        /// - parameters:
+        ///     - host: Remote host of the request.
+        ///     - status: Response HTTP status.
+        ///     - version: Response HTTP version.
+        ///     - headers: Reponse HTTP headers.
+        ///     - body: Response body.
         public init(host: String, status: HTTPResponseStatus, version: HTTPVersion, headers: HTTPHeaders, body: ByteBuffer?) {
             self.host = host
             self.status = status
+            self.version = version
             self.headers = headers
             self.body = body
-            self.version = version
         }
     }
 

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -239,7 +239,7 @@ extension HTTPClient {
         ///     - status: Response HTTP status.
         ///     - headers: Reponse HTTP headers.
         ///     - body: Response body.
-        @available(*, deprecated, message: "please use init(host:status:version:headers:body:) instead")
+        @available(*, deprecated, renamed: "init(host:status:version:headers:body:)")
         public init(host: String, status: HTTPResponseStatus, headers: HTTPHeaders, body: ByteBuffer?) {
             self.host = host
             self.status = status


### PR DESCRIPTION
Add HTTP version to response struct. Closes #164 

Motivation:
Servers are free to respond with different versions in some cases, clients need to have access to returned version.

Modifications:
Copy HTTP version from `.head` part to `Response` struct on init.

Result:
Clients of the library now have access to returned HTTP version.