### PR TITLE
Fix test for misbehaving server

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
@@ -130,7 +130,7 @@ class HTTPClientSOCKSTests: XCTestCase {
             XCTAssertNoThrow(try localClient.syncShutdown())
             XCTAssertNoThrow(try socksBin.shutdown())
         }
-        
+
         // the server will send a bogus message in response to the clients greeting
         // this will be first picked up as an invalid protocol
         XCTAssertThrowsError(try localClient.get(url: "http://localhost/socks/test").wait()) { e in

--- a/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
@@ -130,8 +130,11 @@ class HTTPClientSOCKSTests: XCTestCase {
             XCTAssertNoThrow(try localClient.syncShutdown())
             XCTAssertNoThrow(try socksBin.shutdown())
         }
-
-        // the server will send a bogus message in response to the clients request
-        XCTAssertThrowsError(try localClient.get(url: "http://localhost/socks/test").wait())
+        
+        // the server will send a bogus message in response to the clients greeting
+        // this will be first picked up as an invalid protocol
+        XCTAssertThrowsError(try localClient.get(url: "http://localhost/socks/test").wait()) { e in
+            XCTAssertTrue(e is SOCKSError.InvalidProtocolVersion)
+        }
     }
 }

--- a/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
@@ -24,7 +24,7 @@ struct MockSOCKSError: Error, Hashable {
 
 class TestSOCKSBadServerHandler: ChannelInboundHandler {
     typealias InboundIn = ByteBuffer
-    
+
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         // just write some nonsense bytes
         let buffer = context.channel.allocator.buffer(bytes: [0xAA, 0xBB, 0xCC, 0xDD, 0xEE])
@@ -36,14 +36,13 @@ class MockSOCKSServer {
     let channel: Channel
 
     init(expectedURL: String, expectedResponse: String, misbehave: Bool = false, file: String = #file, line: UInt = #line) throws {
-        
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let bootstrap: ServerBootstrap
         if misbehave {
             bootstrap = ServerBootstrap(group: elg)
                 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                 .childChannelInitializer { channel in
-                    return channel.pipeline.addHandler(TestSOCKSBadServerHandler())
+                    channel.pipeline.addHandler(TestSOCKSBadServerHandler())
                 }
         } else {
             bootstrap = ServerBootstrap(group: elg)
@@ -98,7 +97,7 @@ class SOCKSTestHandler: ChannelInboundHandler, RemovableChannelHandler {
             }
         }
     }
-    
+
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         context.fireErrorCaught(error)
     }
@@ -148,8 +147,8 @@ class TestHTTPServer: ChannelInboundHandler {
 //            let buffer = context.channel.allocator.buffer(bytes: [0xFF, 0xFF, 0xFF, 0xFF])
 //            context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
 //        } else {
-            context.fireErrorCaught(error)
-            context.close(promise: nil)
+        context.fireErrorCaught(error)
+        context.close(promise: nil)
 //        }
     }
 }

--- a/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
@@ -97,10 +97,6 @@ class SOCKSTestHandler: ChannelInboundHandler, RemovableChannelHandler {
             }
         }
     }
-
-    func errorCaught(context: ChannelHandlerContext, error: Error) {
-        context.fireErrorCaught(error)
-    }
 }
 
 class TestHTTPServer: ChannelInboundHandler {
@@ -139,16 +135,7 @@ class TestHTTPServer: ChannelInboundHandler {
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
-//        if self.misbehave {
-//            // We've landed here because of a state error
-//            // which we want when we're misbehaving
-//            // so in this case ignore the error, and send forward
-//            // some invalid socks bytes.
-//            let buffer = context.channel.allocator.buffer(bytes: [0xFF, 0xFF, 0xFF, 0xFF])
-//            context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
-//        } else {
         context.fireErrorCaught(error)
         context.close(promise: nil)
-//        }
     }
 }


### PR DESCRIPTION
The misbehaving SOCKS server test was previously passing, but not for the right reason. The invalid data we were sending was never making it off the server thanks to the SOCKSServerHandshakeHandler.

In fact, as long as SOCKSServerHandshakeHandler is present, it isn't possible to send invalid data. So to test the client now we have to add a completely new handler, which exists only to write some nonsense bytes.

The test still passes, but for the right reason, and we now assert the type of error the client throws too.