### PR TITLE
check body length

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -925,6 +925,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case uncleanShutdown
         case traceRequestWithBody
         case invalidHeaderFieldNames([String])
+        case bodyLengthMismatch
     }
 
     private var code: Code
@@ -969,10 +970,12 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     public static let redirectLimitReached = HTTPClientError(code: .redirectLimitReached)
     /// Redirect Cycle detected.
     public static let redirectCycleDetected = HTTPClientError(code: .redirectCycleDetected)
-    /// Unclean shutdown
+    /// Unclean shutdown.
     public static let uncleanShutdown = HTTPClientError(code: .uncleanShutdown)
-    /// A body was sent in a request with method TRACE
+    /// A body was sent in a request with method TRACE.
     public static let traceRequestWithBody = HTTPClientError(code: .traceRequestWithBody)
-    /// Header field names contain invalid characters
+    /// Header field names contain invalid characters.
     public static func invalidHeaderFieldNames(_ names: [String]) -> HTTPClientError { return HTTPClientError(code: .invalidHeaderFieldNames(names)) }
+    /// Body length is not equal to `Content-Length`.
+    public static let bodyLengthMismatch = HTTPClientError(code: .bodyLengthMismatch)
 }

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -651,7 +651,7 @@ internal class TaskHandler<Delegate: HTTPClientResponseDelegate>: RemovableChann
     let logger: Logger // We are okay to store the logger here because a TaskHandler is just for one request.
 
     var state: State = .idle
-    var expectedBodyLength: Int? = nil
+    var expectedBodyLength: Int?
     var actualBodyLength: Int = 0
     var pendingRead = false
     var mayRead = true

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -796,7 +796,6 @@ extension TaskHandler: ChannelDuplexHandler {
         assert(head.version == HTTPVersion(major: 1, minor: 1),
                "Sending a request in HTTP version \(head.version) which is unsupported by the above `if`")
 
-
         let contentLengths = head.headers[canonicalForm: "content-length"]
         assert(contentLengths.count <= 1)
 

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -841,12 +841,12 @@ extension TaskHandler: ChannelDuplexHandler {
                 let promise = self.task.eventLoop.makePromise(of: Void.self)
                 // All writes have to be switched to the channel EL if channel and task ELs differ
                 if context.eventLoop.inEventLoop {
-                    context.writeAndFlush(self.wrapOutboundOut(.body(part)), promise: promise)
                     self.actualBodyLength += part.readableBytes
+                    context.writeAndFlush(self.wrapOutboundOut(.body(part)), promise: promise)
                 } else {
                     context.eventLoop.execute {
-                        context.writeAndFlush(self.wrapOutboundOut(.body(part)), promise: promise)
                         self.actualBodyLength += part.readableBytes
+                        context.writeAndFlush(self.wrapOutboundOut(.body(part)), promise: promise)
                     }
                 }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -949,8 +949,8 @@ class HTTPClientInternalTests: XCTestCase {
 
         defer {
             XCTAssertNoThrow(try client.syncShutdown())
-            XCTAssertNoThrow(try elg.syncShutdownGracefully())
             XCTAssertNoThrow(try httpBin.shutdown())
+            XCTAssertNoThrow(try elg.syncShutdownGracefully())
         }
 
         let request = try HTTPClient.Request(url: "http://localhost:\(httpBin.port)//get")

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -188,6 +188,7 @@ internal final class HTTPBin {
     let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     let serverChannel: Channel
     let isShutdown: NIOAtomic<Bool> = .makeAtomic(value: false)
+    var connections: NIOAtomic<Int>
     var connectionCount: NIOAtomic<Int> = .makeAtomic(value: 0)
     private let activeConnCounterHandler: CountActiveConnectionsHandler
     var activeConnections: Int {
@@ -233,6 +234,9 @@ internal final class HTTPBin {
         let activeConnCounterHandler = CountActiveConnectionsHandler()
         self.activeConnCounterHandler = activeConnCounterHandler
 
+        let connections = NIOAtomic.makeAtomic(value: 0)
+        self.connections = connections
+
         self.serverChannel = try! ServerBootstrap(group: self.group)
             .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .serverChannelInitializer { channel in
@@ -261,10 +265,10 @@ internal final class HTTPBin {
                     }.flatMap {
                         if ssl {
                             return HTTPBin.configureTLS(channel: channel).flatMap {
-                                channel.pipeline.addHandler(HttpBinHandler(channelPromise: channelPromise, maxChannelAge: maxChannelAge))
+                                channel.pipeline.addHandler(HttpBinHandler(channelPromise: channelPromise, maxChannelAge: maxChannelAge, connectionId: connections.add(1)))
                             }
                         } else {
-                            return channel.pipeline.addHandler(HttpBinHandler(channelPromise: channelPromise, maxChannelAge: maxChannelAge))
+                            return channel.pipeline.addHandler(HttpBinHandler(channelPromise: channelPromise, maxChannelAge: maxChannelAge, connectionId: connections.add(1)))
                         }
                     }
                 }
@@ -357,8 +361,8 @@ internal struct HTTPResponseBuilder {
     }
 }
 
-let globalRequestCounter = NIOAtomic<Int>.makeAtomic(value: 0)
-let globalConnectionCounter = NIOAtomic<Int>.makeAtomic(value: 0)
+//let globalRequestCounter = NIOAtomic<Int>.makeAtomic(value: 0)
+//let globalConnectionCounter = NIOAtomic<Int>.makeAtomic(value: 0)
 
 internal struct RequestInfo: Codable {
     var data: String
@@ -378,13 +382,13 @@ internal final class HttpBinHandler: ChannelInboundHandler {
     let maxChannelAge: TimeAmount?
     var shouldClose = false
     var isServingRequest = false
-    let myConnectionNumber: Int
-    var currentRequestNumber: Int = -1
+    let connectionId: Int
+    var requestId: Int = 0
 
-    init(channelPromise: EventLoopPromise<Channel>? = nil, maxChannelAge: TimeAmount? = nil) {
+    init(channelPromise: EventLoopPromise<Channel>? = nil, maxChannelAge: TimeAmount? = nil, connectionId: Int) {
         self.channelPromise = channelPromise
         self.maxChannelAge = maxChannelAge
-        self.myConnectionNumber = globalConnectionCounter.add(1)
+        self.connectionId = connectionId
     }
 
     func handlerAdded(context: ChannelHandlerContext) {
@@ -424,7 +428,7 @@ internal final class HttpBinHandler: ChannelInboundHandler {
         switch self.unwrapInboundIn(data) {
         case .head(let req):
             self.responseHeaders = HTTPHeaders()
-            self.currentRequestNumber = globalRequestCounter.add(1)
+            self.requestId += 1
             self.parseAndSetOptions(from: req)
             let urlComponents = URLComponents(string: req.uri)!
             switch urlComponents.percentEncodedPath {
@@ -552,8 +556,15 @@ internal final class HttpBinHandler: ChannelInboundHandler {
             context.write(wrapOutboundOut(.head(response.head)), promise: nil)
             if let body = response.body {
                 let requestInfo = RequestInfo(data: String(buffer: body),
-                                              requestNumber: self.currentRequestNumber,
-                                              connectionNumber: self.myConnectionNumber)
+                                              requestNumber: self.requestId,
+                                              connectionNumber: self.connectionId)
+                let responseBody = try! JSONEncoder().encodeAsByteBuffer(requestInfo,
+                                                                         allocator: context.channel.allocator)
+                context.write(wrapOutboundOut(.body(.byteBuffer(responseBody))), promise: nil)
+            } else {
+                let requestInfo = RequestInfo(data: "",
+                                              requestNumber: self.requestId,
+                                              connectionNumber: self.connectionId)
                 let responseBody = try! JSONEncoder().encodeAsByteBuffer(requestInfo,
                                                                          allocator: context.channel.allocator)
                 context.write(wrapOutboundOut(.body(.byteBuffer(responseBody))), promise: nil)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -361,8 +361,8 @@ internal struct HTTPResponseBuilder {
     }
 }
 
-//let globalRequestCounter = NIOAtomic<Int>.makeAtomic(value: 0)
-//let globalConnectionCounter = NIOAtomic<Int>.makeAtomic(value: 0)
+// let globalRequestCounter = NIOAtomic<Int>.makeAtomic(value: 0)
+// let globalConnectionCounter = NIOAtomic<Int>.makeAtomic(value: 0)
 
 internal struct RequestInfo: Codable {
     var data: String

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -361,9 +361,6 @@ internal struct HTTPResponseBuilder {
     }
 }
 
-// let globalRequestCounter = NIOAtomic<Int>.makeAtomic(value: 0)
-// let globalConnectionCounter = NIOAtomic<Int>.makeAtomic(value: 0)
-
 internal struct RequestInfo: Codable {
     var data: String
     var requestNumber: Int

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -110,6 +110,8 @@ extension HTTPClientTests {
             ("testAllMethodsLog", testAllMethodsLog),
             ("testClosingIdleConnectionsInPoolLogsInTheBackground", testClosingIdleConnectionsInPoolLogsInTheBackground),
             ("testDelegateCallinsTolerateRandomEL", testDelegateCallinsTolerateRandomEL),
+            ("testContentLengthTooLongFails", testContentLengthTooLongFails),
+            ("testContentLengthTooShortFails", testContentLengthTooShortFails),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2056,9 +2056,9 @@ class HTTPClientTests: XCTestCase {
         let url = self.defaultHTTPBinURLPrefix + "/post"
         XCTAssertThrowsError(
             try self.defaultClient.execute(request:
-                                            Request(url: url,
-                                                    body: .stream(length: 10) { streamWriter in
-                                                        streamWriter.write(.byteBuffer(ByteBuffer(string: "1")))
+                Request(url: url,
+                        body: .stream(length: 10) { streamWriter in
+                            streamWriter.write(.byteBuffer(ByteBuffer(string: "1")))
                                                     })).wait()) { error in
             XCTAssertEqual(error as! HTTPClientError, HTTPClientError.bodyLengthMismatch)
         }
@@ -2072,9 +2072,9 @@ class HTTPClientTests: XCTestCase {
         let tooLong = "XBAD BAD BAD NOT HTTP/1.1\r\n\r\n"
         XCTAssertThrowsError(
             try self.defaultClient.execute(request:
-                                            Request(url: url,
-                                                    body: .stream(length: 1) { streamWriter in
-                                                        streamWriter.write(.byteBuffer(ByteBuffer(string: tooLong)))
+                Request(url: url,
+                        body: .stream(length: 1) { streamWriter in
+                            streamWriter.write(.byteBuffer(ByteBuffer(string: tooLong)))
                                                     })).wait()) { error in
             XCTAssertEqual(error as! HTTPClientError, HTTPClientError.bodyLengthMismatch)
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1713,7 +1713,8 @@ class HTTPClientTests: XCTestCase {
 
         // req 1 and 2 cannot share the same connection (close header)
         XCTAssertEqual(stats1.connectionNumber + 1, stats2.connectionNumber)
-        XCTAssertEqual(stats1.requestNumber + 1, stats2.requestNumber)
+        XCTAssertEqual(stats1.requestNumber, 1)
+        XCTAssertEqual(stats2.requestNumber, 1)
 
         // req 2 and 3 should share the same connection (keep-alive is default)
         XCTAssertEqual(stats2.requestNumber + 1, stats3.requestNumber)
@@ -1742,7 +1743,8 @@ class HTTPClientTests: XCTestCase {
 
         // req 1 and 2 cannot share the same connection (close header)
         XCTAssertEqual(stats1.connectionNumber + 1, stats2.connectionNumber)
-        XCTAssertEqual(stats1.requestNumber + 1, stats2.requestNumber)
+        XCTAssertEqual(stats1.requestNumber, 1)
+        XCTAssertEqual(stats2.requestNumber, 1)
 
         // req 2 and 3 should share the same connection (keep-alive is default)
         XCTAssertEqual(stats2.requestNumber + 1, stats3.requestNumber)
@@ -1773,7 +1775,7 @@ class HTTPClientTests: XCTestCase {
 
             // req 1 and 2 cannot share the same connection (close header)
             XCTAssertEqual(stats1.connectionNumber + 1, stats2.connectionNumber)
-            XCTAssertEqual(stats1.requestNumber + 1, stats2.requestNumber)
+            XCTAssertEqual(stats2.requestNumber, 1)
 
             // req 2 and 3 should share the same connection (keep-alive is default)
             XCTAssertEqual(stats2.requestNumber + 1, stats3.requestNumber)
@@ -1805,7 +1807,7 @@ class HTTPClientTests: XCTestCase {
 
             // req 1 and 2 cannot share the same connection (close header)
             XCTAssertEqual(stats1.connectionNumber + 1, stats2.connectionNumber)
-            XCTAssertEqual(stats1.requestNumber + 1, stats2.requestNumber)
+            XCTAssertEqual(stats2.requestNumber, 1)
 
             // req 2 and 3 should share the same connection (keep-alive is default)
             XCTAssertEqual(stats2.requestNumber + 1, stats3.requestNumber)
@@ -2052,22 +2054,29 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNoThrow(try future.wait())
     }
 
-    func testContentLengthTooLongFails() {
+    func testContentLengthTooLongFails() throws {
         let url = self.defaultHTTPBinURLPrefix + "/post"
         XCTAssertThrowsError(
             try self.defaultClient.execute(request:
                 Request(url: url,
                         body: .stream(length: 10) { streamWriter in
-                            streamWriter.write(.byteBuffer(ByteBuffer(string: "1")))
-                                                    })).wait()) { error in
+                            let promise = self.defaultClient.eventLoopGroup.next().makePromise(of: Void.self)
+                            DispatchQueue(label: "content-length-test").async {
+                                streamWriter.write(.byteBuffer(ByteBuffer(string: "1"))).cascade(to: promise)
+                            }
+                            return promise.futureResult
+                        })).wait()) { error in
             XCTAssertEqual(error as! HTTPClientError, HTTPClientError.bodyLengthMismatch)
         }
         // Quickly try another request and check that it works.
-        XCTAssertNoThrow(try self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "/get").wait())
+        var response = try self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "get").wait()
+        let info = try response.body!.readJSONDecodable(RequestInfo.self, length: response.body!.readableBytes)
+        XCTAssertEqual(info!.connectionNumber, 1)
+        XCTAssertEqual(info!.requestNumber, 1)
     }
 
     // currently gets stuck because of #250 the server just never replies
-    func testContentLengthTooShortFails() {
+    func testContentLengthTooShortFails() throws {
         let url = self.defaultHTTPBinURLPrefix + "/post"
         let tooLong = "XBAD BAD BAD NOT HTTP/1.1\r\n\r\n"
         XCTAssertThrowsError(
@@ -2080,6 +2089,9 @@ class HTTPClientTests: XCTestCase {
         }
         // Quickly try another request and check that it works. If we by accident wrote some extra bytes into the
         // stream (and reuse the connection) that could cause problems.
-        XCTAssertNoThrow(try self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "/get").wait())
+        var response = try self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "get").wait()
+        let info = try response.body!.readJSONDecodable(RequestInfo.self, length: response.body!.readableBytes)
+        XCTAssertEqual(info!.connectionNumber, 1)
+        XCTAssertEqual(info!.requestNumber, 1)
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
@@ -33,6 +33,7 @@ extension RequestValidationTests {
             ("testGET_HEAD_DELETE_CONNECTRequestCanHaveBody", testGET_HEAD_DELETE_CONNECTRequestCanHaveBody),
             ("testInvalidHeaderFieldNames", testInvalidHeaderFieldNames),
             ("testValidHeaderFieldNames", testValidHeaderFieldNames),
+            ("testMultipleContentLengthOnNilStreamLength", testMultipleContentLengthOnNilStreamLength),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -104,4 +104,14 @@ class RequestValidationTests: XCTestCase {
 
         XCTAssertNoThrow(try headers.validate(method: .GET, body: nil))
     }
+
+    func testMultipleContentLengthOnNilStreamLength() {
+        var headers = HTTPHeaders([("Content-Length", "1"), ("Content-Length", "2")])
+        var buffer = ByteBufferAllocator().buffer(capacity: 10)
+        buffer.writeBytes([UInt8](repeating: 12, count: 10))
+        let body: HTTPClient.Body = .stream() { writer in
+            writer.write(.byteBuffer(buffer))
+        }
+        XCTAssertThrowsError(try headers.validate(method: .PUT, body: body))
+    }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -109,7 +109,7 @@ class RequestValidationTests: XCTestCase {
         var headers = HTTPHeaders([("Content-Length", "1"), ("Content-Length", "2")])
         var buffer = ByteBufferAllocator().buffer(capacity: 10)
         buffer.writeBytes([UInt8](repeating: 12, count: 10))
-        let body: HTTPClient.Body = .stream() { writer in
+        let body: HTTPClient.Body = .stream { writer in
             writer.write(.byteBuffer(buffer))
         }
         XCTAssertThrowsError(try headers.validate(method: .PUT, body: body))


### PR DESCRIPTION
Adds checking for supplied body length.

Motivation:
We need to guard against incorrect body length since we can re-use connection, this is a potential security issue.

Modifications:
 - Adds a check in `HTTPTaskHandler` that if validated headers contain `Content-Length`, user sends exactly that amount of body data.
 - Two tests

Result:
Closes #251 