### PR TITLE
Enable clients to call URLs that include %2F as an escaped backslash

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -464,7 +464,7 @@ extension URL {
         if self.path.isEmpty {
             return "/"
         }
-        return self.path.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? self.path
+        return URLComponents(url: self, resolvingAgainstBaseURL: false)?.percentEncodedPath ?? self.path
     }
 
     var pathHasTrailingSlash: Bool {

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -467,30 +467,8 @@ extension URL {
         return URLComponents(url: self, resolvingAgainstBaseURL: false)?.percentEncodedPath ?? self.path
     }
 
-    var pathHasTrailingSlash: Bool {
-        if #available(OSX 10.11, iOS 9.0, tvOS 9.0, watchOS 2.0, *) {
-            return self.hasDirectoryPath
-        } else {
-            // Most platforms should use `self.hasDirectoryPath`, but on older darwin platforms
-            // we have this approximation instead.
-            let url = self.absoluteString
-
-            var pathEndIndex = url.index(before: url.endIndex)
-            if let queryIndex = url.firstIndex(of: "?") {
-                pathEndIndex = url.index(before: queryIndex)
-            } else if let fragmentIndex = url.suffix(from: url.firstIndex(of: "@") ?? url.startIndex).lastIndex(of: "#") {
-                pathEndIndex = url.index(before: fragmentIndex)
-            }
-
-            return url[pathEndIndex] == "/"
-        }
-    }
-
     var uri: String {
         var uri = self.percentEncodedPath
-        if self.pathHasTrailingSlash, uri != "/" {
-            uri += "/"
-        }
 
         if let query = self.query {
             uri += "?" + query

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -286,6 +286,9 @@ class HTTPClientInternalTests: XCTestCase {
 
         let request11 = try Request(url: "https://someserver.com/some%20path")
         XCTAssertEqual(request11.url.uri, "/some%20path")
+
+        let request12 = try Request(url: "https://someserver.com/some%2Fpathsegment1/pathsegment2")
+        XCTAssertEqual(request12.url.uri, "/some%2Fpathsegment1/pathsegment2")
     }
 
     func testChannelAndDelegateOnDifferentEventLoops() throws {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -37,6 +37,7 @@ extension HTTPClientTests {
             ("testHttpRedirect", testHttpRedirect),
             ("testHttpHostRedirect", testHttpHostRedirect),
             ("testPercentEncoded", testPercentEncoded),
+            ("testPercentEncodedBackslash", testPercentEncodedBackslash),
             ("testMultipleContentLengthHeaders", testMultipleContentLengthHeaders),
             ("testStreaming", testStreaming),
             ("testRemoteClose", testRemoteClose),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -218,6 +218,18 @@ class HTTPClientTests: XCTestCase {
         XCTAssertEqual(.ok, response.status)
     }
 
+    func testPercentEncodedBackslash() throws {
+        let httpBin = HTTPBin()
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        defer {
+            XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
+            XCTAssertNoThrow(try httpBin.shutdown())
+        }
+
+        let response = try httpClient.get(url: "http://localhost:\(httpBin.port)/percent%2Fencoded/hello").wait()
+        XCTAssertEqual(.ok, response.status)
+    }
+
     func testMultipleContentLengthHeaders() throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
         defer {


### PR DESCRIPTION
Hi 👋, thanks for all the great work on this project.

I have a package that calls the Travis API, which uses %2F as part of the URL path segment. This PR adds a test case & migrates to `URLComponents(url: self, resolvingAgainstBaseURL: false)?.percentEncodedPath` which covers that use case.

I also updated the test server to switch on the `percentEncodedPath` so it's easier
to understand the desired behaviour. I've tested this locally on 10.15.4 but not on Ubuntu.