### PR TITLE
fix test and a crash when closed

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionsState.swift
+++ b/Sources/AsyncHTTPClient/ConnectionsState.swift
@@ -229,6 +229,10 @@ extension HTTP1ConnectionProvider {
                 self.openedConnectionsCount -= 1
                 return self.processNextWaiter()
             case .closed:
+                // This can happen in the following scenario: user initiates a connection that will fail to connect,
+                // user calls `syncShutdown` before we received an error from the bootstrap. In this scenario,
+                // pool will be `.closed` but connection will be still in the process of being established/failed,
+                // so then this process finishes, it will get to this point.
                 return .none
             }
         }

--- a/Sources/AsyncHTTPClient/ConnectionsState.swift
+++ b/Sources/AsyncHTTPClient/ConnectionsState.swift
@@ -229,7 +229,6 @@ extension HTTP1ConnectionProvider {
                 self.openedConnectionsCount -= 1
                 return self.processNextWaiter()
             case .closed:
-                assertionFailure("should not happen")
                 return .none
             }
         }

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolTests+XCTest.swift
@@ -34,6 +34,7 @@ extension ConnectionPoolTests {
             ("testAcquireReplace", testAcquireReplace),
             ("testAcquireWhenUnavailableSpecificEL", testAcquireWhenUnavailableSpecificEL),
             ("testAcquireWhenClosed", testAcquireWhenClosed),
+            ("testConnectFailedWhenClosed", testConnectFailedWhenClosed),
             ("testReleaseAliveConnectionEmptyQueue", testReleaseAliveConnectionEmptyQueue),
             ("testReleaseAliveButClosingConnectionEmptyQueue", testReleaseAliveButClosingConnectionEmptyQueue),
             ("testReleaseInactiveConnectionEmptyQueue", testReleaseInactiveConnectionEmptyQueue),

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
@@ -304,9 +304,7 @@ class ConnectionPoolTests: XCTestCase {
 
     func testAcquireWhenClosed() {
         var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
-        var snapshot = state.testsOnly_getInternalState()
-        snapshot.state = .closed
-        state.testsOnly_setInternalState(snapshot)
+        _ = state.close()
 
         XCTAssertFalse(state.enqueue())
 
@@ -322,11 +320,7 @@ class ConnectionPoolTests: XCTestCase {
 
     func testConnectFailedWhenClosed() {
         var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
-        var snapshot = state.testsOnly_getInternalState()
-        snapshot.state = .closed
-        state.testsOnly_setInternalState(snapshot)
-
-        XCTAssertFalse(state.enqueue())
+        _ = state.close()
 
         let action = state.connectFailed()
         switch action {

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
@@ -320,6 +320,23 @@ class ConnectionPoolTests: XCTestCase {
         }
     }
 
+    func testConnectFailedWhenClosed() {
+        var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
+        var snapshot = state.testsOnly_getInternalState()
+        snapshot.state = .closed
+        state.testsOnly_setInternalState(snapshot)
+
+        XCTAssertFalse(state.enqueue())
+
+        let action = state.connectFailed()
+        switch action {
+        case .none:
+            break
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+    }
+
     // MARK: - Release Tests
 
     func testReleaseAliveConnectionEmptyQueue() throws {


### PR DESCRIPTION
Fixes a crash in `testUncleanCloseThrows`.

Motivation:
This PR aims to fix two issues:
1. A crash on precondition, that was not removed when I re-factored how shutdowns work, it is absolutely normal to get a connection failure when client is shutting down, for example in the following scenario:
 - send a request that will fail to connect
 - shutdown the client
 - when connect error will be processed, client will be `.closed`, so it's a completely normal situatuon
2. A racy test, that test tries to establish a connection and shutdown the client while this connection is alive. But it does so in a racy fashion, there is no guarantee that when we get to client shutdown, connection has been established. This will be addressed by using `NIOHTTP1TestServer`, where we wait for `.head` before we attempt to shutdown the client.

Modifications:
1. Rewritten the `testUncleanCloseThrows` to use `NIOHTTP1TestServer` to eliminate a race
2. Removed precondition in `ConnectionState.swift`
3. Added a test to make sure that `connectFailed` is working as expected when the client is `.closed`

Result:
Closes #248