### PR TITLE
Added default value for queue in HTTPClient.shutdown(queue:callback:)

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -164,7 +164,7 @@ public class HTTPClient {
     /// callback instead of an EventLoopFuture. The reason for that is that NIO's EventLoopFutures will call back on an event loop.
     /// The virtue of this function is to shut the event loop down. To work around that we call back on a DispatchQueue
     /// instead.
-    public func shutdown(queue: DispatchQueue, _ callback: @escaping (Error?) -> Void) {
+    public func shutdown(queue: DispatchQueue = .global(), _ callback: @escaping (Error?) -> Void) {
         self.shutdown(requiresCleanClose: false, queue: queue, callback)
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -103,6 +103,7 @@ extension HTTPClientTests {
             ("testRacePoolIdleConnectionsAndGet", testRacePoolIdleConnectionsAndGet),
             ("testAvoidLeakingTLSHandshakeCompletionPromise", testAvoidLeakingTLSHandshakeCompletionPromise),
             ("testAsyncShutdown", testAsyncShutdown),
+            ("testAsyncShutdownDefaultQueue", testAsyncShutdownDefaultQueue),
             ("testValidationErrorsAreSurfaced", testValidationErrorsAreSurfaced),
             ("testUploadsReallyStream", testUploadsReallyStream),
             ("testUploadStreamingCallinToleratedFromOtsideEL", testUploadStreamingCallinToleratedFromOtsideEL),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1799,6 +1799,18 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNoThrow(try promise.futureResult.wait())
     }
 
+    func testAsyncShutdownDefaultQueue() throws {
+        let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
+        let promise = self.clientGroup.next().makePromise(of: Void.self)
+        self.clientGroup.next().execute {
+            localClient.shutdown { error in
+                XCTAssertNil(error)
+                promise.succeed(())
+            }
+        }
+        XCTAssertNoThrow(try promise.futureResult.wait())
+    }
+
     func testValidationErrorsAreSurfaced() throws {
         let request = try HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "get", method: .TRACE, body: .stream { _ in
             self.defaultClient.eventLoopGroup.next().makeSucceededFuture(())


### PR DESCRIPTION
Default it to .global()