### PR TITLE
fix Swift Package Index build

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -115,14 +115,19 @@ class HTTPClientNIOTSTests: XCTestCase {
     func testTrustRootCertificateLoadFail() {
         guard isTestingNIOTS() else { return }
         #if canImport(Network)
-            let tlsConfig = TLSConfiguration.forClient(trustRoots: .file("not/a/certificate"))
-            XCTAssertThrowsError(try tlsConfig.getNWProtocolTLSOptions()) { error in
-                switch error {
-                case let error as NIOSSL.NIOSSLError where error == .failedToLoadCertificate:
-                    break
-                default:
-                    XCTFail("\(error)")
+            if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+                let tlsConfig = TLSConfiguration.forClient(trustRoots: .file("not/a/certificate"))
+
+                XCTAssertThrowsError(try tlsConfig.getNWProtocolTLSOptions()) { error in
+                    switch error {
+                    case let error as NIOSSL.NIOSSLError where error == .failedToLoadCertificate:
+                        break
+                    default:
+                        XCTFail("\(error)")
+                    }
                 }
+            } else {
+                XCTFail("should be impossible")
             }
         #endif
     }


### PR DESCRIPTION
Motivation:

Swift Package Index builds for i(Pad)/tvOS are currently failing because the tests access a method that's only available on iOS12+.

Modification:

Put in the right availability check.

Result:

Should compile in Swift Package Index