### PR TITLE
rename connection pool configuration

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -353,7 +353,7 @@ class HTTP1ConnectionProvider {
         case .park(let connection):
             logger.trace("parking connection",
                          metadata: ["ahc-connection": "\(connection)"])
-            connection.setIdleTimeout(timeout: self.configuration.poolConfiguration.idleTimeout,
+            connection.setIdleTimeout(timeout: self.configuration.connectionPool.idleTimeout,
                                       logger: self.backgroundActivityLogger)
         case .closeProvider:
             logger.debug("closing provider",
@@ -365,7 +365,7 @@ class HTTP1ConnectionProvider {
             logger.trace("parking connection & doing further action",
                          metadata: ["ahc-connection": "\(connection)",
                                     "ahc-action": "\(action)"])
-            connection.setIdleTimeout(timeout: self.configuration.poolConfiguration.idleTimeout,
+            connection.setIdleTimeout(timeout: self.configuration.connectionPool.idleTimeout,
                                       logger: self.backgroundActivityLogger)
             self.execute(action, logger: logger)
         case .closeAnd(let connection, let action):

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -642,7 +642,7 @@ public class HTTPClient {
         /// Default client timeout, defaults to no timeouts.
         public var timeout: Timeout
         /// Connection pool configuration.
-        public var poolConfiguration: PoolConfiguration
+        public var connectionPool: ConnectionPool
         /// Upstream proxy, defaults to no proxy.
         public var proxy: Proxy?
         /// Enables automatic body decompression. Supported algorithms are gzip and deflate.
@@ -653,14 +653,14 @@ public class HTTPClient {
         public init(tlsConfiguration: TLSConfiguration? = nil,
                     redirectConfiguration: RedirectConfiguration? = nil,
                     timeout: Timeout = Timeout(),
-                    poolConfiguration: PoolConfiguration = PoolConfiguration(),
+                    connectionPool: ConnectionPool = ConnectionPool(),
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled) {
             self.tlsConfiguration = tlsConfiguration
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
             self.timeout = timeout
-            self.poolConfiguration = poolConfiguration
+            self.connectionPool = connectionPool
             self.proxy = proxy
             self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
             self.decompression = decompression
@@ -676,7 +676,7 @@ public class HTTPClient {
                 tlsConfiguration: tlsConfiguration,
                 redirectConfiguration: redirectConfiguration,
                 timeout: timeout,
-                poolConfiguration: PoolConfiguration(),
+                connectionPool: ConnectionPool(),
                 proxy: proxy,
                 ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                 decompression: decompression
@@ -693,7 +693,7 @@ public class HTTPClient {
             self.init(tlsConfiguration: TLSConfiguration.forClient(certificateVerification: certificateVerification),
                       redirectConfiguration: redirectConfiguration,
                       timeout: timeout,
-                      poolConfiguration: PoolConfiguration(),
+                      connectionPool: ConnectionPool(),
                       proxy: proxy,
                       ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                       decompression: decompression)
@@ -702,7 +702,7 @@ public class HTTPClient {
         public init(certificateVerification: CertificateVerification,
                     redirectConfiguration: RedirectConfiguration? = nil,
                     timeout: Timeout = Timeout(),
-                    poolConfiguration: TimeAmount = .seconds(60),
+                    connectionPool: TimeAmount = .seconds(60),
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled,
@@ -710,7 +710,7 @@ public class HTTPClient {
             self.init(tlsConfiguration: TLSConfiguration.forClient(certificateVerification: certificateVerification),
                       redirectConfiguration: redirectConfiguration,
                       timeout: timeout,
-                      poolConfiguration: PoolConfiguration(),
+                      connectionPool: ConnectionPool(),
                       proxy: proxy,
                       ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                       decompression: decompression)
@@ -862,7 +862,7 @@ extension HTTPClient.Configuration {
     }
 
     /// Connection pool configuration.
-    public struct PoolConfiguration: Hashable {
+    public struct ConnectionPool: Hashable {
         // Specifies amount of time connections are kept idle in the pool.
         public var idleTimeout: TimeAmount
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1742,7 +1742,7 @@ class HTTPClientTests: XCTestCase {
 
     func testPoolClosesIdleConnections() {
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(poolConfiguration: .init(idleTimeout: .milliseconds(100))))
+                                     configuration: .init(connectionPool: .init(idleTimeout: .milliseconds(100))))
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
         }
@@ -1753,7 +1753,7 @@ class HTTPClientTests: XCTestCase {
 
     func testRacePoolIdleConnectionsAndGet() {
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(poolConfiguration: .init(idleTimeout: .milliseconds(10))))
+                                     configuration: .init(connectionPool: .init(idleTimeout: .milliseconds(10))))
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
         }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools 
 
 # ruby and jazzy for docs generation
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
+# jazzy no longer works on xenial as ruby is too old.
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy --no-ri --no-rdoc ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools


### PR DESCRIPTION
Rename pool configuration type and property to `ConnectionPool`

Motivation:
`HTTPConfiguration.poolConfiguration` is redundant and does not make clear what pool are we talking about.

Modifications:
Rename property and type to `ConnectionPool`

Result:
Closes #286