### PR TITLE
HTTP1Connection: Close on error while in request

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1.1/HTTP1ConnectionStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1.1/HTTP1ConnectionStateMachine.swift
@@ -117,10 +117,10 @@ struct HTTP1ConnectionStateMachine {
             self.state = .closed
             return .fireChannelError(error, closeConnection: false)
 
-        case .inRequest(var requestStateMachine, close: _):
+        case .inRequest(var requestStateMachine, close: let close):
             return self.avoidingStateMachineCoW { state -> Action in
                 let action = requestStateMachine.errorHappened(error)
-                state = .closed
+                state = .inRequest(requestStateMachine, close: close)
                 return state.modify(with: action)
             }
 

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests+XCTest.swift
@@ -37,6 +37,7 @@ extension HTTP1ConnectionStateMachineTests {
             ("testReadsAreForwardedIfConnectionIsClosing", testReadsAreForwardedIfConnectionIsClosing),
             ("testChannelReadsAreIgnoredIfConnectionIsClosing", testChannelReadsAreIgnoredIfConnectionIsClosing),
             ("testRequestIsCancelledWhileWaitingForWritable", testRequestIsCancelledWhileWaitingForWritable),
+            ("testConnectionIsClosedIfErrorHappensWhileInRequest", testConnectionIsClosedIfErrorHappensWhileInRequest),
         ]
     }
 }


### PR DESCRIPTION
### Motivation

In the `HTTP1ConnectionStateMachine` we set the connection state to `.closed` after having forwarded an error to the inner RequestStateMachine. Since we set the error to close, the `state.modify` function did not create an action that would close the connection.

### Changes

- Modify the ConnectionState based on the RequestStateMachine only in the `state.modify` function.
- Add a test to verify the fixed behavior.
- Use ExpressibleByDictionaryLiteral syntax for some HTTPHeaders to increase readability.

### Result

Connections are closed, if an error happens, while we are in a request.