### PR TITLE
Kill build warnings.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.18.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.7.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -212,7 +212,7 @@ internal final class HTTPBin {
         let configuration = TLSConfiguration.forServer(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
                                                        privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
         let context = try! NIOSSLContext(configuration: configuration)
-        return channel.pipeline.addHandler(try! NIOSSLServerHandler(context: context), position: .first)
+        return channel.pipeline.addHandler(NIOSSLServerHandler(context: context), position: .first)
     }
 
     init(ssl: Bool = false,
@@ -655,7 +655,7 @@ internal class HttpBinForSSLUncleanShutdown {
                     let configuration = TLSConfiguration.forServer(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
                                                                    privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
                     let context = try! NIOSSLContext(configuration: configuration)
-                    return channel.pipeline.addHandler(try! NIOSSLServerHandler(context: context), name: "NIOSSLServerHandler", position: .first).flatMap {
+                    return channel.pipeline.addHandler(NIOSSLServerHandler(context: context), name: "NIOSSLServerHandler", position: .first).flatMap {
                         channel.pipeline.addHandler(HttpBinForSSLUncleanShutdownHandler(channelPromise: channelPromise))
                     }
                 }


### PR DESCRIPTION
Motivation:

Build warnings fail our builds.

Modifications:

- Update minimum NIOSSL version
- Remove the use of the now-unnecessary `try` statement.

Result:

No warnings!