### PR TITLE
Make `testSSLHandshakeErrorPropagation` less flaky

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2715,9 +2715,14 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try server.close().wait())
         }
 
-        // We set the connect timeout down very low here because on NIOTS this manifests as a connect
-        // timeout.
-        let config = HTTPClient.Configuration(timeout: HTTPClient.Configuration.Timeout(connect: .milliseconds(100), read: nil))
+        var timeout = HTTPClient.Configuration.Timeout(connect: .seconds(10))
+        if isTestingNIOTS() {
+            // If we are using Network.framework, we set the connect timeout down very low here
+            // because on NIOTS a failing TLS handshake manifests as a connect timeout.
+            timeout.connect = .milliseconds(100)
+        }
+
+        let config = HTTPClient.Configuration(timeout: timeout)
         let client = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup), configuration: config)
         defer {
             XCTAssertNoThrow(try client.syncShutdown())


### PR DESCRIPTION
### Motivation

- The `testSSLHandshakeErrorPropagation` has a very short connect timeout (100ms). The reason for this is, that a failing TLS handshake manifest in NIOTS as a connect timeout and we don’t want to wait for the timeout for to long in our tests.
- When using `NIOSSL` however, we expect a proper `NIOSSLError`. Sometimes though the connection is not setup fast enough (because of the very short 100ms connect timeout), that we get a `connectTimeout` error instead. See build logs: https://ci.swiftserver.group/job/async-http-client-swift52-prb/480/console
    ```
    Test Case 'HTTPClientTests.testSSLHandshakeErrorPropagation' started at 2021-06-22 19:14:49.426
    /code/Tests/AsyncHTTPClientTests/HTTPClientTests.swift:2735: error: 
    HTTPClientTests.testSSLHandshakeErrorPropagation : failed - Handshake failed with unexpected error: connectTimeout(NIO.TimeAmount(nanoseconds: 100000000))
    ```

### Modifications

- Setting the short connect timeout to 100ms when using NIOTS only. This will make sure we get the proper NIOSSLError when using NIOSSL