### PR TITLE
Make DelayOnHeadDelegate resilient

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2895,15 +2895,13 @@ class HTTPClientTests: XCTestCase {
 
     func testCloseWhileBackpressureIsExertedIsFine() throws {
         let request = try Request(url: self.defaultHTTPBinURLPrefix + "close-on-response")
-        let backpressurePromise = self.defaultClient.eventLoopGroup.next().makePromise(of: Void.self)
-
-        let resultFuture = self.defaultClient.execute(
-            request: request, delegate: DelayOnHeadDelegate(promise: backpressurePromise)
-        )
-
-        self.defaultClient.eventLoopGroup.next().scheduleTask(in: .milliseconds(50)) {
-            backpressurePromise.succeed(())
+        let delegate = DelayOnHeadDelegate(eventLoop: self.clientGroup.next()) { _, promise in
+            promise.futureResult.eventLoop.scheduleTask(in: .milliseconds(50)) {
+                promise.succeed(())
+            }
         }
+
+        let resultFuture = self.defaultClient.execute(request: request, delegate: delegate)
 
         // The full response must be correctly delivered.
         var data = try resultFuture.wait()
@@ -2920,15 +2918,11 @@ class HTTPClientTests: XCTestCase {
         }
 
         let request = try Request(url: self.defaultHTTPBinURLPrefix + "close-on-response")
-        let backpressurePromise = self.defaultClient.eventLoopGroup.next().makePromise(of: Void.self)
-
-        let resultFuture = self.defaultClient.execute(
-            request: request, delegate: DelayOnHeadDelegate(promise: backpressurePromise)
-        )
-
-        self.defaultClient.eventLoopGroup.next().scheduleTask(in: .milliseconds(50)) {
+        let delegate = DelayOnHeadDelegate(eventLoop: self.clientGroup.next()) { _, backpressurePromise in
             backpressurePromise.fail(ExpectedError.expected)
         }
+
+        let resultFuture = self.defaultClient.execute(request: request, delegate: delegate)
 
         // The task must be failed.
         XCTAssertThrowsError(try resultFuture.wait()) { error in


### PR DESCRIPTION
Currently the `DelayOnHeadDelegate` test utility depends on correct timings. Right now, if a request is slower than 50ms in  `testErrorAfterCloseWhileBackpressureExerted` the test will fail, since the backpressure promise is failed, before a head was received. This pr fixes this, by giving the user a callback, when the head was received.