### PR TITLE
fix test faling with NIOTS

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -797,7 +797,7 @@ class HTTPClientInternalTests: XCTestCase {
     }
 
     func testUncleanCloseThrows() {
-        let server = NIOHTTP1TestServer(group: self.clientGroup)
+        let server = NIOHTTP1TestServer(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
         defer {
             XCTAssertNoThrow(try server.stop())
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -797,9 +797,11 @@ class HTTPClientInternalTests: XCTestCase {
     }
 
     func testUncleanCloseThrows() {
-        let server = NIOHTTP1TestServer(group: MultiThreadedEventLoopGroup(numberOfThreads: 1))
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let server = NIOHTTP1TestServer(group: group)
         defer {
             XCTAssertNoThrow(try server.stop())
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -23,17 +23,23 @@ class HTTPClientInternalTests: XCTestCase {
     typealias Request = HTTPClient.Request
     typealias Task = HTTPClient.Task
 
+    var serverGroup: EventLoopGroup!
     var clientGroup: EventLoopGroup!
 
     override func setUp() {
         XCTAssertNil(self.clientGroup)
+        XCTAssertNil(self.serverGroup)
+        self.serverGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.clientGroup = getDefaultEventLoopGroup(numberOfThreads: 1)
     }
 
     override func tearDown() {
+        XCTAssertNotNil(self.serverGroup)
+        XCTAssertNoThrow(try self.serverGroup.syncShutdownGracefully())
         XCTAssertNotNil(self.clientGroup)
         XCTAssertNoThrow(try self.clientGroup.syncShutdownGracefully())
         self.clientGroup = nil
+        self.serverGroup = nil
     }
 
     func testHTTPPartsHandler() throws {
@@ -797,11 +803,9 @@ class HTTPClientInternalTests: XCTestCase {
     }
 
     func testUncleanCloseThrows() {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let server = NIOHTTP1TestServer(group: group)
+        let server = NIOHTTP1TestServer(group: self.serverGroup)
         defer {
             XCTAssertNoThrow(try server.stop())
-            XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2031,7 +2031,7 @@ class HTTPClientTests: XCTestCase {
         let second = elg.next()
         XCTAssertFalse(first === second)
 
-        let httpServer = NIOHTTP1TestServer(group: first)
+        let httpServer = NIOHTTP1TestServer(group: self.serverGroup)
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(first))
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())


### PR DESCRIPTION
Fixes test crashing on precondition.

Motivation:
When tests are executed on macOS client ELG is actually a `NIOTS` ELG, so it's incompatible with `NIOHTTP1TestServer`

Modifications:
Use separate ELG in `testUncleanCloseThrows`

Result:
Closes #256 