### PR TITLE
Update NIO family dependencies to 5.2+ versions and fix deprecations

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,10 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.29.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.13.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.9.1"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.10.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -637,7 +637,7 @@ public class HTTPClient {
 
     /// `HTTPClient` configuration.
     public struct Configuration {
-        /// TLS configuration, defaults to `TLSConfiguration.forClient()`.
+        /// TLS configuration, defaults to `TLSConfiguration.makeClientConfiguration()`.
         public var tlsConfiguration: Optional<TLSConfiguration>
         /// Enables following 3xx redirects automatically, defaults to `RedirectConfiguration()`.
         ///
@@ -701,7 +701,9 @@ public class HTTPClient {
                     proxy: Proxy? = nil,
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled) {
-            self.init(tlsConfiguration: TLSConfiguration.forClient(certificateVerification: certificateVerification),
+            var tlsConfig = TLSConfiguration.makeClientConfiguration()
+            tlsConfig.certificateVerification = certificateVerification
+            self.init(tlsConfiguration: tlsConfig,
                       redirectConfiguration: redirectConfiguration,
                       timeout: timeout,
                       connectionPool: ConnectionPool(),
@@ -718,7 +720,9 @@ public class HTTPClient {
                     ignoreUncleanSSLShutdown: Bool = false,
                     decompression: Decompression = .disabled,
                     backgroundActivityLogger: Logger?) {
-            self.init(tlsConfiguration: TLSConfiguration.forClient(certificateVerification: certificateVerification),
+            var tlsConfig = TLSConfiguration.makeClientConfiguration()
+            tlsConfig.certificateVerification = certificateVerification
+            self.init(tlsConfiguration: tlsConfig,
                       redirectConfiguration: redirectConfiguration,
                       timeout: timeout,
                       connectionPool: ConnectionPool(),

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -72,7 +72,7 @@ extension NIOClientTCPBootstrap {
             //
             // Note that TLS proxies are not supported at the moment. This means that we will always speak
             // plaintext to the proxy but we do support sending HTTPS traffic through the proxy.
-            sslContext = sslContextCache.sslContext(tlsConfiguration: configuration.tlsConfiguration ?? .forClient(),
+            sslContext = sslContextCache.sslContext(tlsConfiguration: configuration.tlsConfiguration ?? .makeClientConfiguration(),
                                                     eventLoop: eventLoop,
                                                     logger: logger).map { $0 }
         } else {
@@ -130,7 +130,7 @@ extension NIOClientTCPBootstrap {
                                       eventLoop: eventLoop,
                                       requiresTLS: requiresTLS,
                                       sslContextCache: sslContextCache,
-                                      tlsConfiguration: configuration.tlsConfiguration ?? .forClient(),
+                                      tlsConfiguration: configuration.tlsConfiguration ?? .makeClientConfiguration(),
                                       useProxy: configuration.proxy != nil,
                                       logger: logger)
             .map { bootstrap -> NIOClientTCPBootstrap in

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -97,9 +97,13 @@ class HTTPClientNIOTSTests: XCTestCase {
         guard isTestingNIOTS() else { return }
         #if canImport(Network)
             let httpBin = HTTPBin(ssl: true)
+            var tlsConfig = TLSConfiguration.makeClientConfiguration()
+            tlsConfig.certificateVerification = .none
+            tlsConfig.minimumTLSVersion = .tlsv11
+            tlsConfig.maximumTLSVersion = .tlsv1
             let httpClient = HTTPClient(
                 eventLoopGroupProvider: .shared(self.clientGroup),
-                configuration: .init(tlsConfiguration: TLSConfiguration.forClient(minimumTLSVersion: .tlsv11, maximumTLSVersion: .tlsv1, certificateVerification: .none))
+                configuration: .init(tlsConfiguration: tlsConfig)
             )
             defer {
                 XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
@@ -116,7 +120,8 @@ class HTTPClientNIOTSTests: XCTestCase {
         guard isTestingNIOTS() else { return }
         #if canImport(Network)
             if #available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
-                let tlsConfig = TLSConfiguration.forClient(trustRoots: .file("not/a/certificate"))
+                var tlsConfig = TLSConfiguration.makeClientConfiguration()
+                tlsConfig.trustRoots = .file("not/a/certificate")
 
                 XCTAssertThrowsError(try tlsConfig.getNWProtocolTLSOptions()) { error in
                     switch error {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -290,7 +290,7 @@ internal final class HTTPBin {
 
     static func configureTLS(channel: Channel) -> EventLoopFuture<Void> {
         let configuration = TLSConfiguration.makeServerConfiguration(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
-                                                       privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
+                                                                     privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
         let context = try! NIOSSLContext(configuration: configuration)
         return channel.pipeline.addHandler(NIOSSLServerHandler(context: context), position: .first)
     }
@@ -774,7 +774,7 @@ internal class HttpBinForSSLUncleanShutdown {
                 let requestDecoder = HTTPRequestDecoder()
                 return channel.pipeline.addHandler(ByteToMessageHandler(requestDecoder)).flatMap {
                     let configuration = TLSConfiguration.makeServerConfiguration(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
-                                                                   privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
+                                                                                 privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
                     let context = try! NIOSSLContext(configuration: configuration)
                     return channel.pipeline.addHandler(NIOSSLServerHandler(context: context), name: "NIOSSLServerHandler", position: .first).flatMap {
                         channel.pipeline.addHandler(HttpBinForSSLUncleanShutdownHandler(channelPromise: channelPromise))

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -289,7 +289,7 @@ internal final class HTTPBin {
     }
 
     static func configureTLS(channel: Channel) -> EventLoopFuture<Void> {
-        let configuration = TLSConfiguration.forServer(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
+        let configuration = TLSConfiguration.makeServerConfiguration(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
                                                        privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
         let context = try! NIOSSLContext(configuration: configuration)
         return channel.pipeline.addHandler(NIOSSLServerHandler(context: context), position: .first)
@@ -773,7 +773,7 @@ internal class HttpBinForSSLUncleanShutdown {
             .childChannelInitializer { channel in
                 let requestDecoder = HTTPRequestDecoder()
                 return channel.pipeline.addHandler(ByteToMessageHandler(requestDecoder)).flatMap {
-                    let configuration = TLSConfiguration.forServer(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
+                    let configuration = TLSConfiguration.makeServerConfiguration(certificateChain: [.certificate(try! NIOSSLCertificate(bytes: Array(cert.utf8), format: .pem))],
                                                                    privateKey: .privateKey(try! NIOSSLPrivateKey(bytes: Array(key.utf8), format: .pem)))
                     let context = try! NIOSSLContext(configuration: configuration)
                     return channel.pipeline.addHandler(NIOSSLServerHandler(context: context), name: "NIOSSLServerHandler", position: .first).flatMap {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2858,7 +2858,10 @@ class HTTPClientTests: XCTestCase {
 
         // We use a specially crafted client that has no cipher suites to offer. To do this we ask
         // only for cipher suites incompatible with our TLS version.
-        let tlsConfig = TLSConfiguration.forClient(minimumTLSVersion: .tlsv13, maximumTLSVersion: .tlsv12, certificateVerification: .none)
+        var tlsConfig = TLSConfiguration.makeClientConfiguration()
+        tlsConfig.minimumTLSVersion = .tlsv13
+        tlsConfig.maximumTLSVersion = .tlsv12
+        tlsConfig.certificateVerification = .none
         let localHTTPBin = HTTPBin(ssl: true)
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                      configuration: HTTPClient.Configuration(tlsConfiguration: tlsConfig))
@@ -2951,7 +2954,9 @@ class HTTPClientTests: XCTestCase {
         }
 
         // First two requests use identical TLS configurations.
-        let firstRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: .forClient(certificateVerification: .none))
+        var tlsConfig = TLSConfiguration.makeClientConfiguration()
+        tlsConfig.certificateVerification = .none
+        let firstRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: tlsConfig)
         let firstResponse = try localClient.execute(request: firstRequest).wait()
         guard let firstBody = firstResponse.body else {
             XCTFail("No request body found")
@@ -2959,7 +2964,7 @@ class HTTPClientTests: XCTestCase {
         }
         let firstConnectionNumber = try decoder.decode(RequestInfo.self, from: firstBody).connectionNumber
 
-        let secondRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: .forClient(certificateVerification: .none))
+        let secondRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: tlsConfig)
         let secondResponse = try localClient.execute(request: secondRequest).wait()
         guard let secondBody = secondResponse.body else {
             XCTFail("No request body found")
@@ -2968,7 +2973,10 @@ class HTTPClientTests: XCTestCase {
         let secondConnectionNumber = try decoder.decode(RequestInfo.self, from: secondBody).connectionNumber
 
         // Uses a differrent TLS config.
-        let thirdRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: .forClient(maximumTLSVersion: .tlsv1, certificateVerification: .none))
+        var tlsConfig2 = TLSConfiguration.makeClientConfiguration()
+        tlsConfig2.certificateVerification = .none
+        tlsConfig2.maximumTLSVersion = .tlsv1
+        let thirdRequest = try HTTPClient.Request(url: "https://localhost:\(localHTTPBin.port)/get", method: .GET, tlsConfiguration: tlsConfig2)
         let thirdResponse = try localClient.execute(request: thirdRequest).wait()
         guard let thirdBody = thirdResponse.body else {
             XCTFail("No request body found")

--- a/Tests/AsyncHTTPClientTests/SSLContextCacheTests.swift
+++ b/Tests/AsyncHTTPClientTests/SSLContextCacheTests.swift
@@ -26,7 +26,7 @@ final class SSLContextCacheTests: XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
 
-        XCTAssertNoThrow(try cache.sslContext(tlsConfiguration: .forClient(),
+        XCTAssertNoThrow(try cache.sslContext(tlsConfiguration: .makeClientConfiguration(),
                                               eventLoop: eventLoop,
                                               logger: HTTPClient.loggingDisabled).wait())
     }
@@ -42,10 +42,10 @@ final class SSLContextCacheTests: XCTestCase {
         var firstContext: NIOSSLContext?
         var secondContext: NIOSSLContext?
 
-        XCTAssertNoThrow(firstContext = try cache.sslContext(tlsConfiguration: .forClient(),
+        XCTAssertNoThrow(firstContext = try cache.sslContext(tlsConfiguration: .makeClientConfiguration(),
                                                              eventLoop: eventLoop,
                                                              logger: HTTPClient.loggingDisabled).wait())
-        XCTAssertNoThrow(secondContext = try cache.sslContext(tlsConfiguration: .forClient(),
+        XCTAssertNoThrow(secondContext = try cache.sslContext(tlsConfiguration: .makeClientConfiguration(),
                                                               eventLoop: eventLoop,
                                                               logger: HTTPClient.loggingDisabled).wait())
         XCTAssertNotNil(firstContext)
@@ -64,12 +64,14 @@ final class SSLContextCacheTests: XCTestCase {
         var firstContext: NIOSSLContext?
         var secondContext: NIOSSLContext?
 
-        XCTAssertNoThrow(firstContext = try cache.sslContext(tlsConfiguration: .forClient(),
+        XCTAssertNoThrow(firstContext = try cache.sslContext(tlsConfiguration: .makeClientConfiguration(),
                                                              eventLoop: eventLoop,
                                                              logger: HTTPClient.loggingDisabled).wait())
 
         // Second one has a _different_ TLSConfiguration.
-        XCTAssertNoThrow(secondContext = try cache.sslContext(tlsConfiguration: .forClient(certificateVerification: .none),
+        var testTLSConfig = TLSConfiguration.makeClientConfiguration()
+        testTLSConfig.certificateVerification = .none
+        XCTAssertNoThrow(secondContext = try cache.sslContext(tlsConfiguration: testTLSConfig,
                                                               eventLoop: eventLoop,
                                                               logger: HTTPClient.loggingDisabled).wait())
         XCTAssertNotNil(firstContext)


### PR DESCRIPTION
Updated:
- NIO
- NIOSSL
- NIO Extras
- NIOTS

Also fix `TLSConfiguration.forClient()` warnings by converting to `TLSConfiguration.makeClientConfiguration()`. Also the same for `forServer()`.