### PR TITLE
Updated swift-nio to 2.18.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.16.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),


### PR DESCRIPTION
Not sure if this is worth opening a PR for, since any new checkouts will never see this issue, and it's only necessary due to tests, so please feel free to close this if it's not necessary.

Motivation:

Due to using new ByteBuffer initializers from https://github.com/apple/swift-nio/releases/tag/2.18.0 in some tests (specifically, `ByteBuffer(string: ...)`), the project will no longer compile if an older version of swift-nio is checked out.

Modifications:

Updated swift-nio from 2.16.0 to 2.18.0.

Result:

SPM should now grab the latest version of swift-nio if this version of async-http-client is used.