### PR TITLE
Generate trust roots SecCertificate for Transport Services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.build
+.git

--- a/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
@@ -60,7 +60,7 @@
         ///
         /// - Parameter queue: Dispatch queue to run `sec_protocol_options_set_verify_block` on.
         /// - Returns: Equivalent NWProtocolTLS Options
-        func getNWProtocolTLSOptions() -> NWProtocolTLS.Options {
+        func getNWProtocolTLSOptions() throws -> NWProtocolTLS.Options {
             let options = NWProtocolTLS.Options()
 
             let useMTELGExplainer = """
@@ -125,12 +125,8 @@
             var secTrustRoots: [SecCertificate]?
             switch trustRoots {
             case .some(.certificates(let certificates)):
-                do {
-                    secTrustRoots = try certificates.compactMap { certificate in
-                        try SecCertificateCreateWithData(nil, Data(certificate.toDERBytes()) as CFData)
-                    }
-                } catch {
-                    // failed to load
+                secTrustRoots = try certificates.compactMap { certificate in
+                    try SecCertificateCreateWithData(nil, Data(certificate.toDERBytes()) as CFData)
                 }
             case .some(.file):
                 preconditionFailure("TLSConfiguration.trustRoots.file is not supported")

--- a/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
@@ -128,7 +128,7 @@
 
             // the certificate chain
             if self.certificateChain.count > 0 {
-                preconditionFailure("TLSConfiguration.certificateChain is not supported")
+                preconditionFailure("TLSConfiguration.certificateChain is not supported. \(useMTELGExplainer)")
             }
 
             // private key
@@ -173,6 +173,7 @@
                             SecTrustSetAnchorCertificates(trust, trustRootCertificates as CFArray)
                         }
                         if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+                            dispatchPrecondition(condition: .onQueue(Self.tlsDispatchQueue))
                             SecTrustEvaluateAsyncWithError(trust, Self.tlsDispatchQueue) { _, result, error in
                                 if let error = error {
                                     print("Trust failed: \(error.localizedDescription)")

--- a/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
@@ -128,8 +128,11 @@
                 secTrustRoots = try certificates.compactMap { certificate in
                     try SecCertificateCreateWithData(nil, Data(certificate.toDERBytes()) as CFData)
                 }
-            case .some(.file):
-                preconditionFailure("TLSConfiguration.trustRoots.file is not supported")
+            case .some(.file(let file)):
+                let certificates = try NIOSSLCertificate.fromPEMFile(file)
+                secTrustRoots = try certificates.compactMap { certificate in
+                    try SecCertificateCreateWithData(nil, Data(certificate.toDERBytes()) as CFData)
+                }
 
             case .some(.default), .none:
                 break

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -180,9 +180,11 @@ extension NIOClientTCPBootstrap {
             // if eventLoop is compatible with NIOTransportServices create a NIOTSConnectionBootstrap
             if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *), let tsBootstrap = NIOTSConnectionBootstrap(validatingGroup: eventLoop) {
                 // create NIOClientTCPBootstrap with NIOTS TLS provider
-                let parameters = tlsConfiguration.getNWProtocolTLSOptions()
-                let tlsProvider = NIOTSClientTLSProvider(tlsOptions: parameters)
-                return eventLoop.makeSucceededFuture(NIOClientTCPBootstrap(tsBootstrap, tls: tlsProvider))
+                return tlsConfiguration.getNWProtocolTLSOptions(on: eventLoop)
+                    .map { parameters in
+                        let tlsProvider = NIOTSClientTLSProvider(tlsOptions: parameters)
+                        return NIOClientTCPBootstrap(tsBootstrap, tls: tlsProvider)
+                    }
             }
         #endif
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests+XCTest.swift
@@ -29,6 +29,7 @@ extension HTTPClientNIOTSTests {
             ("testTLSFailError", testTLSFailError),
             ("testConnectionFailError", testConnectionFailError),
             ("testTLSVersionError", testTLSVersionError),
+            ("testTrustRootCertificateLoadFail", testTrustRootCertificateLoadFail),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -111,4 +111,19 @@ class HTTPClientNIOTSTests: XCTestCase {
             }
         #endif
     }
+    
+    func testTrustRootCertificateLoadFail() {
+        guard isTestingNIOTS() else { return }
+        #if canImport(Network)
+        let tlsConfig = TLSConfiguration.forClient(trustRoots: .file("not/a/certificate"))
+        XCTAssertThrowsError(try tlsConfig.getNWProtocolTLSOptions()) { error in
+            switch error {
+            case let error as NIOSSL.NIOSSLError where error == .failedToLoadCertificate:
+                break
+            default:
+                XCTFail("\(error)")
+            }
+        }
+        #endif
+    }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -111,19 +111,19 @@ class HTTPClientNIOTSTests: XCTestCase {
             }
         #endif
     }
-    
+
     func testTrustRootCertificateLoadFail() {
         guard isTestingNIOTS() else { return }
         #if canImport(Network)
-        let tlsConfig = TLSConfiguration.forClient(trustRoots: .file("not/a/certificate"))
-        XCTAssertThrowsError(try tlsConfig.getNWProtocolTLSOptions()) { error in
-            switch error {
-            case let error as NIOSSL.NIOSSLError where error == .failedToLoadCertificate:
-                break
-            default:
-                XCTFail("\(error)")
+            let tlsConfig = TLSConfiguration.forClient(trustRoots: .file("not/a/certificate"))
+            XCTAssertThrowsError(try tlsConfig.getNWProtocolTLSOptions()) { error in
+                switch error {
+                case let error as NIOSSL.NIOSSLError where error == .failedToLoadCertificate:
+                    break
+                default:
+                    XCTFail("\(error)")
+                }
             }
-        }
         #endif
     }
 }


### PR DESCRIPTION
This PR is a result of another #321.

In that PR I provided an alternative structure to `TLSConfiguration` for when connecting with Transport Services. 

In this one I construct the `NWProtocolTLS.Options` from `TLSConfiguration`. It does mean a little more work for whenever we make a connection, but having spoken to @weissi he doesn't seem to think that is an issue. 

Also there is no method to create a `SecIdentity` at the moment. We need to generate a pkcs#12 from the certificate chain and private key, which can then be used to create the `SecIdentity`.

This should resolve #292