### PR TITLE
add 5.4 docker setup for CI

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,9 +17,10 @@ RUN apt-get update && apt-get install -y wget
 RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools libz-dev curl jq # used by integration tests
 
 # ruby and jazzy for docs generation
-RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-# jazzy no longer works on xenial as ruby is too old.
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then  gem install jazzy --no-ri --no-rdoc ; fi
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
+# switch of gem docs building
+RUN echo "gem: --no-document" > ~/.gemrc
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then gem install jazzy ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/docker-compose.2004.54.yaml
+++ b/docker/docker-compose.2004.54.yaml
@@ -1,0 +1,18 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: async-http-client:20.04-5.4
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.4"
+
+  test:
+    image: async-http-client:20.04-5.4
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  shell:
+    image: async-http-client:20.04-5.4


### PR DESCRIPTION
motivation: 5.4 is out!

changes:  add docker compose setup for ubuntu 20.04 and 5.4 toolchain