### PR TITLE
ChannelRead because of closing connection: Remove preconditions

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine+Demand.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine+Demand.swift
@@ -50,7 +50,7 @@ extension HTTPRequestStateMachine {
                 self.state = .modifying
                 buffer.append(body)
                 self.state = .waitingForBytes(buffer)
-                
+
             case .modifying:
                 preconditionFailure("Invalid state: \(self.state)")
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
@@ -523,12 +523,22 @@ struct HTTPRequestStateMachine {
             where head.status.code < 300:
 
             return self.avoidingStateMachineCoW { state -> Action in
-                let (remainingBuffer, _) = responseStreamState.end()
-                state = .running(
-                    .streaming(expectedBodyLength: expectedBodyLength, sentBodyBytes: sentBodyBytes, producer: producerState),
-                    .endReceived
-                )
-                return .forwardResponseBodyParts(remainingBuffer)
+                let (remainingBuffer, connectionAction) = responseStreamState.end()
+                switch connectionAction {
+                case .none:
+                    state = .running(
+                        .streaming(expectedBodyLength: expectedBodyLength, sentBodyBytes: sentBodyBytes, producer: producerState),
+                        .endReceived
+                    )
+                    return .forwardResponseBodyParts(remainingBuffer)
+                case .close:
+                    // If we receive a `.close` as a connectionAction from the responseStreamState
+                    // this means, that the response end was signaled by a connection close. Since
+                    // the request is still uploading, we will not be able to finish the upload. For
+                    // this reason we can fail the request here.
+                    state = .failed(HTTPClientError.remoteConnectionClosed)
+                    return .failRequest(HTTPClientError.remoteConnectionClosed, .close)
+                }
             }
 
         case .running(.streaming(_, _, let producerState), .receivingBody(let head, var responseStreamState)):
@@ -536,6 +546,8 @@ struct HTTPRequestStateMachine {
             assert(producerState == .paused, "Expected to have paused the request body stream, when the head was received. Invalid state: \(self.state)")
 
             return self.avoidingStateMachineCoW { state -> Action in
+                // We can ignore the connectionAction from the responseStreamState, since the
+                // connection should be closed anyway.
                 let (remainingBuffer, _) = responseStreamState.end()
                 state = .finished
                 return .succeedRequest(.close, remainingBuffer)

--- a/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests+XCTest.swift
@@ -52,6 +52,7 @@ extension HTTPRequestStateMachineTests {
             ("testErrorWhileRunningARequestClosesTheStream", testErrorWhileRunningARequestClosesTheStream),
             ("testCanReadHTTP1_0ResponseWithoutBody", testCanReadHTTP1_0ResponseWithoutBody),
             ("testCanReadHTTP1_0ResponseWithBody", testCanReadHTTP1_0ResponseWithBody),
+            ("testFailHTTP1_0RequestThatIsStillUploading", testFailHTTP1_0RequestThatIsStillUploading),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests+XCTest.swift
@@ -50,6 +50,8 @@ extension HTTPRequestStateMachineTests {
             ("testReadTimeoutThatFiresToLateIsIgnored", testReadTimeoutThatFiresToLateIsIgnored),
             ("testCancellationThatIsInvokedToLateIsIgnored", testCancellationThatIsInvokedToLateIsIgnored),
             ("testErrorWhileRunningARequestClosesTheStream", testErrorWhileRunningARequestClosesTheStream),
+            ("testCanReadHTTP1_0ResponseWithoutBody", testCanReadHTTP1_0ResponseWithoutBody),
+            ("testCanReadHTTP1_0ResponseWithBody", testCanReadHTTP1_0ResponseWithBody),
         ]
     }
 }


### PR DESCRIPTION
### Motivation

NIO may send `channelRead` events without a handlers requesting more data with a `context.read()` invocation. This happens if the remote has closed the connection and NIO wants to inform the handlers as soon as possible.

### Changes

- Don't `precondition` on `channelRead` events anymore.
- Close channel if we received an http end without a `context.read()` invocation