### PR TITLE
make cookie parsing case insensitive

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
@@ -18,7 +18,7 @@ import XCTest
 
 class HTTPClientCookieTests: XCTestCase {
     func testCookie() {
-        let v = "key=value; Path=/path; Domain=example.com; Expires=Wed, 21 Oct 2015 07:28:00 GMT; Max-Age=42; Secure; HttpOnly"
+        let v = "key=value; PaTh=/path; DoMaIn=example.com; eXpIRes=Wed, 21 Oct 2015 07:28:00 GMT; max-AGE=42; seCURE; HTTPOnly"
         let c = HTTPClient.Cookie(header: v, defaultDomain: "exampe.org")!
         XCTAssertEqual("key", c.name)
         XCTAssertEqual("value", c.value)


### PR DESCRIPTION
Make cookie parsing case-insensitive, closes #205

Motivation:
As per https://tools.ietf.org/html/rfc6265#section-5.2.2, cookie names should be case-insensitive, and currently they are not.

Modifications:
1. always split cookie component into name and optional value, lowercase the name and then match by this name using pre-defined lowercased constant
2. modify one of the tests to send differently-cased cookie components

Result:
Cookie parsing is case-insensitive.