### PR TITLE
Add tests to observe HTTP/1.1 connection closures

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP1ClientChannelHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ClientChannelHandlerTests.swift
@@ -465,18 +465,3 @@ class ReadEventHitHandler: ChannelOutboundHandler {
         context.read()
     }
 }
-
-class MockConnectionDelegate: HTTP1ConnectionDelegate {
-    private(set) var hitConnectionReleased = 0
-    private(set) var hitConnectionClosed = 0
-
-    init() {}
-
-    func http1ConnectionReleased(_: HTTP1Connection) {
-        self.hitConnectionReleased += 1
-    }
-
-    func http1ConnectionClosed(_: HTTP1Connection) {
-        self.hitConnectionClosed += 1
-    }
-}

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests+XCTest.swift
@@ -30,6 +30,8 @@ extension HTTP1ConnectionTests {
             ("testCreateNewConnectionFailureClosedIO", testCreateNewConnectionFailureClosedIO),
             ("testGETRequest", testGETRequest),
             ("testConnectionClosesOnCloseHeader", testConnectionClosesOnCloseHeader),
+            ("testConnectionClosesOnRandomlyAppearingCloseHeader", testConnectionClosesOnRandomlyAppearingCloseHeader),
+            ("testConnectionClosesAfterTheRequestWithoutHavingSentAnCloseHeader", testConnectionClosesAfterTheRequestWithoutHavingSentAnCloseHeader),
         ]
     }
 }


### PR DESCRIPTION
### Motivation

There are a number of tests in `HTTPClientInternalTest` that are hard to reproduce after the refactor. The current implementation has a number of (`internal`) properties that will be removed with the refactor. For example there is a way to access the underlying channel from a request today. We don't want to expose those things in a new implementation. But we want to test at least the same things. For this reason I added some tests around sudden HTTP/1.1 connection closures that we want to use going forward.

### Changes

- Moved `MockConnectionDelegate` to HTTP1ConnectionTests.swift, where it is actually used.
- Added tests around sudden connection closures

### Result

Easier test after the implementation has been switched over.