### PR TITLE
Update to NIOSSL 2.12.x and fix tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.8.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2711,7 +2711,10 @@ class HTTPClientTests: XCTestCase {
             if isTestingNIOTS() {
                 XCTAssertEqual(error as? ChannelError, .connectTimeout(.milliseconds(100)))
             } else {
-                XCTAssertEqual(error as? NIOSSLError, NIOSSLError.uncleanShutdown)
+                switch error as? NIOSSLError {
+                case .some(.handshakeFailed(.sslError(_))): break
+                default: XCTFail("Handshake failed with unexpected error: \(String(describing: error))")
+                }
             }
         }
     }
@@ -2755,7 +2758,10 @@ class HTTPClientTests: XCTestCase {
             if isTestingNIOTS() {
                 XCTAssertEqual(error as? ChannelError, .connectTimeout(.milliseconds(200)))
             } else {
-                XCTAssertEqual(error as? NIOSSLError, NIOSSLError.uncleanShutdown)
+                switch error as? NIOSSLError {
+                case .some(.handshakeFailed(.sslError(_))): break
+                default: XCTFail("Handshake failed with unexpected error: \(String(describing: error))")
+                }
             }
         }
     }


### PR DESCRIPTION
The way NIOSSL propagated TLS handshake fails was incorrect. This was fixed and released in NIOSSL 2.12.

This PR updates to NIOSSL 2.12.x, and fixes tests that were broken as part of the change.