### PR TITLE
The host header should also include the port

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -253,6 +253,11 @@ extension HTTPClient {
             return self.scheme == "https" || self.scheme == "https+unix"
         }
 
+        /// Specified port.
+        public var specifiedPort: Int? {
+            return self.url.port
+        }
+
         /// Resolved port.
         public var port: Int {
             return self.url.port ?? (self.useTLS ? 443 : 80)
@@ -772,7 +777,7 @@ extension TaskHandler: ChannelDuplexHandler {
         var headers = request.headers
 
         if !request.headers.contains(name: "Host") {
-            headers.add(name: "Host", value: request.host)
+            headers.add(name: "Host", value: "\(request.host)\(request.specifiedPort.map { ":\($0)" } ?? "")")
         }
 
         do {

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -774,7 +774,7 @@ extension TaskHandler: ChannelDuplexHandler {
         if !request.headers.contains(name: "host") {
             let port = request.port
             var host = request.host
-            if (port != 80 || request.scheme != "http") && (port != 443 || request.scheme != "https") {
+            if !(port == 80 && request.scheme == "http"), !(port == 443 && request.scheme == "https") {
                 host += ":\(port)"
             }
             headers.add(name: "host", value: host)

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -254,7 +254,7 @@ extension HTTPClient {
         }
 
         /// Specified port.
-        public var specifiedPort: Int? {
+        var specifiedPort: Int? {
             return self.url.port
         }
 

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -253,11 +253,6 @@ extension HTTPClient {
             return self.scheme == "https" || self.scheme == "https+unix"
         }
 
-        /// Specified port.
-        var specifiedPort: Int? {
-            return self.url.port
-        }
-
         /// Resolved port.
         public var port: Int {
             return self.url.port ?? (self.useTLS ? 443 : 80)
@@ -777,7 +772,9 @@ extension TaskHandler: ChannelDuplexHandler {
         var headers = request.headers
 
         if !request.headers.contains(name: "Host") {
-            headers.add(name: "Host", value: "\(request.host)\(request.specifiedPort.map { ":\($0)" } ?? "")")
+            let port = request.port
+            let host = (port != 80 && port != 443) ? "\(request.host):\(port)" : request.host
+            headers.add(name: "Host", value: host)
         }
 
         do {

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -771,10 +771,13 @@ extension TaskHandler: ChannelDuplexHandler {
                                    uri: request.uri)
         var headers = request.headers
 
-        if !request.headers.contains(name: "Host") {
+        if !request.headers.contains(name: "host") {
             let port = request.port
-            let host = (port != 80 && port != 443) ? "\(request.host):\(port)" : request.host
-            headers.add(name: "Host", value: host)
+            var host = request.host
+            if (port != 80 || request.scheme != "http") && (port != 443 || request.scheme != "https") {
+                host += ":\(port)"
+            }
+            headers.add(name: "host", value: host)
         }
 
         do {

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -27,6 +27,7 @@ extension HTTPClientInternalTests {
         return [
             ("testHTTPPartsHandler", testHTTPPartsHandler),
             ("testBadHTTPRequest", testBadHTTPRequest),
+            ("testHostPort", testHostPort),
             ("testHTTPPartsHandlerMultiBody", testHTTPPartsHandlerMultiBody),
             ("testProxyStreaming", testProxyStreaming),
             ("testProxyStreamingFailure", testProxyStreamingFailure),

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -109,16 +109,21 @@ class HTTPClientInternalTests: XCTestCase {
         XCTAssertNoThrow(try channel.writeOutbound(request2))
         let request3 = try Request(url: "http://localhost:8080/get")
         XCTAssertNoThrow(try channel.writeOutbound(request3))
+        let request4 = try Request(url: "http://localhost:443/get")
+        XCTAssertNoThrow(try channel.writeOutbound(request4))
+        let request5 = try Request(url: "https://localhost:80/get")
+        XCTAssertNoThrow(try channel.writeOutbound(request5))
 
-        var head1 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get")
-        head1.headers.add(name: "Host", value: "localhost")
+        let head1 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get", headers: ["host": "localhost"])
         XCTAssertEqual(HTTPClientRequestPart.head(head1), recorder.writes[0])
-        var head2 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get")
-        head2.headers.add(name: "Host", value: "localhost")
+        let head2 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get", headers: ["host": "localhost"])
         XCTAssertEqual(HTTPClientRequestPart.head(head2), recorder.writes[2])
-        var head3 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get")
-        head3.headers.add(name: "Host", value: "localhost:8080")
+        let head3 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get", headers: ["host": "localhost:8080"])
         XCTAssertEqual(HTTPClientRequestPart.head(head3), recorder.writes[4])
+        let head4 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get", headers: ["host": "localhost:443"])
+        XCTAssertEqual(HTTPClientRequestPart.head(head4), recorder.writes[6])
+        let head5 = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get", headers: ["host": "localhost:80"])
+        XCTAssertEqual(HTTPClientRequestPart.head(head5), recorder.writes[8])
     }
 
     func testHTTPPartsHandlerMultiBody() throws {

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -49,7 +49,7 @@ class HTTPClientInternalTests: XCTestCase {
                                                     ignoreUncleanSSLShutdown: false,
                                                     logger: HTTPClient.loggingDisabled)).wait()
 
-        var request = try Request(url: "http://localhost/get")
+        var request = try Request(url: "http://localhost:8080/get")
         request.headers.add(name: "X-Test-Header", value: "X-Test-Value")
         request.body = .string("1234")
 
@@ -57,7 +57,7 @@ class HTTPClientInternalTests: XCTestCase {
         XCTAssertEqual(3, recorder.writes.count)
         var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1), method: .GET, uri: "/get")
         head.headers.add(name: "X-Test-Header", value: "X-Test-Value")
-        head.headers.add(name: "Host", value: "localhost")
+        head.headers.add(name: "Host", value: "localhost:8080")
         head.headers.add(name: "Content-Length", value: "4")
         XCTAssertEqual(HTTPClientRequestPart.head(head), recorder.writes[0])
         let buffer = ByteBuffer.of(string: "1234")

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -216,7 +216,7 @@ class HTTPClientTests: XCTestCase {
             return
         }
         let hostName = try? JSONDecoder().decode(RequestInfo.self, from: body).data
-        XCTAssertEqual("127.0.0.1", hostName)
+        XCTAssertEqual("127.0.0.1:\(self.defaultHTTPBin.port)", hostName)
     }
 
     func testPercentEncoded() throws {
@@ -763,7 +763,7 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
                                                     method: .GET,
                                                     uri: "/foo",
-                                                    headers: HTTPHeaders([("Host", "localhost")]))),
+                                                    headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
                                         try web.readInbound()))
         XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                         try web.readInbound()))
@@ -787,7 +787,7 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
                                                     method: .GET,
                                                     uri: "/foo",
-                                                    headers: HTTPHeaders([("Host", "localhost")]))),
+                                                    headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
                                         try web.readInbound()))
         XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                         try web.readInbound()))
@@ -808,7 +808,7 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
                                                     method: .GET,
                                                     uri: "/foo",
-                                                    headers: HTTPHeaders([("Host", "localhost")]))),
+                                                    headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
                                         try web.readInbound()))
         XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                         try web.readInbound()))
@@ -831,7 +831,7 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
                                                         method: .GET,
                                                         uri: "/foo",
-                                                        headers: HTTPHeaders([("Host", "localhost")]))),
+                                                        headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
                                             try web.readInbound()))
             XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                             try web.readInbound()))
@@ -859,7 +859,7 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
                                                         method: .GET,
                                                         uri: "/foo",
-                                                        headers: HTTPHeaders([("Host", "localhost")]))),
+                                                        headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
                                             try web.readInbound()))
             XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                             try web.readInbound()))
@@ -1036,7 +1036,7 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(XCTAssertEqual(.head(.init(version: .init(major: 1, minor: 1),
                                                         method: .GET,
                                                         uri: "/foo",
-                                                        headers: HTTPHeaders([("Host", "localhost")]))),
+                                                        headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
                                             try web.readInbound()))
             XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                             try web.readInbound()))


### PR DESCRIPTION
See https://tools.ietf.org/html/rfc7230#section-5.4

- If port is not 80 or 443 then add to host header.
- Fixed up tests