### PR TITLE
allow empty value cookies

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -50,7 +50,7 @@ extension HTTPClient {
                 return nil
             }
 
-            let nameAndValue = components[0].split(separator: "=", maxSplits: 1).map {
+            let nameAndValue = components[0].split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false).map {
                 $0.trimmingCharacters(in: .whitespaces)
             }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests+XCTest.swift
@@ -26,6 +26,7 @@ extension HTTPClientCookieTests {
     static var allTests: [(String, (HTTPClientCookieTests) -> () throws -> Void)] {
         return [
             ("testCookie", testCookie),
+            ("testEmptyValueCookie", testEmptyValueCookie),
             ("testCookieDefaults", testCookieDefaults),
             ("testCookieInit", testCookieInit),
         ]

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
@@ -30,6 +30,19 @@ class HTTPClientCookieTests: XCTestCase {
         XCTAssertTrue(c.secure)
     }
 
+    func testEmptyValueCookie() {
+        let v = "cookieValue=; Path=/"
+        let c = HTTPClient.Cookie(header: v, defaultDomain: "exampe.org")!
+        XCTAssertEqual("cookieValue", c.name)
+        XCTAssertEqual("", c.value)
+        XCTAssertEqual("/", c.path)
+        XCTAssertEqual("exampe.org", c.domain)
+        XCTAssertNil(c.expires)
+        XCTAssertNil(c.maxAge)
+        XCTAssertFalse(c.httpOnly)
+        XCTAssertFalse(c.secure)
+    }
+
     func testCookieDefaults() {
         let v = "key=value"
         let c = HTTPClient.Cookie(header: v, defaultDomain: "example.org")!


### PR DESCRIPTION
Allow empty-value cookies, closes #206 

Motivation:
RFC allows empty-value cookies, so we should handle them as well

Modifications:
1. Fix split in cookie parsing
2. Add a test

Result:
We can now allow empty value cookies