### PR TITLE
fix malformed cookie parsing

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -61,7 +61,7 @@ extension HTTPClient {
             self.name = nameAndValue[0]
             self.value = nameAndValue[1]
 
-            guard !name.isEmpty else {
+            guard !self.name.isEmpty else {
                 return nil
             }
 

--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -61,6 +61,10 @@ extension HTTPClient {
             self.name = nameAndValue[0]
             self.value = nameAndValue[1]
 
+            guard !name.isEmpty else {
+                return nil
+            }
+
             self.path = "/"
             self.domain = defaultDomain
             self.expires = nil
@@ -70,6 +74,8 @@ extension HTTPClient {
 
             for component in components[1...] {
                 switch self.parseComponent(component) {
+                case (nil, nil):
+                    continue
                 case ("path", .some(let value)):
                     self.path = value
                 case ("domain", .some(let value)):
@@ -114,14 +120,16 @@ extension HTTPClient {
             self.secure = secure
         }
 
-        func parseComponent(_ component: String) -> (String, String?) {
+        func parseComponent(_ component: String) -> (String?, String?) {
             let nameAndValue = component.split(separator: "=", maxSplits: 1).map {
                 $0.trimmingCharacters(in: .whitespaces)
             }
             if nameAndValue.count == 2 {
                 return (nameAndValue[0].lowercased(), nameAndValue[1])
+            } else if nameAndValue.count == 1 {
+                return (nameAndValue[0].lowercased(), nil)
             }
-            return (nameAndValue[0].lowercased(), nil)
+            return (nil, nil)
         }
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests+XCTest.swift
@@ -29,6 +29,7 @@ extension HTTPClientCookieTests {
             ("testEmptyValueCookie", testEmptyValueCookie),
             ("testCookieDefaults", testCookieDefaults),
             ("testCookieInit", testCookieInit),
+            ("testMalformedCookies", testMalformedCookies),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
@@ -67,4 +67,19 @@ class HTTPClientCookieTests: XCTestCase {
         XCTAssertTrue(c.httpOnly)
         XCTAssertTrue(c.secure)
     }
+
+    func testMalformedCookies() {
+        XCTAssertNil(HTTPClient.Cookie(header: "", defaultDomain: "exampe.org"))
+        XCTAssertNil(HTTPClient.Cookie(header: ";;", defaultDomain: "exampe.org"))
+        XCTAssertNil(HTTPClient.Cookie(header: "name;;", defaultDomain: "exampe.org"))
+        XCTAssertNotNil(HTTPClient.Cookie(header: "name=;;", defaultDomain: "exampe.org"))
+        XCTAssertNotNil(HTTPClient.Cookie(header: "name=value;;", defaultDomain: "exampe.org"))
+        XCTAssertNotNil(HTTPClient.Cookie(header: "name=value;x;", defaultDomain: "exampe.org"))
+        XCTAssertNotNil(HTTPClient.Cookie(header: "name=value;x=;", defaultDomain: "exampe.org"))
+        XCTAssertNotNil(HTTPClient.Cookie(header: "name=value;;x=;", defaultDomain: "exampe.org"))
+        XCTAssertNil(HTTPClient.Cookie(header: ";key=value", defaultDomain: "exampe.org"))
+        XCTAssertNil(HTTPClient.Cookie(header: "key;key=value", defaultDomain: "exampe.org"))
+        XCTAssertNil(HTTPClient.Cookie(header: "=;", defaultDomain: "exampe.org"))
+        XCTAssertNil(HTTPClient.Cookie(header: "=value;", defaultDomain: "exampe.org"))
+    }
 }


### PR DESCRIPTION
Fixes malformed cookie parsing, closes #209.

Motivation:
We do not check that cookie component name could be empty, assuming that split array is not empty, that could lead to crash.

Modifications:
1. return empty pairs if split array is empty
2. add a test

Result:
Cookie parsing is more robust.