### PR TITLE
don't flush on every body part

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -767,9 +767,10 @@ extension TaskHandler: ChannelDuplexHandler {
 
         return body.stream(HTTPClient.Body.StreamWriter { part in
             context.eventLoop.assertInEventLoop()
-            return context.writeAndFlush(self.wrapOutboundOut(.body(part))).map {
+            context.write(self.wrapOutboundOut(.body(part))).whenSuccess {
                 self.callOutToDelegateFireAndForget(value: part, self.delegate.didSendRequestPart)
             }
+            return context.eventLoop.makeSucceededFuture(())
         })
     }
 


### PR DESCRIPTION
Right now we call `flush` on every body part write, this can be suboptimal, closes #203 

Motivation:
Library users can write data in small chunk, in this case we are not buffering enough data, better solution would be to buffer at the NIO level in this case.

Modifications:
Body part write is not not flushing, just `write`

Result:
Body part writes are not flushing anymore