### PR TITLE
Better support for UNIX Domain sockets

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -113,6 +113,10 @@ final class ConnectionPool {
                 self.scheme = .https
             case "unix":
                 self.scheme = .unix
+            case "http+unix":
+                self.scheme = .http_unix
+            case "https+unix":
+                self.scheme = .https_unix
             default:
                 fatalError("HTTPClient.Request scheme should already be a valid one")
             }
@@ -130,10 +134,12 @@ final class ConnectionPool {
             case http
             case https
             case unix
+            case http_unix
+            case https_unix
 
             var requiresTLS: Bool {
                 switch self {
-                case .https:
+                case .https, .https_unix:
                     return true
                 default:
                     return false
@@ -455,7 +461,7 @@ class HTTP1ConnectionProvider {
         case .http, .https:
             let address = HTTPClient.resolveAddress(host: self.key.host, port: self.key.port, proxy: self.configuration.proxy)
             channel = bootstrap.connect(host: address.host, port: address.port)
-        case .unix:
+        case .unix, .http_unix, .https_unix:
             channel = bootstrap.connect(unixDomainSocketPath: self.key.unixPath)
         }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -726,6 +726,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     private enum Code: Equatable {
         case invalidURL
         case emptyHost
+        case missingSocketPath
         case alreadyShutdown
         case emptyScheme
         case unsupportedScheme(String)
@@ -758,6 +759,8 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     public static let invalidURL = HTTPClientError(code: .invalidURL)
     /// URL does not contain host.
     public static let emptyHost = HTTPClientError(code: .emptyHost)
+    /// URL does not contain a socketPath as a host for http(s)+unix shemes.
+    public static let missingSocketPath = HTTPClientError(code: .missingSocketPath)
     /// Client is shutdown and cannot be used for new requests.
     public static let alreadyShutdown = HTTPClientError(code: .alreadyShutdown)
     /// URL does not contain scheme.

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -654,7 +654,7 @@ extension ChannelPipeline {
     }
 
     func addSSLHandlerIfNeeded(for key: ConnectionPool.Key, tlsConfiguration: TLSConfiguration?, addSSLClient: Bool, handshakePromise: EventLoopPromise<Void>) {
-        guard key.scheme == .https else {
+        guard key.scheme.requiresTLS else {
             handshakePromise.succeed(())
             return
         }

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -665,7 +665,7 @@ extension ChannelPipeline {
                 let tlsConfiguration = tlsConfiguration ?? TLSConfiguration.forClient()
                 let context = try NIOSSLContext(configuration: tlsConfiguration)
                 handlers = [
-                    try NIOSSLClientHandler(context: context, serverHostname: key.host.isIPAddress ? nil : key.host),
+                    try NIOSSLClientHandler(context: context, serverHostname: (key.host.isIPAddress || key.host.isEmpty) ? nil : key.host),
                     TLSEventsHandler(completionPromise: handshakePromise),
                 ]
             } else {

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -99,20 +99,23 @@ extension HTTPClient {
     public struct Request {
         /// Represent kind of Request
         enum Kind {
+            enum UnixScheme {
+                case baseURL
+            }
+
             /// Remote host request.
             case host
             /// UNIX Domain Socket HTTP request.
-            case unixSocket
+            case unixSocket(_ scheme: UnixScheme)
 
             private static var hostSchemes = ["http", "https"]
             private static var unixSchemes = ["unix"]
 
             init(forScheme scheme: String) throws {
-                if Kind.host.supports(scheme: scheme) {
-                    self = .host
-                } else if Kind.unixSocket.supports(scheme: scheme) {
-                    self = .unixSocket
-                } else {
+                switch scheme {
+                case "http", "https": self = .host
+                case "unix": self = .unixSocket(.baseURL)
+                default:
                     throw HTTPClientError.unsupportedScheme(scheme)
                 }
             }
@@ -126,6 +129,24 @@ extension HTTPClient {
                     return host
                 case .unixSocket:
                     return ""
+                }
+            }
+
+            func socketPathFromURL(_ url: URL) throws -> String {
+                switch self {
+                case .unixSocket(.baseURL):
+                    return url.baseURL?.path ?? url.path
+                case .host:
+                    return ""
+                }
+            }
+
+            func uriFromURL(_ url: URL) -> String {
+                switch self {
+                case .host:
+                    return url.uri
+                case .unixSocket(.baseURL):
+                    return url.baseURL != nil ? url.uri : "/"
                 }
             }
 
@@ -147,6 +168,10 @@ extension HTTPClient {
         public let scheme: String
         /// Remote host, resolved from `URL`.
         public let host: String
+        /// Socket path, resolved from `URL`.
+        let socketPath: String
+        /// URI composed of the path and query, resolved from `URL`.
+        let uri: String
         /// Request custom HTTP Headers, defaults to no headers.
         public var headers: HTTPHeaders
         /// Request body, defaults to no body.
@@ -199,6 +224,8 @@ extension HTTPClient {
 
             self.kind = try Kind(forScheme: scheme)
             self.host = try self.kind.hostFromURL(url)
+            self.socketPath = try self.kind.socketPathFromURL(url)
+            self.uri = self.kind.uriFromURL(url)
 
             self.redirectState = nil
             self.url = url
@@ -712,19 +739,9 @@ extension TaskHandler: ChannelDuplexHandler {
         self.state = .idle
         let request = self.unwrapOutboundIn(data)
 
-        let uri: String
-        switch (self.kind, request.url.baseURL) {
-        case (.host, _):
-            uri = request.url.uri
-        case (.unixSocket, .none):
-            uri = "/" // we don't have a real path, the path we have is the path of the UNIX Domain Socket.
-        case (.unixSocket, .some(_)):
-            uri = request.url.uri
-        }
-
         var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
                                    method: request.method,
-                                   uri: uri)
+                                   uri: request.uri)
         var headers = request.headers
 
         if !request.headers.contains(name: "Host") {

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -64,7 +64,7 @@ extension ClientBootstrap {
         } else {
             let tlsConfiguration = configuration.tlsConfiguration ?? TLSConfiguration.forClient()
             let sslContext = try NIOSSLContext(configuration: tlsConfiguration)
-            let hostname = (!requiresTLS || host.isIPAddress) ? nil : host
+            let hostname = (!requiresTLS || host.isIPAddress || host.isEmpty) ? nil : host
             let tlsProvider = try NIOSSLClientTLSProvider<ClientBootstrap>(context: sslContext, serverHostname: hostname)
             return NIOClientTCPBootstrap(self, tls: tlsProvider)
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -234,7 +234,6 @@ internal final class HTTPBin {
 
         self.serverChannel = try! ServerBootstrap(group: self.group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .childChannelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .serverChannelInitializer { channel in
                 channel.pipeline.addHandler(activeConnCounterHandler)
             }.childChannelInitializer { channel in

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -90,6 +90,8 @@ extension HTTPClientTests {
             ("testMakeSecondRequestWhilstFirstIsOngoing", testMakeSecondRequestWhilstFirstIsOngoing),
             ("testUDSBasic", testUDSBasic),
             ("testUDSSocketAndPath", testUDSSocketAndPath),
+            ("testHTTPPlusUNIX", testHTTPPlusUNIX),
+            ("testHTTPSPlusUNIX", testHTTPSPlusUNIX),
             ("testUseExistingConnectionOnDifferentEL", testUseExistingConnectionOnDifferentEL),
             ("testWeRecoverFromServerThatClosesTheConnectionOnUs", testWeRecoverFromServerThatClosesTheConnectionOnUs),
             ("testPoolClosesIdleConnections", testPoolClosesIdleConnections),


### PR DESCRIPTION
These changes upgrade the unix domain socket handling to address the following issues:
- Using socket paths currently requires obtuse URL objects with a specially constructed baseURL. These are not easily serializable as strings.
- It is currently not possible to connect to a server over a socket path that uses TLS.

To maintain backward compatibility, this PR introduces two new URL schemes: `http+unix://`, and `https+unix://`. These url schemes, while not universal, are used in a standard way by other services ([some](https://github.com/httpie/httpie-unixsocket) - [examples](https://github.com/msabramo/requests-unixsocket)), and work by %-encoding the socket path as the url hostname. These are easy to construct using standard swift types:
```swift
let socketURL = URL(string: "https+unix://\(path.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)/echo-uri")
```
This produces a url that looks something like this: `https+unix://%2Ftmp%2FfilePath.socket/echo-uri`, which is fully supported by `URL`, and can be serialized and deserialized to and from a String easily.

When the `https+unix://` URL scheme is used, TLS is turned on. It is still up to the user to perform certificate validation under this scheme, but at the very least an encrypted connection over a socket is now possible if the server is configured to only provide such a configuration.

I'd also like to think I did a good job keeping things neat and tidy, and inline with the style of the repo, but I'm open to any and all feedback! (This is my first time contributing to any large open source project, so please be kind 😅)

### Where to go from here

Some future improvements that can be made:
- More tests…
- Some documentation on Request outlining the different possibilities.
- It would be nice to have a factory on URL to build a unix socket URL from a socket path and server path.
- We need some constants for "http", "https", "unix", "http+unix", and "https+unix" - it's a bit unwieldy at the moment.
- Perhaps deprecating the `unix:` scheme for the next major version? It's use is a bit unwieldy from a user's point of view (especially as many frameworks like Vapor have client constructors that take in strings as the URLs), and I doubt its currently widely used.