### PR TITLE
Update Readme to account for Package.swift format

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add the following entry in your <code>Package.swift</code> to start using <code>
 ```
 and  `AsyncHTTPClient` dependency to your target:
 ```swift
-.target(name: "MyApp", dependencies: ["AsyncHTTPClient"]),
+.target(name: "MyApp", dependencies: [.product(name: "AsyncHTTPClient", package: "async-http-client")]),
 ```
 
 #### Request-Response API


### PR DESCRIPTION
Adding the product dependency to the target by name only produces an error in Xcode 12.4. Instead, the product dependency should be given as a `.product`. 

This PR updates the README with the new format, so that new user's won't stumble over this.