### PR TITLE
fix flaky testContentLengthTooLongFails test

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2319,7 +2319,7 @@ class HTTPClientTests: XCTestCase {
     }
 
     func testContentLengthTooLongFails() throws {
-        let url = self.defaultHTTPBinURLPrefix + "/post"
+        let url = self.defaultHTTPBinURLPrefix + "post"
         XCTAssertThrowsError(
             try self.defaultClient.execute(request:
                 Request(url: url,
@@ -2348,7 +2348,7 @@ class HTTPClientTests: XCTestCase {
 
     // currently gets stuck because of #250 the server just never replies
     func testContentLengthTooShortFails() throws {
-        let url = self.defaultHTTPBinURLPrefix + "/post"
+        let url = self.defaultHTTPBinURLPrefix + "post"
         let tooLong = "XBAD BAD BAD NOT HTTP/1.1\r\n\r\n"
         XCTAssertThrowsError(
             try self.defaultClient.execute(request:


### PR DESCRIPTION
Fixes flaky test

Motivation:
Test was actually getting `404` and was closing connection too early.

Modifications:
Fix request path.

Result:
Closes #265 