### PR TITLE
Fix open connection counting, make testRaceNewRequestsVsShutdown pass

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionsState.swift
+++ b/Sources/AsyncHTTPClient/ConnectionsState.swift
@@ -196,8 +196,9 @@ extension HTTP1ConnectionProvider {
                     return self.processNextWaiter()
                 }
             case .closed:
-                self.openedConnectionsCount -= 1
-                self.leasedConnections.remove(ConnectionKey(connection))
+                if nil != self.leasedConnections.remove(ConnectionKey(connection)) {
+                    self.openedConnectionsCount -= 1
+                }
 
                 return self.processNextWaiter()
             }


### PR DESCRIPTION
AsyncHTTPClient 1.2.0 commit hash: c9a9bf061d713c91ee9974fa8a6afe413acfd0e9

Context:

[`testRaceNewRequestsVsShutdown`](https://github.com/swift-server/async-http-client/blob/ffcd1e1a1cb2072dd9d0bdd51f794bf37afc2cb8/Tests/AsyncHTTPClientTests/HTTPClientTests.swift#L1377) is  failing in [`ConnectionsState.assertInvariants()`](https://github.com/swift-server/async-http-client/blob/ffcd1e1a1cb2072dd9d0bdd51f794bf37afc2cb8/Sources/AsyncHTTPClient/ConnectionsState.swift#L86) because `openedConnectionsCount` is negative.

 (Are tests run in `release` configuration?).

```swift
        func assertInvariants() {
            assert(self.waiters.isEmpty)
            assert(self.availableConnections.isEmpty)
            assert(self.leasedConnections.isEmpty)
            assert(self.openedConnectionsCount == 0)
            assert(self.pending == 0)
        }
```

Steps to reproduce:

```
swift test
```

**swift --version**

```
Apple Swift version 5.2.4 (swiftlang-1103.0.32.9 clang-1103.0.32.53)
Target: x86_64-apple-darwin19.6.0
```

**uname -a**

``Darwin xxx 19.6.0 Darwin Kernel Version 19.6.0: Sun Jul  5 00:43:10 PDT 2020; root:xnu-6153.141.1~9/RELEASE_X86_64 x86_6
```