### PR TITLE
Refactor Request Validation

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPExecutingRequest.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPExecutingRequest.swift
@@ -189,9 +189,17 @@ protocol HTTPRequestExecutor {
 protocol HTTPExecutingRequest: AnyObject {
     /// The request's head.
     ///
-    /// Based on the content of the request head the task executor will call `startRequestBodyStream`
-    /// after `requestHeadSent` was called.
+    /// The HTTP request head, that shall be sent. The HTTPRequestExecutor **will not** run any validation
+    /// check on the request head. All necessary metadata about the request head the executor expects in
+    /// the ``requestFramingMetadata``.
     var requestHead: HTTPRequestHead { get }
+
+    /// The request's framing metadata.
+    ///
+    /// The request framing metadata that is derived from the ``requestHead``. Based on the content of the
+    /// request framing metadata the executor will call ``startRequestBodyStream`` after
+    /// ``requestHeadSent``.
+    var requestFramingMetadata: RequestFramingMetadata { get }
 
     /// The maximal `TimeAmount` that is allowed to pass between `channelRead`s from the Channel.
     var idleReadTimeout: TimeAmount? { get }

--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestFramingMetadata.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestFramingMetadata.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct RequestFramingMetadata: Equatable {
-    enum Body: Equatable {
+struct RequestFramingMetadata: Hashable {
+    enum Body: Hashable {
         case none
         case stream
         case fixedSize(Int)

--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestFramingMetadata.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestFramingMetadata.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-struct RequestFramingMetadata {
-    enum Body {
+struct RequestFramingMetadata: Equatable {
+    enum Body: Equatable {
         case none
         case stream
         case fixedSize(Int)

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -313,11 +313,6 @@ extension HTTPClient {
 
             let metadata = try head.headers.validate(method: self.method, body: self.body)
 
-            // This assert can go away when (if ever!) the above `if` correctly handles other HTTP versions. For example
-            // in HTTP/1.0, we need to treat the absence of a 'connection: keep-alive' as a close too.
-            assert(head.version == HTTPVersion(major: 1, minor: 1),
-                   "Sending a request in HTTP version \(head.version) which is unsupported by the above `if`")
-
             return (head, metadata)
         }
     }

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -293,6 +293,33 @@ extension HTTPClient {
         public var port: Int {
             return self.url.port ?? (self.useTLS ? 443 : 80)
         }
+
+        func createRequestHead() throws -> (HTTPRequestHead, RequestFramingMetadata) {
+            var head = HTTPRequestHead(
+                version: .http1_1,
+                method: self.method,
+                uri: self.uri,
+                headers: self.headers
+            )
+
+            if !head.headers.contains(name: "host") {
+                let port = self.port
+                var host = self.host
+                if !(port == 80 && self.scheme == "http"), !(port == 443 && self.scheme == "https") {
+                    host += ":\(port)"
+                }
+                head.headers.add(name: "host", value: host)
+            }
+
+            let metadata = try head.headers.validate(method: self.method, body: self.body)
+
+            // This assert can go away when (if ever!) the above `if` correctly handles other HTTP versions. For example
+            // in HTTP/1.0, we need to treat the absence of a 'connection: keep-alive' as a close too.
+            assert(head.version == HTTPVersion(major: 1, minor: 1),
+                   "Sending a request in HTTP version \(head.version) which is unsupported by the above `if`")
+
+            return (head, metadata)
+        }
     }
 
     /// Represent HTTP response.
@@ -877,46 +904,29 @@ extension TaskHandler: ChannelDuplexHandler {
     typealias OutboundOut = HTTPClientRequestPart
 
     func write(context: ChannelHandlerContext, data: NIOAny, promise: EventLoopPromise<Void>?) {
+        let request = self.unwrapOutboundIn(data)
         self.state = .sendingBodyWaitingResponseHead
 
-        let request = self.unwrapOutboundIn(data)
-
-        var head = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
-                                   method: request.method,
-                                   uri: request.uri)
-        var headers = request.headers
-
-        if !request.headers.contains(name: "host") {
-            let port = request.port
-            var host = request.host
-            if !(port == 80 && request.scheme == "http"), !(port == 443 && request.scheme == "https") {
-                host += ":\(port)"
-            }
-            headers.add(name: "host", value: host)
-        }
+        let head: HTTPRequestHead
+        let metadata: RequestFramingMetadata
 
         do {
-            try headers.validate(method: request.method, body: request.body)
+            (head, metadata) = try request.createRequestHead()
         } catch {
             self.errorCaught(context: context, error: error)
             promise?.fail(error)
             return
         }
 
-        head.headers = headers
-
-        if head.headers[canonicalForm: "connection"].map({ $0.lowercased() }).contains("close") {
-            self.closing = true
-        }
         // This assert can go away when (if ever!) the above `if` correctly handles other HTTP versions. For example
         // in HTTP/1.0, we need to treat the absence of a 'connection: keep-alive' as a close too.
-        assert(head.version == HTTPVersion(major: 1, minor: 1),
+        assert(head.version == .http1_1,
                "Sending a request in HTTP version \(head.version) which is unsupported by the above `if`")
 
-        let contentLengths = head.headers[canonicalForm: "content-length"]
-        assert(contentLengths.count <= 1)
-
-        self.expectedBodyLength = contentLengths.first.flatMap { Int($0) }
+        if case .fixedSize(let length) = metadata.body {
+            self.expectedBodyLength = length
+        }
+        self.closing = metadata.connectionClose
 
         context.write(wrapOutboundOut(.head(head))).map {
             self.callOutToDelegateFireAndForget(value: head, self.delegate.didSendRequestHead)

--- a/Sources/AsyncHTTPClient/RequestValidation.swift
+++ b/Sources/AsyncHTTPClient/RequestValidation.swift
@@ -19,7 +19,7 @@ extension HTTPHeaders {
     mutating func validate(method: HTTPMethod, body: HTTPClient.Body?) throws -> RequestFramingMetadata {
         var metadata = RequestFramingMetadata(connectionClose: false, body: .none)
 
-        if self[canonicalForm: "connection"].map({ $0.lowercased() }).contains("close") {
+        if self[canonicalForm: "connection"].lazy.map({ $0.lowercased() }).contains("close") {
             metadata.connectionClose = true
         }
 

--- a/Tests/AsyncHTTPClientTests/RequestBagTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests.swift
@@ -53,9 +53,10 @@ final class RequestBagTests: XCTestCase {
         var maybeRequest: HTTPClient.Request?
         XCTAssertNoThrow(maybeRequest = try HTTPClient.Request(url: "https://swift.org", method: .POST, body: requestBody))
         guard let request = maybeRequest else { return XCTFail("Expected to have a request") }
-
         let delegate = UploadCountingDelegate(eventLoop: embeddedEventLoop)
-        let bag = RequestBag(
+
+        var maybeRequestBag: RequestBag<UploadCountingDelegate>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
             request: request,
             eventLoopPreference: .delegate(on: embeddedEventLoop),
             task: .init(eventLoop: embeddedEventLoop, logger: logger),
@@ -63,7 +64,9 @@ final class RequestBagTests: XCTestCase {
             connectionDeadline: .now() + .seconds(30),
             idleReadTimeout: nil,
             delegate: delegate
-        )
+        ))
+        guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
+
         XCTAssert(bag.task.eventLoop === embeddedEventLoop)
 
         let executor = MockRequestExecutor(pauseRequestBodyPartStreamAfterASingleWrite: true)
@@ -161,7 +164,8 @@ final class RequestBagTests: XCTestCase {
         guard let request = maybeRequest else { return XCTFail("Expected to have a request") }
 
         let delegate = UploadCountingDelegate(eventLoop: embeddedEventLoop)
-        let bag = RequestBag(
+        var maybeRequestBag: RequestBag<UploadCountingDelegate>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
             request: request,
             eventLoopPreference: .delegate(on: embeddedEventLoop),
             task: .init(eventLoop: embeddedEventLoop, logger: logger),
@@ -169,7 +173,8 @@ final class RequestBagTests: XCTestCase {
             connectionDeadline: .now() + .seconds(30),
             idleReadTimeout: nil,
             delegate: delegate
-        )
+        ))
+        guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
         XCTAssert(bag.task.eventLoop === embeddedEventLoop)
 
         let executor = MockRequestExecutor()
@@ -202,7 +207,8 @@ final class RequestBagTests: XCTestCase {
         guard let request = maybeRequest else { return XCTFail("Expected to have a request") }
 
         let delegate = UploadCountingDelegate(eventLoop: embeddedEventLoop)
-        let bag = RequestBag(
+        var maybeRequestBag: RequestBag<UploadCountingDelegate>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
             request: request,
             eventLoopPreference: .delegate(on: embeddedEventLoop),
             task: .init(eventLoop: embeddedEventLoop, logger: logger),
@@ -210,7 +216,8 @@ final class RequestBagTests: XCTestCase {
             connectionDeadline: .now() + .seconds(30),
             idleReadTimeout: nil,
             delegate: delegate
-        )
+        ))
+        guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
         XCTAssert(bag.eventLoop === embeddedEventLoop)
 
         let executor = MockRequestExecutor()
@@ -233,7 +240,8 @@ final class RequestBagTests: XCTestCase {
         guard let request = maybeRequest else { return XCTFail("Expected to have a request") }
 
         let delegate = UploadCountingDelegate(eventLoop: embeddedEventLoop)
-        let bag = RequestBag(
+        var maybeRequestBag: RequestBag<UploadCountingDelegate>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
             request: request,
             eventLoopPreference: .delegate(on: embeddedEventLoop),
             task: .init(eventLoop: embeddedEventLoop, logger: logger),
@@ -241,7 +249,8 @@ final class RequestBagTests: XCTestCase {
             connectionDeadline: .now() + .seconds(30),
             idleReadTimeout: nil,
             delegate: delegate
-        )
+        ))
+        guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
         XCTAssert(bag.eventLoop === embeddedEventLoop)
 
         let executor = MockRequestExecutor()
@@ -273,7 +282,8 @@ final class RequestBagTests: XCTestCase {
         guard let request = maybeRequest else { return XCTFail("Expected to have a request") }
 
         let delegate = UploadCountingDelegate(eventLoop: embeddedEventLoop)
-        let bag = RequestBag(
+        var maybeRequestBag: RequestBag<UploadCountingDelegate>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
             request: request,
             eventLoopPreference: .delegate(on: embeddedEventLoop),
             task: .init(eventLoop: embeddedEventLoop, logger: logger),
@@ -281,7 +291,8 @@ final class RequestBagTests: XCTestCase {
             connectionDeadline: .now() + .seconds(30),
             idleReadTimeout: nil,
             delegate: delegate
-        )
+        ))
+        guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
 
         let queuer = MockTaskQueuer()
         bag.requestWasQueued(queuer)
@@ -328,7 +339,8 @@ final class RequestBagTests: XCTestCase {
         guard let request = maybeRequest else { return XCTFail("Expected to have a request") }
 
         let delegate = UploadCountingDelegate(eventLoop: embeddedEventLoop)
-        let bag = RequestBag(
+        var maybeRequestBag: RequestBag<UploadCountingDelegate>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
             request: request,
             eventLoopPreference: .delegate(on: embeddedEventLoop),
             task: .init(eventLoop: embeddedEventLoop, logger: logger),
@@ -336,7 +348,8 @@ final class RequestBagTests: XCTestCase {
             connectionDeadline: .now() + .seconds(30),
             idleReadTimeout: nil,
             delegate: delegate
-        )
+        ))
+        guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
 
         let executor = MockRequestExecutor()
         bag.willExecuteRequest(executor)

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
@@ -32,6 +32,8 @@ extension RequestValidationTests {
             ("testGET_HEAD_DELETE_CONNECTRequestCanHaveBody", testGET_HEAD_DELETE_CONNECTRequestCanHaveBody),
             ("testInvalidHeaderFieldNames", testInvalidHeaderFieldNames),
             ("testValidHeaderFieldNames", testValidHeaderFieldNames),
+            ("testMetadataDetectConnectionClose", testMetadataDetectConnectionClose),
+            ("testMetadataDefaultIsConnectionCloseIsFalse", testMetadataDefaultIsConnectionCloseIsFalse),
             ("testNoHeadersNoBody", testNoHeadersNoBody),
             ("testNoHeadersHasBody", testNoHeadersHasBody),
             ("testContentLengthHeaderNoBody", testContentLengthHeaderNoBody),


### PR DESCRIPTION
### Motivation

Currently the request validation (mainly checking for correct headers is sprinkled around). This makes reuse in new code hard.

### Changes

- Refactored code from `TaskHandler` into new method `HTTPClient.Request.createRequestHead` that creates an `HTTPRequestHead` and matching `RequestFramingMetadata`
- Added required property `requestFramingMetadata` to `HTTPExecutingRequest`
- Added property `requestFramingMetadata` to `RequestBag`