### PR TITLE
Ensure the HTTPConnectionPool calls shutdown on active connections.

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -235,7 +235,7 @@ final class HTTPConnectionPool {
             }
 
             for connection in cleanupContext.cancel {
-                connection.close(promise: nil)
+                connection.shutdown()
             }
 
             for connectionID in cleanupContext.connectBackoff {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests+XCTest.swift
@@ -31,6 +31,7 @@ extension HTTPConnectionPoolTests {
             ("testConnectionCreationIsRetriedUntilRequestIsFailed", testConnectionCreationIsRetriedUntilRequestIsFailed),
             ("testConnectionCreationIsRetriedUntilPoolIsShutdown", testConnectionCreationIsRetriedUntilPoolIsShutdown),
             ("testConnectionCreationIsRetriedUntilRequestIsCancelled", testConnectionCreationIsRetriedUntilRequestIsCancelled),
+            ("testConnectionShutdownIsCalledOnActiveConnections", testConnectionShutdownIsCalledOnActiveConnections),
         ]
     }
 }


### PR DESCRIPTION
### Motivation

Currently active connections are just closed on shutdown. We expect running requests to be cancelled though.

### Changes

- Trigger the correct method on `HTTPConnectionPool.Connection` to cancel the request and close the connection then
- Add a test

### Result

A better behaving http client.