### PR TITLE
Fixed an issue where redirects to socket path-based servers from any server was always allowed

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -107,8 +107,8 @@ extension HTTPClient {
             /// UNIX Domain Socket HTTP request.
             case unixSocket(_ scheme: UnixScheme)
 
-            private static var hostSchemes = ["http", "https"]
-            private static var unixSchemes = ["unix", "http+unix", "https+unix"]
+            private static var hostRestrictedSchemes: Set = ["http", "https"]
+            private static var allSupportedSchemes: Set = ["http", "https", "unix", "http+unix", "https+unix"]
 
             init(forScheme scheme: String) throws {
                 switch scheme {
@@ -158,12 +158,14 @@ extension HTTPClient {
                 }
             }
 
-            func supports(scheme: String) -> Bool {
+            func supportsRedirects(to scheme: String?) -> Bool {
+                guard let scheme = scheme?.lowercased() else { return false }
+
                 switch self {
                 case .host:
-                    return Kind.hostSchemes.contains(scheme)
+                    return Kind.hostRestrictedSchemes.contains(scheme)
                 case .unixSocket:
-                    return Kind.unixSchemes.contains(scheme)
+                    return Kind.allSupportedSchemes.contains(scheme)
                 }
             }
         }
@@ -1049,7 +1051,7 @@ internal struct RedirectHandler<ResponseType> {
             return nil
         }
 
-        guard self.request.kind.supports(scheme: self.request.scheme) else {
+        guard self.request.kind.supportsRedirects(to: url.scheme) else {
             return nil
         }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -495,6 +495,12 @@ internal final class HttpBinHandler: ChannelInboundHandler {
                 headers.add(name: "Location", value: "/redirect/infinite1")
                 self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
                 return
+            case "/redirect/target":
+                var headers = self.responseHeaders
+                let targetURL = req.headers["X-Target-Redirect-URL"].first ?? ""
+                headers.add(name: "Location", value: targetURL)
+                self.resps.append(HTTPResponseBuilder(status: .found, headers: headers))
+                return
             case "/percent%20encoded":
                 if req.method != .GET {
                     self.resps.append(HTTPResponseBuilder(status: .methodNotAllowed))


### PR DESCRIPTION
Motivation:

An arbitrary HTTP(S) server should not be able to trigger redirects, and thus activity, to a local socket-path based server, though the opposite may be a valid scenario. Currently, requests in either direction are allowed since the checks don't actually check the destination scheme.

Modifications:

- Added a method to HTTPBin to redirect to the specified target.
- Added failing tests that perform redirects from a regular server to a socket-based server and vice versa.
- Refactored `hostSchemes`/`unixSchemes` to `hostRestrictedSchemes`/`allSupportedSchemes`, which better describes what they do.
- Refactored `Request.supports()` to `Request.supportsRedirects(to:)` since it is only used by Redirects now.
- Check the destination URL's scheme rather than the current URL's scheme when validating a redirect.

Result:

Closes #230