### PR TITLE
HTTPSchedulableRequest requires HTTPExecutableRequest 

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Waiter.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Waiter.swift
@@ -18,7 +18,7 @@ extension HTTPConnectionPool {
     struct RequestID: Hashable {
         private let objectIdentifier: ObjectIdentifier
 
-        init(_ request: HTTPScheduledRequest) {
+        init(_ request: HTTPSchedulableRequest) {
             self.objectIdentifier = ObjectIdentifier(request)
         }
     }
@@ -28,7 +28,7 @@ extension HTTPConnectionPool {
             RequestID(self.request)
         }
 
-        var request: HTTPScheduledRequest
+        var request: HTTPSchedulableRequest
 
         private var eventLoopRequirement: EventLoop? {
             switch self.request.eventLoopPreference.preference {
@@ -41,7 +41,7 @@ extension HTTPConnectionPool {
             }
         }
 
-        init(request: HTTPScheduledRequest) {
+        init(request: HTTPSchedulableRequest) {
             self.request = request
         }
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -70,7 +70,7 @@ enum HTTPConnectionPool {
             }
         }
 
-        fileprivate func execute(request: HTTPExecutingRequest) {
+        fileprivate func execute(request: HTTPExecutableRequest) {
             switch self._ref {
 //            case .http1_1(let connection):
 //                return connection.execute(request: request)

--- a/Sources/AsyncHTTPClient/RequestBag.swift
+++ b/Sources/AsyncHTTPClient/RequestBag.swift
@@ -312,7 +312,7 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
     }
 }
 
-extension RequestBag: HTTPScheduledRequest {
+extension RequestBag: HTTPSchedulableRequest {
     func requestWasQueued(_ scheduler: HTTPRequestScheduler) {
         if self.task.eventLoop.inEventLoop {
             self.requestWasQueued0(scheduler)
@@ -334,7 +334,7 @@ extension RequestBag: HTTPScheduledRequest {
     }
 }
 
-extension RequestBag: HTTPExecutingRequest {
+extension RequestBag: HTTPExecutableRequest {
     func willExecuteRequest(_ executor: HTTPRequestExecutor) {
         if self.task.eventLoop.inEventLoop {
             self.willExecuteRequest0(executor)

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+WaiterTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+WaiterTests.swift
@@ -15,6 +15,7 @@
 @testable import AsyncHTTPClient
 import Logging
 import NIO
+import NIOHTTP1
 import XCTest
 
 class HTTPConnectionPool_WaiterTests: XCTestCase {
@@ -44,7 +45,7 @@ class HTTPConnectionPool_WaiterTests: XCTestCase {
     }
 }
 
-private class MockScheduledRequest: HTTPScheduledRequest {
+private class MockScheduledRequest: HTTPSchedulableRequest {
     init(eventLoopPreference: HTTPClient.EventLoopPreference) {
         self.eventLoopPreference = eventLoopPreference
     }
@@ -58,6 +59,40 @@ private class MockScheduledRequest: HTTPScheduledRequest {
     }
 
     func fail(_: Error) {
+        preconditionFailure("Unimplemented")
+    }
+
+    // MARK: HTTPExecutableRequest
+
+    var requestHead: HTTPRequestHead { preconditionFailure("Unimplemented") }
+    var requestFramingMetadata: RequestFramingMetadata { preconditionFailure("Unimplemented") }
+    var idleReadTimeout: TimeAmount? { preconditionFailure("Unimplemented") }
+
+    func willExecuteRequest(_: HTTPRequestExecutor) {
+        preconditionFailure("Unimplemented")
+    }
+
+    func requestHeadSent() {
+        preconditionFailure("Unimplemented")
+    }
+
+    func resumeRequestBodyStream() {
+        preconditionFailure("Unimplemented")
+    }
+
+    func pauseRequestBodyStream() {
+        preconditionFailure("Unimplemented")
+    }
+
+    func receiveResponseHead(_: HTTPResponseHead) {
+        preconditionFailure("Unimplemented")
+    }
+
+    func receiveResponseBodyParts(_: CircularBuffer<ByteBuffer>) {
+        preconditionFailure("Unimplemented")
+    }
+
+    func succeedRequest(_: CircularBuffer<ByteBuffer>?) {
         preconditionFailure("Unimplemented")
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestBagTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests.swift
@@ -402,22 +402,22 @@ class MockRequestExecutor: HTTPRequestExecutor {
     // this should always be called twice. When we receive the first call, the next call to produce
     // data is already scheduled. If we call pause here, once, after the second call new subsequent
     // calls should not be scheduled.
-    func writeRequestBodyPart(_ part: IOData, request: HTTPExecutingRequest) {
+    func writeRequestBodyPart(_ part: IOData, request: HTTPExecutableRequest) {
         if self.requestBodyParts.isEmpty, self.pauseRequestBodyPartStreamAfterASingleWrite {
             request.pauseRequestBodyStream()
         }
         self.requestBodyParts.append(.body(part))
     }
 
-    func finishRequestBodyStream(_: HTTPExecutingRequest) {
+    func finishRequestBodyStream(_: HTTPExecutableRequest) {
         self.requestBodyParts.append(.endOfStream)
     }
 
-    func demandResponseBodyStream(_: HTTPExecutingRequest) {
+    func demandResponseBodyStream(_: HTTPExecutableRequest) {
         self.signalledDemandForResponseBody = true
     }
 
-    func cancelRequest(_: HTTPExecutingRequest) {
+    func cancelRequest(_: HTTPExecutableRequest) {
         self.isCancelled = true
     }
 }
@@ -490,7 +490,7 @@ class MockTaskQueuer: HTTPRequestScheduler {
 
     init() {}
 
-    func cancelRequest(_: HTTPScheduledRequest) {
+    func cancelRequest(_: HTTPSchedulableRequest) {
         self.hitCancelCount += 1
     }
 }


### PR DESCRIPTION
### Motivation

Scheduling a request on the new `ConnectionPool` will require a request to be schedulable _and_ executable. In fact there should never be a request that is schedulable but not executable. For that reason the renamed `HTTPSchedulableRequest` depends on `HTTPExecutableRequest`.

### Changes

- Rename: `HTTPExecutingRequest` -> `HTTPExecutableRequest`
- Rename: `HTTPSchedulableRequest` -> `HTTPScheduledRequest`
- `HTTPSchedulableRequest` requires `HTTPExecutableRequest`