### PR TITLE
Add missing availability to APIs requiring macOS 10.15 / iOS 13.0

### DIFF
--- a/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
@@ -22,6 +22,7 @@
 
     extension TLSVersion {
         /// return Network framework TLS protocol version
+        @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
         var nwTLSProtocolVersion: tls_protocol_version_t {
             switch self {
             case .tlsv1:


### PR DESCRIPTION
tls_protocol_version_t was introduced in macOS 10.15 / iOS 13.0, so we need to annotate it with proper availability.