### PR TITLE
fix missing connect timeout and make tests safer

### DIFF
--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -79,7 +79,7 @@ extension NIOClientTCPBootstrap {
         requiresTLS: Bool,
         configuration: HTTPClient.Configuration
     ) throws -> NIOClientTCPBootstrap {
-        let bootstrap: NIOClientTCPBootstrap
+        var bootstrap: NIOClientTCPBootstrap
         #if canImport(Network)
             // if eventLoop is compatible with NIOTransportServices create a NIOTSConnectionBootstrap
             if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *), let tsBootstrap = NIOTSConnectionBootstrap(validatingGroup: eventLoop) {
@@ -106,10 +106,15 @@ extension NIOClientTCPBootstrap {
             }
         #endif
 
+        if let timeout = configuration.timeout.connect {
+            bootstrap = bootstrap.connectTimeout(timeout)
+        }
+
         // don't enable TLS if we have a proxy, this will be enabled later on
         if requiresTLS, configuration.proxy == nil {
             return bootstrap.enableTLS()
         }
+
         return bootstrap
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -89,7 +89,6 @@ class HTTPClientNIOTSTests: XCTestCase {
             switch error {
             case ChannelError.connectTimeout(let timeout):
                 XCTAssertLessThanOrEqual(timeout, .milliseconds(150))
-                break
             default:
                 XCTFail("Unexpected error: \(error)")
             }
@@ -109,9 +108,9 @@ class HTTPClientNIOTSTests: XCTestCase {
                 XCTAssertNoThrow(try httpBin.shutdown())
             }
 
-        XCTAssertThrowsError(try httpClient.get(url: "https://localhost:\(httpBin.port)/get").wait()) { error in
-            XCTAssertEqual((error as? HTTPClient.NWTLSError)?.status, errSSLHandshakeFail)
-        }
+            XCTAssertThrowsError(try httpClient.get(url: "https://localhost:\(httpBin.port)/get").wait()) { error in
+                XCTAssertEqual((error as? HTTPClient.NWTLSError)?.status, errSSLHandshakeFail)
+            }
         #endif
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -86,12 +86,7 @@ class HTTPClientNIOTSTests: XCTestCase {
         XCTAssertNoThrow(try httpBin.shutdown())
 
         XCTAssertThrowsError(try httpClient.get(url: "https://localhost:\(port)/get").wait()) { error in
-            switch error {
-            case ChannelError.connectTimeout(let timeout):
-                XCTAssertLessThanOrEqual(timeout, .milliseconds(150))
-            default:
-                XCTFail("Unexpected error: \(error)")
-            }
+            XCTAssertEqual(.connectTimeout(.milliseconds(100)), error as? ChannelError)
         }
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -46,6 +46,7 @@ extension HTTPClientTests {
             ("testStreaming", testStreaming),
             ("testRemoteClose", testRemoteClose),
             ("testReadTimeout", testReadTimeout),
+            ("testConnectTimeout", testConnectTimeout),
             ("testDeadline", testDeadline),
             ("testCancel", testCancel),
             ("testStressCancel", testStressCancel),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -432,12 +432,7 @@ class HTTPClientTests: XCTestCase {
 
         // This must throw as 198.51.100.254 is reserved for documentation only
         XCTAssertThrowsError(try httpClient.get(url: "http://198.51.100.254:65535/get").wait()) { error in
-            switch error {
-            case ChannelError.connectTimeout(let timeout):
-                XCTAssertLessThanOrEqual(timeout, .milliseconds(150))
-            default:
-                XCTFail("Unexpected error: \(error)")
-            }
+            XCTAssertEqual(.connectTimeout(.milliseconds(100)), error as? ChannelError)
         }
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1680,7 +1680,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testAvoidLeakingTLSHandshakeCompletionPromise() {
-        let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
+        let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup), configuration: .init(timeout: .init(connect: .milliseconds(100))))
         let localHTTPBin = HTTPBin()
         let port = localHTTPBin.port
         XCTAssertNoThrow(try localHTTPBin.shutdown())

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -425,7 +425,7 @@ class HTTPClientTests: XCTestCase {
     func testConnectTimeout() throws {
         let httpBin = HTTPBin(ssl: false)
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(timeout: .init(connect: .milliseconds(100), read: .milliseconds(150))))
+                                    configuration: .init(timeout: .init(connect: .milliseconds(100), read: .milliseconds(150))))
 
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown())
@@ -438,7 +438,6 @@ class HTTPClientTests: XCTestCase {
             switch error {
             case ChannelError.connectTimeout(let timeout):
                 XCTAssertLessThanOrEqual(timeout, .milliseconds(150))
-                break
             default:
                 XCTFail("Unexpected error: \(error)")
             }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -423,7 +423,6 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testConnectTimeout() throws {
-        let httpBin = HTTPBin(ssl: false)
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                     configuration: .init(timeout: .init(connect: .milliseconds(100), read: .milliseconds(150))))
 
@@ -431,10 +430,8 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
 
-        let port = httpBin.port
-        XCTAssertNoThrow(try httpBin.shutdown())
-
-        XCTAssertThrowsError(try httpClient.get(url: "https://localhost:\(port)/get").wait()) { error in
+        // This must throw as 198.51.100.254 is reserved for documentation only
+        XCTAssertThrowsError(try httpClient.get(url: "http://198.51.100.254:65535/get").wait()) { error in
             switch error {
             case ChannelError.connectTimeout(let timeout):
                 XCTAssertLessThanOrEqual(timeout, .milliseconds(150))


### PR DESCRIPTION
Fix missing connect timeout and make some tests faster and safer.

Motivation:
1. During pool implementation/refactoring we lost connection timeout, this PR fixes that
2. `testConnectionFailError` is slow, 10 seconds, due to not having a timeout set
3. `testConnectionFailError` and `testTLSVersionError` use dangerous `do-try-XCFail-catch` pattern

Modifications:
1. Set connection timeout if specified
2. Set connect timeout to 150 ms to make `testTLSVersionError` faster
3. Use `XCTAssertThrowsError` in `testConnectionFailError` and `testTLSVersionError`
4. Add general connection timeout test, since `testConnectionFailError` is NIOTS-specific.

Result:
Fixes an issue where connection timeout configuration was not respected, hopefully makes tests more robust