### PR TITLE
Fixes default timeout documentation comment

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -639,7 +639,7 @@ public class HTTPClient {
         ///  - `307: Temporary Redirect`
         ///  - `308: Permanent Redirect`
         public var redirectConfiguration: RedirectConfiguration
-        /// Default client timeout, defaults to no timeouts.
+        /// Default client timeout, defaults to no `read` timeout and 10 seconds `connect` timeout.
         public var timeout: Timeout
         /// Connection pool configuration.
         public var connectionPool: ConnectionPool


### PR DESCRIPTION
Motivation:
Right now documentation states that timrout defaults to no timeout, this
is no actually true, if timeout is not set NIO bootstrap defaults to 10
seconds connect timeout.

Modifications:
Updates documentation comment.

Result:
Closes #118