### PR TITLE
Support request specific TLS configuration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", .branch("main")),
-//        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.13.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.27.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", .branch("main")),
+//        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.12.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),

--- a/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
@@ -1,3 +1,17 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
 import NIOSSL
 
 /// Wrapper around `TLSConfiguration` from NIOSSL to provide a best effort implementation of `Hashable`

--- a/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
@@ -13,6 +13,6 @@ struct BestEffortHashableTLSConfiguration: Hashable {
     }
     
     static func == (lhs: BestEffortHashableTLSConfiguration, rhs: BestEffortHashableTLSConfiguration) -> Bool {
-        lhs.base.bestEffortEquals(rhs.base)
+        return lhs.base.bestEffortEquals(rhs.base)
     }
 }

--- a/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the AsyncHTTPClient open source project
 //
-// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
@@ -1,0 +1,18 @@
+import NIOSSL
+
+/// Wrapper around `TLSConfiguration` from NIOSSL to provide a best effort implementation of `Hashable`
+struct BestEffortHashableTLSConfiguration: Hashable {
+    let base: TLSConfiguration
+    
+    init(wrapping base: TLSConfiguration) {
+        self.base = base
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        base.bestEffortHash(into: &hasher)
+    }
+    
+    static func == (lhs: BestEffortHashableTLSConfiguration, rhs: BestEffortHashableTLSConfiguration) -> Bool {
+        lhs.base.bestEffortEquals(rhs.base)
+    }
+}

--- a/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/BestEffortHashableTLSConfiguration.swift
@@ -3,15 +3,15 @@ import NIOSSL
 /// Wrapper around `TLSConfiguration` from NIOSSL to provide a best effort implementation of `Hashable`
 struct BestEffortHashableTLSConfiguration: Hashable {
     let base: TLSConfiguration
-    
+
     init(wrapping base: TLSConfiguration) {
         self.base = base
     }
-    
+
     func hash(into hasher: inout Hasher) {
-        base.bestEffortHash(into: &hasher)
+        self.base.bestEffortHash(into: &hasher)
     }
-    
+
     static func == (lhs: BestEffortHashableTLSConfiguration, rhs: BestEffortHashableTLSConfiguration) -> Bool {
         return lhs.base.bestEffortEquals(rhs.base)
     }

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -82,7 +82,7 @@ final class ConnectionPool {
             } else {
                 let provider = HTTP1ConnectionProvider(key: key,
                                                        eventLoop: taskEventLoop,
-                                                       configuration: self.configuration,
+                                                       configuration: key.config(overriding: self.configuration),
                                                        pool: self,
                                                        backgroundActivityLogger: self.backgroundActivityLogger)
                 let enqueued = provider.enqueue()
@@ -165,6 +165,15 @@ final class ConnectionPool {
                     return false
                 }
             }
+        }
+
+        /// Returns a key-specific `HTTPClient.Configuration` by overriding the properties of `base`
+        func config(overriding base: HTTPClient.Configuration) -> HTTPClient.Configuration {
+            var config = base
+            if let tlsConfiguration = self.tlsConfiguration {
+                config.tlsConfiguration = tlsConfiguration.base
+            }
+            return config
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -20,7 +20,6 @@ import NIOHTTP1
 import NIOHTTPCompression
 import NIOTLS
 import NIOTransportServices
-import NIOSSL
 
 /// A connection pool that manages and creates new connections to hosts respecting the specified preferences
 ///

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -20,6 +20,7 @@ import NIOHTTP1
 import NIOHTTPCompression
 import NIOTLS
 import NIOTransportServices
+import NIOSSL
 
 /// A connection pool that manages and creates new connections to hosts respecting the specified preferences
 ///
@@ -139,12 +140,16 @@ final class ConnectionPool {
             self.port = request.port
             self.host = request.host
             self.unixPath = request.socketPath
+            if let tls = request.tlsConfiguration {
+                self.tlsConfiguration = BestEffortHashableTLSConfiguration(wrapping: tls)
+            }
         }
 
         var scheme: Scheme
         var host: String
         var port: Int
         var unixPath: String
+        var tlsConfiguration: BestEffortHashableTLSConfiguration?
 
         enum Scheme: Hashable {
             case http

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -205,20 +205,53 @@ extension HTTPClient {
         ///     - method: HTTP method.
         ///     - headers: Custom HTTP headers.
         ///     - body: Request body.
+        /// - throws:
+        ///     - `invalidURL` if URL cannot be parsed.
+        ///     - `emptyScheme` if URL does not contain HTTP scheme.
+        ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.
+        ///     - `emptyHost` if URL does not contains a host.
+        public init(url: String, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil) throws {
+            try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: nil)
+        }
+        
+        /// Create HTTP request.
+        ///
+        /// - parameters:
+        ///     - url: Remote `URL`.
+        ///     - version: HTTP version.
+        ///     - method: HTTP method.
+        ///     - headers: Custom HTTP headers.
+        ///     - body: Request body.
         ///     - tlsConfiguration: Request TLS configuration
         /// - throws:
         ///     - `invalidURL` if URL cannot be parsed.
         ///     - `emptyScheme` if URL does not contain HTTP scheme.
         ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.
         ///     - `emptyHost` if URL does not contains a host.
-        public init(url: String, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration? = nil) throws {
+        public init(url: String, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration?) throws {
             guard let url = URL(string: url) else {
                 throw HTTPClientError.invalidURL
             }
-
+            
             try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: tlsConfiguration)
         }
 
+        /// Create an HTTP `Request`.
+        ///
+        /// - parameters:
+        ///     - url: Remote `URL`.
+        ///     - method: HTTP method.
+        ///     - headers: Custom HTTP headers.
+        ///     - body: Request body.
+        /// - throws:
+        ///     - `emptyScheme` if URL does not contain HTTP scheme.
+        ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.
+        ///     - `emptyHost` if URL does not contains a host.
+        ///     - `missingSocketPath` if URL does not contains a socketPath as an encoded host.
+        public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil) throws {
+            try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: nil)
+        }
+        
         /// Create an HTTP `Request`.
         ///
         /// - parameters:
@@ -232,16 +265,16 @@ extension HTTPClient {
         ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.
         ///     - `emptyHost` if URL does not contains a host.
         ///     - `missingSocketPath` if URL does not contains a socketPath as an encoded host.
-        public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration? = nil) throws {
+        public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration?) throws {
             guard let scheme = url.scheme?.lowercased() else {
                 throw HTTPClientError.emptyScheme
             }
-
+            
             self.kind = try Kind(forScheme: scheme)
             self.host = try self.kind.hostFromURL(url)
             self.socketPath = try self.kind.socketPathFromURL(url)
             self.uri = self.kind.uriFromURL(url)
-
+            
             self.redirectState = nil
             self.url = url
             self.method = method

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -205,6 +205,7 @@ extension HTTPClient {
         ///     - method: HTTP method.
         ///     - headers: Custom HTTP headers.
         ///     - body: Request body.
+        ///     - tlsConfiguration: Request TLS configuration
         /// - throws:
         ///     - `invalidURL` if URL cannot be parsed.
         ///     - `emptyScheme` if URL does not contain HTTP scheme.
@@ -215,7 +216,7 @@ extension HTTPClient {
                 throw HTTPClientError.invalidURL
             }
 
-            try self.init(url: url, method: method, headers: headers, body: body)
+            try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: tlsConfiguration)
         }
 
         /// Create an HTTP `Request`.
@@ -225,6 +226,7 @@ extension HTTPClient {
         ///     - method: HTTP method.
         ///     - headers: Custom HTTP headers.
         ///     - body: Request body.
+        ///     - tlsConfiguration: Request TLS configuration
         /// - throws:
         ///     - `emptyScheme` if URL does not contain HTTP scheme.
         ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -186,6 +186,8 @@ extension HTTPClient {
         public var headers: HTTPHeaders
         /// Request body, defaults to no body.
         public var body: Body?
+        /// Request-specific TLS configuration, defaults to no request-specific TLS configuration.
+        public var tlsConfiguration: TLSConfiguration?
 
         struct RedirectState {
             var count: Int
@@ -208,7 +210,7 @@ extension HTTPClient {
         ///     - `emptyScheme` if URL does not contain HTTP scheme.
         ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.
         ///     - `emptyHost` if URL does not contains a host.
-        public init(url: String, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil) throws {
+        public init(url: String, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration? = nil) throws {
             guard let url = URL(string: url) else {
                 throw HTTPClientError.invalidURL
             }
@@ -228,7 +230,7 @@ extension HTTPClient {
         ///     - `unsupportedScheme` if URL does contains unsupported HTTP scheme.
         ///     - `emptyHost` if URL does not contains a host.
         ///     - `missingSocketPath` if URL does not contains a socketPath as an encoded host.
-        public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil) throws {
+        public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration? = nil) throws {
             guard let scheme = url.scheme?.lowercased() else {
                 throw HTTPClientError.emptyScheme
             }
@@ -244,6 +246,7 @@ extension HTTPClient {
             self.scheme = scheme
             self.headers = headers
             self.body = body
+            self.tlsConfiguration = tlsConfiguration
         }
 
         /// Whether request will be executed using secure socket.

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -213,7 +213,7 @@ extension HTTPClient {
         public init(url: String, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil) throws {
             try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: nil)
         }
-        
+
         /// Create HTTP request.
         ///
         /// - parameters:
@@ -232,7 +232,7 @@ extension HTTPClient {
             guard let url = URL(string: url) else {
                 throw HTTPClientError.invalidURL
             }
-            
+
             try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: tlsConfiguration)
         }
 
@@ -251,7 +251,7 @@ extension HTTPClient {
         public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil) throws {
             try self.init(url: url, method: method, headers: headers, body: body, tlsConfiguration: nil)
         }
-        
+
         /// Create an HTTP `Request`.
         ///
         /// - parameters:
@@ -269,12 +269,12 @@ extension HTTPClient {
             guard let scheme = url.scheme?.lowercased() else {
                 throw HTTPClientError.emptyScheme
             }
-            
+
             self.kind = try Kind(forScheme: scheme)
             self.host = try self.kind.hostFromURL(url)
             self.socketPath = try self.kind.socketPathFromURL(url)
             self.uri = self.kind.uriFromURL(url)
-            
+
             self.redirectState = nil
             self.url = url
             self.method = method

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -150,9 +150,9 @@ extension NIOClientTCPBootstrap {
         let key = destination
 
         let requiresTLS = key.scheme.requiresTLS
-        // Override specific key configuration.
+        // Override optional connection pool configuration.
         var keyConfiguration = configuration
-        if let tlsConfiguration = destination.tlsConfiguration {
+        if let tlsConfiguration = key.tlsConfiguration {
             keyConfiguration.tlsConfiguration = tlsConfiguration.base
         }
         let bootstrap: NIOClientTCPBootstrap

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -165,7 +165,8 @@ extension NIOClientTCPBootstrap {
             let requiresSSLHandler = configuration.proxy != nil && key.scheme.requiresTLS
             let handshakePromise = channel.eventLoop.makePromise(of: Void.self)
 
-            channel.pipeline.addSSLHandlerIfNeeded(for: key, tlsConfiguration: configuration.tlsConfiguration, addSSLClient: requiresSSLHandler, handshakePromise: handshakePromise)
+            let tlsConfiguration = key.tlsConfiguration?.base ?? configuration.tlsConfiguration
+            channel.pipeline.addSSLHandlerIfNeeded(for: key, tlsConfiguration: tlsConfiguration, addSSLClient: requiresSSLHandler, handshakePromise: handshakePromise)
 
             return handshakePromise.futureResult.flatMap {
                 channel.pipeline.addHTTPClientHandlers(leftOverBytesStrategy: .forwardBytes)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -133,6 +133,7 @@ extension HTTPClientTests {
             ("testFileDownloadChunked", testFileDownloadChunked),
             ("testCloseWhileBackpressureIsExertedIsFine", testCloseWhileBackpressureIsExertedIsFine),
             ("testErrorAfterCloseWhileBackpressureExerted", testErrorAfterCloseWhileBackpressureExerted),
+            ("testRequestSpecificTLS", testRequestSpecificTLS),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2916,7 +2916,7 @@ class HTTPClientTests: XCTestCase {
             XCTAssertEqual(error as? ExpectedError, .expected)
         }
     }
-    
+
     func testRequestSpecificTLS() throws {
         let configuration = HTTPClient.Configuration(tlsConfiguration: nil,
                                                      timeout: .init(),
@@ -2926,12 +2926,12 @@ class HTTPClientTests: XCTestCase {
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                      configuration: configuration)
         let decoder = JSONDecoder()
-        
+
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
             XCTAssertNoThrow(try localHTTPBin.shutdown())
         }
-        
+
         // First two requests use identical TLS configurations.
         let firstRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: .forClient(certificateVerification: .none))
         let firstResponse = try localClient.execute(request: firstRequest).wait()
@@ -2940,7 +2940,7 @@ class HTTPClientTests: XCTestCase {
             return
         }
         let firstConnectionNumber = try decoder.decode(RequestInfo.self, from: firstBody).connectionNumber
-        
+
         let secondRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: .forClient(certificateVerification: .none))
         let secondResponse = try localClient.execute(request: secondRequest).wait()
         guard let secondBody = secondResponse.body else {
@@ -2948,7 +2948,7 @@ class HTTPClientTests: XCTestCase {
             return
         }
         let secondConnectionNumber = try decoder.decode(RequestInfo.self, from: secondBody).connectionNumber
-        
+
         // Uses a differrent TLS config.
         let thirdRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: .forClient(maximumTLSVersion: .tlsv1, certificateVerification: .none))
         let thirdResponse = try localClient.execute(request: thirdRequest).wait()
@@ -2957,7 +2957,7 @@ class HTTPClientTests: XCTestCase {
             return
         }
         let thirdConnectionNumber = try decoder.decode(RequestInfo.self, from: thirdBody).connectionNumber
-        
+
         XCTAssertEqual(firstResponse.status, .ok)
         XCTAssertEqual(secondResponse.status, .ok)
         XCTAssertEqual(thirdResponse.status, .ok)


### PR DESCRIPTION
Adds support for request-specific TLS configuration:
`Request(url: "https://webserver.com", tlsConfiguration: .forClient())`

https://github.com/apple/swift-nio-ssl/pull/280 must be released, before this can be merged.