### PR TITLE
Add support for FileRegion in HTTPClient.Body

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -60,6 +60,16 @@ extension HTTPClient {
             }
         }
 
+        /// Create and stream body using `FileRegion`.
+        ///
+        /// - parameters:
+        ///     - buffer: Body `FileRegion` representation.
+        public static func fileRegion(_ fileRegion: FileRegion) -> Body {
+            return Body(length: fileRegion.readableBytes) { writer in
+                writer.write(.fileRegion(fileRegion))
+            }
+        }
+
         /// Create and stream body using `StreamWriter`.
         ///
         /// - parameters:

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -98,6 +98,7 @@ extension HTTPClientTests {
             ("testRacePoolIdleConnectionsAndGet", testRacePoolIdleConnectionsAndGet),
             ("testAvoidLeakingTLSHandshakeCompletionPromise", testAvoidLeakingTLSHandshakeCompletionPromise),
             ("testAsyncShutdown", testAsyncShutdown),
+            ("testFileRegion", testFileRegion),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1733,7 +1733,7 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
         // create random block of text
-        let uint8Array = Array<Int8>(repeating: 0, count: 16384).map { _ in Int8.random(in: 32...127)}
+        let uint8Array = [Int8](repeating: 0, count: 16384).map { _ in Int8.random(in: 32...127)}
         let asciiString = String(utf8String: uint8Array)!
         let asciiData = Data(asciiString.utf8)
 
@@ -1755,7 +1755,6 @@ class HTTPClientTests: XCTestCase {
             let bytes = response.body.flatMap { $0.getData(at: 0, length: $0.readableBytes) }
             let responseData = try JSONDecoder().decode(RequestInfo.self, from: bytes!)
             XCTAssertEqual(String(data: asciiData[4190..<12745], encoding: .utf8)!, responseData.data)
-            
         } catch {
             XCTFail("\(error)")
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1726,7 +1726,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testFileRegion() {
-        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(group))
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
         let httpBin = HTTPBin()
         defer {
             XCTAssertNoThrow(try httpBin.shutdown())

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1733,8 +1733,9 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
         // create random block of text
-        let uint8Array = [Int8](repeating: 0, count: 16384).map { _ in Int8.random(in: 32...127)}
-        let asciiString = String(utf8String: uint8Array)!
+        let asciiString = String(decoding: Array(repeating: UInt8(0), count: 16384).map { _ in
+            UInt8.random(in: .init(ascii: "A") ... .init(ascii: "z"))
+        }, as: UTF8.self)
         let asciiData = Data(asciiString.utf8)
 
         let filename = "randomfile"


### PR DESCRIPTION
Given you can initialise an `IOData` with a `FileRegion` it seems sensible to provide this functionality to users of AsyncHTTPClient.