### PR TITLE
Fixes propagation of errors during TLS handshake

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -935,16 +935,9 @@ class TLSEventsHandler: ChannelInboundHandler, RemovableChannelHandler {
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-        if let sslError = error as? NIOSSLError {
-            switch sslError {
-            case .handshakeFailed:
-                self.completionPromise?.fail(error)
-                self.completionPromise = nil
-                context.pipeline.removeHandler(self, promise: nil)
-            default:
-                break
-            }
-        }
+        self.completionPromise?.fail(error)
+        self.completionPromise = nil
+        context.pipeline.removeHandler(self, promise: nil)
         context.fireErrorCaught(error)
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -125,6 +125,7 @@ extension HTTPClientTests {
             ("testBodyUploadAfterEndFails", testBodyUploadAfterEndFails),
             ("testNoBytesSentOverBodyLimit", testNoBytesSentOverBodyLimit),
             ("testDoubleError", testDoubleError),
+            ("testSSLHandshakeErrorPropagation", testSSLHandshakeErrorPropagation),
         ]
     }
 }


### PR DESCRIPTION
Motivation:
Right now we only handle one type of SSL error: `.handshakeFailed`,
but in reality a multitude of errors can happen, for example, remote
party might just close connection that will in turn raise
`.uncleanShutdown` error, that will be dropped on the floor and
users will only get non-descriptive `NoResult` error.

Modifications:
Handle all types of SSL errors during handshake instead of just one.
Adds a test.

Result:
Closes #313