### PR TITLE
All internal connection flow should be executed when shutting down

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -423,6 +423,8 @@ class HTTP1ConnectionProvider {
             switch action {
             case .closeAnd:
                 // This happens when client was shut down during connect
+                logger.trace("connection cancelled due to client shutdown",
+                             metadata: ["ahc-connection": "\(channel)"])
                 connection.channel.close(promise: nil)
                 waiter.promise.fail(HTTPClientError.cancelled)
             default:

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolTests+XCTest.swift
@@ -62,6 +62,10 @@ extension ConnectionPoolTests {
             ("testConnectionRemoteCloseRelease", testConnectionRemoteCloseRelease),
             ("testConnectionTimeoutRelease", testConnectionTimeoutRelease),
             ("testAcquireAvailableBecomesUnavailable", testAcquireAvailableBecomesUnavailable),
+            ("testShutdownOnPendingAndSuccess", testShutdownOnPendingAndSuccess),
+            ("testShutdownOnPendingAndError", testShutdownOnPendingAndError),
+            ("testShutdownTimeout", testShutdownTimeout),
+            ("testShutdownRemoteClosed", testShutdownRemoteClosed),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
@@ -1403,12 +1403,9 @@ class ConnectionPoolTests: XCTestCase {
         let waiter = HTTP1ConnectionProvider.Waiter(promise: connectionPromise, setupComplete: setupPromise.futureResult, preference: .indifferent)
         var action = state.acquire(waiter: waiter)
 
-        switch action {
-        case .create:
-            // expected
-            break
-        default:
-            XCTFail("Unexpected action: \(action)")
+        guard case .create = action else {
+            XCTFail("unexpected action \(action)")
+            return
         }
 
         let snapshot = state.testsOnly_getInternalState()
@@ -1426,17 +1423,9 @@ class ConnectionPoolTests: XCTestCase {
         let connection = Connection(channel: EmbeddedChannel(), provider: self.http1ConnectionProvider)
 
         action = state.offer(connection: connection)
-        switch action {
-        case .closeAnd(_, let next):
-            switch next {
-            case .closeProvider:
-                // expected
-                break
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        default:
-            XCTFail("Unexpected action: \(action)")
+        guard case .closeAnd(_, .closeProvider) = action else {
+            XCTFail("unexpected action \(action)")
+            return
         }
 
         connectionPromise.fail(TempError())
@@ -1453,12 +1442,9 @@ class ConnectionPoolTests: XCTestCase {
         let waiter = HTTP1ConnectionProvider.Waiter(promise: connectionPromise, setupComplete: setupPromise.futureResult, preference: .indifferent)
         var action = state.acquire(waiter: waiter)
 
-        switch action {
-        case .create:
-            // expected
-            break
-        default:
-            XCTFail("Unexpected action: \(action)")
+        guard case .create = action else {
+            XCTFail("unexpected action \(action)")
+            return
         }
 
         let snapshot = state.testsOnly_getInternalState()
@@ -1474,12 +1460,9 @@ class ConnectionPoolTests: XCTestCase {
         }
 
         action = state.connectFailed()
-        switch action {
-        case .closeProvider:
-            // expected
-            break
-        default:
-            XCTFail("Unexpected action: \(action)")
+        guard case .closeProvider = action else {
+            XCTFail("unexpected action \(action)")
+            return
         }
 
         connectionPromise.fail(TempError())

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolTests.swift
@@ -1391,6 +1391,168 @@ class ConnectionPoolTests: XCTestCase {
         }
     }
 
+    // MARK: - Shutdown tests
+
+    func testShutdownOnPendingAndSuccess() {
+        var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
+
+        XCTAssertTrue(state.enqueue())
+
+        let connectionPromise = self.eventLoop.makePromise(of: Connection.self)
+        let setupPromise = self.eventLoop.makePromise(of: Void.self)
+        let waiter = HTTP1ConnectionProvider.Waiter(promise: connectionPromise, setupComplete: setupPromise.futureResult, preference: .indifferent)
+        var action = state.acquire(waiter: waiter)
+
+        switch action {
+        case .create:
+            // expected
+            break
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+
+        let snapshot = state.testsOnly_getInternalState()
+        XCTAssertEqual(snapshot.openedConnectionsCount, 1)
+
+        if let (waiters, available, leased, clean) = state.close() {
+            XCTAssertTrue(waiters.isEmpty)
+            XCTAssertTrue(available.isEmpty)
+            XCTAssertTrue(leased.isEmpty)
+            XCTAssertFalse(clean)
+        } else {
+            XCTFail("Expecting snapshot")
+        }
+
+        let connection = Connection(channel: EmbeddedChannel(), provider: self.http1ConnectionProvider)
+
+        action = state.offer(connection: connection)
+        switch action {
+        case .closeAnd(_, let next):
+            switch next {
+            case .closeProvider:
+                // expected
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+
+        connectionPromise.fail(TempError())
+        setupPromise.succeed(())
+    }
+
+    func testShutdownOnPendingAndError() {
+        var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
+
+        XCTAssertTrue(state.enqueue())
+
+        let connectionPromise = self.eventLoop.makePromise(of: Connection.self)
+        let setupPromise = self.eventLoop.makePromise(of: Void.self)
+        let waiter = HTTP1ConnectionProvider.Waiter(promise: connectionPromise, setupComplete: setupPromise.futureResult, preference: .indifferent)
+        var action = state.acquire(waiter: waiter)
+
+        switch action {
+        case .create:
+            // expected
+            break
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+
+        let snapshot = state.testsOnly_getInternalState()
+        XCTAssertEqual(snapshot.openedConnectionsCount, 1)
+
+        if let (waiters, available, leased, clean) = state.close() {
+            XCTAssertTrue(waiters.isEmpty)
+            XCTAssertTrue(available.isEmpty)
+            XCTAssertTrue(leased.isEmpty)
+            XCTAssertFalse(clean)
+        } else {
+            XCTFail("Expecting snapshot")
+        }
+
+        action = state.connectFailed()
+        switch action {
+        case .closeProvider:
+            // expected
+            break
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+
+        connectionPromise.fail(TempError())
+        setupPromise.succeed(())
+    }
+
+    func testShutdownTimeout() {
+        var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
+
+        var snapshot = self.http1ConnectionProvider.state.testsOnly_getInternalState()
+
+        let connection = Connection(channel: EmbeddedChannel(), provider: self.http1ConnectionProvider)
+        snapshot.availableConnections.append(connection)
+        snapshot.openedConnectionsCount = 1
+
+        state.testsOnly_setInternalState(snapshot)
+
+        if let (waiters, available, leased, clean) = state.close() {
+            XCTAssertTrue(waiters.isEmpty)
+            XCTAssertFalse(available.isEmpty)
+            XCTAssertTrue(leased.isEmpty)
+            XCTAssertTrue(clean)
+        } else {
+            XCTFail("Expecting snapshot")
+        }
+
+        let action = state.timeout(connection: connection)
+        switch action {
+        case .closeAnd(_, let next):
+            switch next {
+            case .closeProvider:
+                // expected
+                break
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+    }
+
+    func testShutdownRemoteClosed() {
+        var state = HTTP1ConnectionProvider.ConnectionsState(eventLoop: self.eventLoop)
+
+        var snapshot = self.http1ConnectionProvider.state.testsOnly_getInternalState()
+
+        let connection = Connection(channel: EmbeddedChannel(), provider: self.http1ConnectionProvider)
+        snapshot.availableConnections.append(connection)
+        snapshot.openedConnectionsCount = 1
+
+        state.testsOnly_setInternalState(snapshot)
+
+        if let (waiters, available, leased, clean) = state.close() {
+            XCTAssertTrue(waiters.isEmpty)
+            XCTAssertFalse(available.isEmpty)
+            XCTAssertTrue(leased.isEmpty)
+            XCTAssertTrue(clean)
+        } else {
+            XCTFail("Expecting snapshot")
+        }
+
+        let action = state.remoteClosed(connection: connection)
+        switch action {
+        case .closeProvider:
+            // expected
+            break
+        default:
+            XCTFail("Unexpected action: \(action)")
+        }
+    }
+
+    // MARK: - Helpers
+
     override func setUp() {
         XCTAssertNil(self.eventLoop)
         XCTAssertNil(self.http1ConnectionProvider)


### PR DESCRIPTION
All internal connection flow should be executed when shutting down.

Motivation:
When we shut the client down, we expect the provider to finish all its tasks, if there are some, and then delete itself and succeed the close promise. Currently, if connection is created unsuccessfully, or available connection is closed/times out before we close it as part of shutdown, those connection will not trigger correct flow.

Modifications:
1. `connectFailed` now triggers correct flow when client is `.closed`
2. `timeout` now triggers correct flow when client is `.closed`
3. `removeClose` now triggers correct flow when client is `.closed`
4. `offer` is refactored
5. Added 4 new tests, that specifically test described scenarios

Result:
Closes #263 
Closes #260 