### PR TITLE
fix validation error propagation

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -554,10 +554,10 @@ extension HTTPClient {
 
         func fail<Delegate: HTTPClientResponseDelegate>(with error: Error, delegateType: Delegate.Type) {
             if let connection = self.connection {
-                connection.channel.close(promise: nil)
                 self.releaseAssociatedConnection(delegateType: delegateType, closing: true)
                     .whenSuccess {
                         self.promise.fail(error)
+                        connection.channel.close(promise: nil)
                     }
             }
         }
@@ -729,7 +729,7 @@ extension TaskHandler: ChannelDuplexHandler {
             try headers.validate(method: request.method, body: request.body)
         } catch {
             promise?.fail(error)
-            context.fireErrorCaught(error)
+            self.failTaskAndNotifyDelegate(error: error, self.delegate.didReceiveError)
             self.state = .end
             return
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -96,6 +96,7 @@ extension HTTPClientTests {
             ("testRacePoolIdleConnectionsAndGet", testRacePoolIdleConnectionsAndGet),
             ("testAvoidLeakingTLSHandshakeCompletionPromise", testAvoidLeakingTLSHandshakeCompletionPromise),
             ("testAsyncShutdown", testAsyncShutdown),
+            ("testValidationErrorsAreSurfaced", testValidationErrorsAreSurfaced),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1679,7 +1679,7 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNoThrow(try promise.futureResult.wait())
     }
 
-    func testValidationErrorsAreSurfaced() {
+    func testValidationErrorsAreSurfaced() throws {
         let httpBin = HTTPBin()
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
         defer {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1667,7 +1667,7 @@ class HTTPClientTests: XCTestCase {
         }
     }
 
-    func testAsyncShutdown() {
+    func testAsyncShutdown() throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
         let promise = self.clientGroup.next().makePromise(of: Void.self)
         self.clientGroup.next().execute {
@@ -1687,7 +1687,7 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try httpBin.shutdown())
         }
 
-        let request = try! HTTPClient.Request(url: "http://localhost:\(httpBin.port)/get", method: .TRACE, body: .stream { writer in
+        let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)/get", method: .TRACE, body: .stream { _ in
             httpClient.eventLoopGroup.next().makeSucceededFuture(())
         })
         let runningRequest = httpClient.execute(request: request)


### PR DESCRIPTION
Fixes request validation error propagation and use-after-shutdown, closes #217 and #220.

Motivation:
First issue is that validation errors are not passed to task fail methods. Second is that channel closed before connection is released from the pool, in this case clients will get wrong error (`remoteConnectionClosed`) and connection will be released twice, potentially trying to execute stuff on a shutdown event loop.

Modifications:
1. use task failing method for error propagation
2. close channel after connection was released

Result:
Error propagation is fixed.