### PR TITLE
Fix CI for Swift 5.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools 
 RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev build-essential
 # switch of gem docs building
 RUN echo "gem: --no-document" > ~/.gemrc
-RUN if [ "${ubuntu_version}" != "xenial" ] ; then gem install jazzy ; fi
+RUN if [ "${ubuntu_version}" != "xenial" ] ; then gem install jazzy -v 0.13.7 ; fi
 
 # tools
 RUN mkdir -p $HOME/.tools


### PR DESCRIPTION
### Motivation

The Swift 5.3 CI currently fails with the error:

```bash
ERROR:  Error installing jazzy:
	The last version of jazzy (>= 0) to support your Ruby & RubyGems was 0.13.7. Try installing it with `gem install jazzy -v 0.13.7`
	jazzy requires Ruby version >= 2.6.3. The current ruby version is 2.5.0.
```

Example log: https://ci.swiftserver.group/job/async-http-client-swift53-prb/338/console

### Changes

- Explicitly set jazzy version number

### Result

Happy Swift 5.3 CI