### PR TITLE
test: that streaming actually works

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -96,6 +96,7 @@ extension HTTPClientTests {
             ("testRacePoolIdleConnectionsAndGet", testRacePoolIdleConnectionsAndGet),
             ("testAvoidLeakingTLSHandshakeCompletionPromise", testAvoidLeakingTLSHandshakeCompletionPromise),
             ("testAsyncShutdown", testAsyncShutdown),
+            ("testUploadsReallyStream", testUploadsReallyStream),
         ]
     }
 }


### PR DESCRIPTION
Motivation:

We didn't have a test that tested that streaming really streams, ie.
that request body part N arrives before N+1 is sent.

Modification:

Test it.

Result:

Better test coverage.