### PR TITLE
Fix HTTP/1.0 support

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1.1/HTTP1ConnectionStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1.1/HTTP1ConnectionStateMachine.swift
@@ -256,7 +256,7 @@ struct HTTP1ConnectionStateMachine {
                 let action = requestStateMachine.channelRead(part)
 
                 if case .head(let head) = part, close == false {
-                    close = head.headers[canonicalForm: "connection"].contains(where: { $0.lowercased() == "close" })
+                    close = !head.isKeepAlive
                 }
                 state = .inRequest(requestStateMachine, close: close)
                 return state.modify(with: action)

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests+XCTest.swift
@@ -28,6 +28,8 @@ extension HTTP1ConnectionStateMachineTests {
             ("testPOSTRequestWithWriteAndReadBackpressure", testPOSTRequestWithWriteAndReadBackpressure),
             ("testResponseReadingWithBackpressure", testResponseReadingWithBackpressure),
             ("testAConnectionCloseHeaderInTheRequestLeadsToConnectionCloseAfterRequest", testAConnectionCloseHeaderInTheRequestLeadsToConnectionCloseAfterRequest),
+            ("testAHTTP1_0ResponseWithoutKeepAliveHeaderLeadsToConnectionCloseAfterRequest", testAHTTP1_0ResponseWithoutKeepAliveHeaderLeadsToConnectionCloseAfterRequest),
+            ("testAHTTP1_0ResponseWithKeepAliveHeaderLeadsToConnectionBeingKeptAlive", testAHTTP1_0ResponseWithKeepAliveHeaderLeadsToConnectionBeingKeptAlive),
             ("testAConnectionCloseHeaderInTheResponseLeadsToConnectionCloseAfterRequest", testAConnectionCloseHeaderInTheResponseLeadsToConnectionCloseAfterRequest),
             ("testNIOTriggersChannelActiveTwice", testNIOTriggersChannelActiveTwice),
             ("testIdleConnectionBecomesInactive", testIdleConnectionBecomesInactive),


### PR DESCRIPTION
### Motivation

Currently we don't close connections if we receive an HTTP/1.0 response but no keep-alive header.

### Changes

- Use `HTTPResponseHead.isKeepAlive` instead of relying on our own test
- Add tests

### Result

Happy HTTP/1.0 communication.