### PR TITLE
draft for streaming el fixes

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -766,7 +766,7 @@ extension TaskHandler: ChannelDuplexHandler {
         }
 
         func doIt() -> EventLoopFuture<Void> {
-            body.stream(HTTPClient.Body.StreamWriter { part in
+            return body.stream(HTTPClient.Body.StreamWriter { part in
                 self.task.eventLoop.assertInEventLoop()
                 func doIt() -> EventLoopFuture<Void> {
                     return context.writeAndFlush(self.wrapOutboundOut(.body(part))).map {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -98,6 +98,8 @@ extension HTTPClientTests {
             ("testAsyncShutdown", testAsyncShutdown),
             ("testValidationErrorsAreSurfaced", testValidationErrorsAreSurfaced),
             ("testUploadsReallyStream", testUploadsReallyStream),
+            ("testUploadStreamingCallinToleratedFromOtsideEL", testUploadStreamingCallinToleratedFromOtsideEL),
+            ("testUploadStreamingIsCalledOnTaskEL", testUploadStreamingIsCalledOnTaskEL),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -447,40 +447,22 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testUploadStreaming() throws {
-        let group = getDefaultEventLoopGroup(numberOfThreads: 4)
-        defer {
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
-        }
-
         let httpBin = HTTPBin()
-        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(group))
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
             XCTAssertNoThrow(try httpBin.shutdown())
         }
 
-        let el1 = group.next()
-        let el2 = group.next()
-        XCTAssertFalse(el1 === el2)
-
         let body: HTTPClient.Body = .stream(length: 8) { writer in
-            XCTAssert(el1.inEventLoop)
             let buffer = ByteBuffer.of(string: "1234")
             return writer.write(.byteBuffer(buffer)).flatMap {
-                XCTAssert(el1.inEventLoop)
                 let buffer = ByteBuffer.of(string: "4321")
                 return writer.write(.byteBuffer(buffer))
             }
         }
 
-        do {
-            // Pre-populate pool with a connection on a different EL
-            let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/get", method: .GET)
-            XCTAssertNoThrow(try httpClient.execute(request: request, delegate: ResponseAccumulator(request: request), eventLoop: .delegateAndChannel(on: el2)).wait())
-        }
-
-        let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/post", method: .POST, body: body)
-        let response = try httpClient.execute(request: request, delegate: ResponseAccumulator(request: request), eventLoop: .delegate(on: el1)).wait()
+        let response = try httpClient.post(url: "http://localhost:\(httpBin.port)/post", body: body).wait()
         let bytes = response.body.flatMap { $0.getData(at: 0, length: $0.readableBytes) }
         let data = try JSONDecoder().decode(RequestInfo.self, from: bytes!)
 
@@ -1827,5 +1809,63 @@ class HTTPClientTests: XCTestCase {
         sentOffAllBodyPartsPromise.succeed(())
         XCTAssertNoThrow(try endPromise.futureResult.wait())
         XCTAssertNoThrow(try runningRequest.wait())
+    }
+
+    func testUploadStreamingCallinToleratedFromOtsideEL() throws {
+        let httpBin = HTTPBin()
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
+        defer {
+            XCTAssertNoThrow(try httpClient.syncShutdown())
+            XCTAssertNoThrow(try httpBin.shutdown())
+        }
+
+        let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/get", method: .POST, body: .stream(length: 4) { writer in
+            let promise = httpClient.eventLoopGroup.next().makePromise(of: Void.self)
+            // We have to toleare callins from any thread
+            DispatchQueue(label: "upload-streaming").async {
+                writer.write(.byteBuffer(ByteBuffer.of(string: "1234"))).whenComplete { _ in
+                    promise.succeed(())
+                }
+            }
+            return promise.futureResult
+        })
+        XCTAssertNoThrow(try httpClient.execute(request: request).wait())
+    }
+
+    func testUploadStreamingIsCalledOnTaskEL() throws {
+        let group = getDefaultEventLoopGroup(numberOfThreads: 4)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+
+        let httpBin = HTTPBin()
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(group))
+        defer {
+            XCTAssertNoThrow(try httpClient.syncShutdown())
+            XCTAssertNoThrow(try httpBin.shutdown())
+        }
+
+        let el1 = group.next()
+        let el2 = group.next()
+        XCTAssertFalse(el1 === el2)
+
+        do {
+            // Pre-populate pool with a connection on a different EL
+            let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/get", method: .GET)
+            XCTAssertNoThrow(try httpClient.execute(request: request, delegate: ResponseAccumulator(request: request), eventLoop: .delegateAndChannel(on: el2)).wait())
+        }
+
+        let body: HTTPClient.Body = .stream(length: 8) { writer in
+            XCTAssert(el1.inEventLoop)
+            let buffer = ByteBuffer.of(string: "1234")
+            return writer.write(.byteBuffer(buffer)).flatMap {
+                XCTAssert(el1.inEventLoop)
+                let buffer = ByteBuffer.of(string: "4321")
+                return writer.write(.byteBuffer(buffer))
+            }
+        }
+        let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/post", method: .POST, body: body)
+        let response = httpClient.execute(request: request, delegate: ResponseAccumulator(request: request), eventLoop: .delegate(on: el1))
+        XCTAssertNoThrow(try response.wait())
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1796,7 +1796,7 @@ class HTTPClientTests: XCTestCase {
                                            method: .POST,
                                            headers: ["transfer-encoding": "chunked"],
                                            body: .stream { streamWriter in
-                                               streamWriterPromise.succeed((streamWriter))
+                                               streamWriterPromise.succeed(streamWriter)
                                                return sentOffAllBodyPartsPromise.futureResult
             })
         }


### PR DESCRIPTION
Fixes programming model for upload streaming

Motivation:
Right now EL on which we execute streaming call back is not explicitly defined. Also, we do not check on which EL part write is executed, meaning we can fail if `.write` is not called on correct EL.

Modifications:
1. Call to `body.stream` is now executed on tasks EL
2. Calls to `writeAndFlush` are always called on channel EL
3. Added tests for those to cases
4. Removed a hack in test introduced in #219 
5. Fixed #219 shutdown to not call to shutdown EL

Result:
1. closes #198
2. closes #200 