### PR TITLE
issue #318: Address warning reported by thread safety analyzer 

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -110,7 +110,9 @@ final class ConnectionPool {
     }
 
     var count: Int {
-        return self.providers.count
+        return self.lock.withLock {
+            return self.providers.count
+        }
     }
 
     /// Used by the `ConnectionPool` to index its `HTTP1ConnectionProvider`s


### PR DESCRIPTION
Motivation:

Thread safety analyzer reports warning about observable state
leaving lock guarded code blocks. This PR address the warnings.

Analysis of the warning does not prove that we have a real bug and all the
warnings are considered as potential bugs.

Analyzer used is:
`docker run --rm -v $(pwd):/src -w /src swift:5.3.1 swift test -c
release --sanitize=thread --enable-test-discovery`

Modifications:

* accessor to count of connections in connection pool is guarded by lock
* forced materialization of a potentially lazy collection into an array before returning
  the collection from lock guarded code block

Result:

Most of thread safety warnings are addressed without modification of observable
code behaviour.