### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,55 +1,38 @@
 # Code of Conduct
-To be a truly great community, AsyncHTTPClient needs to welcome developers from all walks of life,
-with different backgrounds, and with a wide range of experience. A diverse and friendly
-community will have more great ideas, more unique perspectives, and produce more great
-code. We will work diligently to make the AsyncHTTPClient community welcoming to everyone.
 
-To give clarity of what is expected of our members, AsyncHTTPClient has adopted the code of conduct
-defined by [contributor-covenant.org](https://www.contributor-covenant.org). This document is used across many open source
-communities, and we think it articulates our values well. The full text is copied below:
+To be a truly great community, the AsyncHTTPClient project needs to welcome developers from all walks of life, with different backgrounds, and with a wide range of experience. A diverse and friendly community will have more great ideas, more unique perspectives, and produce more great code.  We will work diligently to make the AsyncHTTPClient community welcoming to everyone.
 
-### Contributor Code of Conduct v1.3
-As contributors and maintainers of this project, and in the interest of fostering an open and
-welcoming community, we pledge to respect all people who contribute through reporting
-issues, posting feature requests, updating documentation, submitting pull requests or patches,
-and other activities.
+To give clarity of what is expected of our members, this code of conduct is based on [contributor-covenant.org](http://contributor-covenant.org). This document is used across many open source communities, and we think it articulates our values well.
 
-We are committed to making participation in this project a harassment-free experience for
-everyone, regardless of level of experience, gender, gender identity and expression, sexual
-orientation, disability, personal appearance, body size, race, ethnicity, age, religion, or
-nationality.
+### Contributor Code of Conduct v1.4
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language (e.g., prefer non-gendered words like “folks” to “guys”, non-ableist words like “soundness check” to “sanity check”, etc.)
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:
-- The use of sexualized language or imagery
-- Personal attacks
-- Trolling or insulting/derogatory comments
-- Public or private harassment
-- Publishing other’s private information, such as physical or electronic addresses, without explicit permission
-- Other unethical or unprofessional conduct
 
-Project maintainers have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of
-Conduct, or to ban temporarily or permanently any contributor for other behaviors that they
-deem inappropriate, threatening, offensive, or harmful.
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-By adopting this Code of Conduct, project maintainers commit themselves to fairly and
-consistently applying these principles to every aspect of managing this project. Project
-maintainers who do not follow or enforce the Code of Conduct may be permanently removed
-from the project team.
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-This code of conduct applies both within project spaces and in public spaces when an
-individual is representing the project or its community.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
-contacting a project maintainer at [conduct@swiftserver.group](mailto:conduct@swiftserver.group). All complaints will be reviewed and
-investigated and will result in a response that is deemed necessary and appropriate to the
-circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter
-of an incident.
+This Code of Conduct applies within all project spaces managed by the AsyncHTTPClient project, including (but not limited to) source code repositories, bug trackers, web sites, documentation, and online forums. It also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
-*This policy is adapted from the Contributor Code of Conduct [version 1.3.0](https://contributor-covenant.org/version/1/3/0/).*
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a project maintainer at [swift-server-conduct@group.apple.com](mailto:swift-server-conduct@group.apple.com) or by flagging the behavior for moderation (e.g., in the Forums), whether you are the target of that behavior or not. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident. The site of the disputed behavior is usually not an acceptable place to discuss moderation decisions, and moderators may move or remove any such discussion.
 
-### Reporting
-A working group of community members is committed to promptly addressing any [reported issues](mailto:conduct@swiftserver.group).
-Working group members are volunteers appointed by the project lead, with a
-preference for individuals with varied backgrounds and perspectives. Membership is expected
-to change regularly, and may grow or shrink.
+Project maintainers are held to a higher standard, and project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+If you disagree with a moderation action, you can appeal to the Core Team (or individual Core Team members) privately.
+
+This policy is adapted from the Contributor Code of Conduct [version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).


### PR DESCRIPTION
When we updated to Code of Conduct 1.4, we may have forgotten AHC.