### PR TITLE
Add defensive connection closure.

### DIFF
--- a/Sources/AsyncHTTPClient/Connection.swift
+++ b/Sources/AsyncHTTPClient/Connection.swift
@@ -72,6 +72,10 @@ extension Connection {
     func close() -> EventLoopFuture<Void> {
         return self.channel.close()
     }
+
+    func close(promise: EventLoopPromise<Void>?) {
+        return self.channel.close(promise: promise)
+    }
 }
 
 /// Methods of Connection which are used in ConnectionsState extracted as protocol

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -352,6 +352,14 @@ class HTTP1ConnectionProvider {
             self.state.release(connection: connection, closing: closing)
         }
 
+        // We close defensively here: we may have failed to actually close on other codepaths,
+        // or we may be expecting the server to close. In either case, we want our FD back, so
+        // we close now to cover our backs. We don't care about the result: if the channel is
+        // _already_ closed, that's fine by us.
+        if closing {
+            connection.close(promise: nil)
+        }
+
         switch action {
         case .none:
             break

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -812,7 +812,7 @@ class HTTPClientInternalTests: XCTestCase {
 
         XCTAssert(connection !== connection2)
         try! connection2.channel.eventLoop.submit {
-            connection2.release(closing: true, logger: HTTPClient.loggingDisabled)
+            connection2.release(closing: false, logger: HTTPClient.loggingDisabled)
         }.wait()
         XCTAssertTrue(connection2.channel.isActive)
     }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -126,6 +126,7 @@ extension HTTPClientTests {
             ("testNoBytesSentOverBodyLimit", testNoBytesSentOverBodyLimit),
             ("testDoubleError", testDoubleError),
             ("testSSLHandshakeErrorPropagation", testSSLHandshakeErrorPropagation),
+            ("testWeCloseConnectionsWhenConnectionCloseSetByServer", testWeCloseConnectionsWhenConnectionCloseSetByServer),
         ]
     }
 }


### PR DESCRIPTION
Motivation:

Currently when either we or the server send Connection: close, we
correctly do not return that connection to the pool. However, we rely on
the server actually performing the connection closure: we never call
close() ourselves. This is unnecessarily optimistic: a server may
absolutely fail to close this connection. To protect our own file
descriptors, we should make sure that any connection we do not return
the pool is closed.

Modifications:

If we think a connection is closing when we release it, we now call
close() on it defensively.

Result:

We no longer leak connections when the server fails to close them.

Fixes #324.