### PR TITLE
fix location header lookup

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -140,12 +140,8 @@ extension HTTPClient {
 }
 
 extension HTTPClient.Response {
-    var cookieHeaders: [HTTPHeaders.Element] {
-        return headers.filter { $0.name.lowercased() == "set-cookie" }
-    }
-
     /// List of HTTP cookies returned by the server.
     public var cookies: [HTTPClient.Cookie] {
-        return self.cookieHeaders.compactMap { HTTPClient.Cookie(header: $0.value, defaultDomain: self.host) }
+        return self.headers["set-cookie"].compactMap { HTTPClient.Cookie(header: $0, defaultDomain: self.host) }
     }
 }

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -963,11 +963,11 @@ internal struct RedirectHandler<ResponseType> {
             return nil
         }
 
-        guard let location = headers.first(where: { $0.name == "Location" }) else {
+        guard let location = headers.first(name: "Location") else {
             return nil
         }
 
-        guard let url = URL(string: location.value, relativeTo: request.url) else {
+        guard let url = URL(string: location, relativeTo: request.url) else {
             return nil
         }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -425,7 +425,7 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 return
             case "/redirect/302":
                 var headers = HTTPHeaders()
-                headers.add(name: "Location", value: "/ok")
+                headers.add(name: "location", value: "/ok")
                 self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
                 return
             case "/redirect/https":


### PR DESCRIPTION
Fix `Location` header case-sensitive lookup, closes #185 

Motivation:
HTTP Header names are case-insensitive.

Modifications:
Use `.first` method provided by `HTTPHeaders`
Remove `cookieHeaders` method and instead use getter provided by `HTTPHeaders`

Result:
Redirects will now be processed correctly.