### PR TITLE
Adjust gen_docs script Default branch is `main`

### DIFF
--- a/scripts/generate_docs.sh
+++ b/scripts/generate_docs.sh
@@ -17,7 +17,7 @@ set -e
 
 my_path="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 root_path="$my_path/.."
-version=$(git describe --abbrev=0 --tags || echo "master")
+version=$(git describe --abbrev=0 --tags || echo "main")
 modules=(AsyncHTTPClient)
 
 if [[ "$(uname -s)" == "Linux" ]]; then


### PR DESCRIPTION
Spotted a last instance of the word "master" in the scripts.

This completes the move to main as the main branch name