### PR TITLE
Add logging to the new HTTPConnectionPool

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -124,7 +124,7 @@ final class ConnectionPool {
     /// A key is initialized from a `URL`, it uses the components to derive a hashed value
     /// used by the `providers` dictionary to allow retrieving and creating
     /// connection providers associated to a certain request in constant time.
-    struct Key: Hashable {
+    struct Key: Hashable, CustomStringConvertible {
         init(_ request: HTTPClient.Request) {
             switch request.scheme {
             case "http":
@@ -178,6 +178,19 @@ final class ConnectionPool {
                 config.tlsConfiguration = tlsConfiguration.base
             }
             return config
+        }
+
+        var description: String {
+            var hasher = Hasher()
+            self.tlsConfiguration?.hash(into: &hasher)
+            let hash = hasher.finalize()
+            var path = ""
+            if self.unixPath != "" {
+                path = self.unixPath
+            } else {
+                path = "\(self.host):\(self.port)"
+            }
+            return "\(self.scheme)://\(path) TLS-hash: \(hash)"
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -65,7 +65,7 @@ extension HTTPConnectionPool.ConnectionFactory {
         logger: Logger
     ) {
         var logger = logger
-        logger[metadataKey: "ahc-connection"] = "\(connectionID)"
+        logger[metadataKey: "ahc-connection-id"] = "\(connectionID)"
 
         self.makeChannel(connectionID: connectionID, deadline: deadline, eventLoop: eventLoop, logger: logger).whenComplete { result in
             switch result {

--- a/Sources/AsyncHTTPClient/RequestBag.swift
+++ b/Sources/AsyncHTTPClient/RequestBag.swift
@@ -73,6 +73,8 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
     }
 
     private func requestWasQueued0(_ scheduler: HTTPRequestScheduler) {
+        self.logger.debug("Request was queued (waiting for a connection to become available)")
+
         self.task.eventLoop.assertInEventLoop()
         self.state.requestWasQueued(scheduler)
     }


### PR DESCRIPTION
### Motivation

To debug the new `HTTPConnectionPool` and `Connections`, it would be great to get a rather complete event story.

### Changes

- Added a number of trace logs
- Added a nicer debug output for `Connection.Key`

### Result

A better debuggable AHC client.