### PR TITLE
[HTTPConnectionPool] Move Connections down in the file

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -22,113 +22,6 @@ protocol HTTPConnectionPoolDelegate {
 }
 
 final class HTTPConnectionPool {
-    struct Connection: Hashable {
-        typealias ID = Int
-
-        private enum Reference {
-            case http1_1(HTTP1Connection)
-            case http2(HTTP2Connection)
-            case __testOnly_connection(ID, EventLoop)
-        }
-
-        private let _ref: Reference
-
-        fileprivate static func http1_1(_ conn: HTTP1Connection) -> Self {
-            Connection(_ref: .http1_1(conn))
-        }
-
-        fileprivate static func http2(_ conn: HTTP2Connection) -> Self {
-            Connection(_ref: .http2(conn))
-        }
-
-        static func __testOnly_connection(id: ID, eventLoop: EventLoop) -> Self {
-            Connection(_ref: .__testOnly_connection(id, eventLoop))
-        }
-
-        var id: ID {
-            switch self._ref {
-            case .http1_1(let connection):
-                return connection.id
-            case .http2(let connection):
-                return connection.id
-            case .__testOnly_connection(let id, _):
-                return id
-            }
-        }
-
-        var eventLoop: EventLoop {
-            switch self._ref {
-            case .http1_1(let connection):
-                return connection.channel.eventLoop
-            case .http2(let connection):
-                return connection.channel.eventLoop
-            case .__testOnly_connection(_, let eventLoop):
-                return eventLoop
-            }
-        }
-
-        fileprivate func executeRequest(_ request: HTTPExecutableRequest) {
-            switch self._ref {
-            case .http1_1(let connection):
-                return connection.executeRequest(request)
-            case .http2(let connection):
-                return connection.executeRequest(request)
-            case .__testOnly_connection:
-                break
-            }
-        }
-
-        /// Shutdown cancels any running requests on the connection and then closes the connection
-        fileprivate func shutdown() {
-            switch self._ref {
-            case .http1_1(let connection):
-                return connection.shutdown()
-            case .http2(let connection):
-                return connection.shutdown()
-            case .__testOnly_connection:
-                break
-            }
-        }
-
-        /// Closes the connection without cancelling running requests. Use this when you are sure, that the
-        /// connection is currently idle.
-        fileprivate func close(promise: EventLoopPromise<Void>?) {
-            switch self._ref {
-            case .http1_1(let connection):
-                return connection.close(promise: promise)
-            case .http2(let connection):
-                return connection.close(promise: promise)
-            case .__testOnly_connection:
-                promise?.succeed(())
-            }
-        }
-
-        static func == (lhs: HTTPConnectionPool.Connection, rhs: HTTPConnectionPool.Connection) -> Bool {
-            switch (lhs._ref, rhs._ref) {
-            case (.http1_1(let lhsConn), .http1_1(let rhsConn)):
-                return lhsConn.id == rhsConn.id
-            case (.http2(let lhsConn), .http2(let rhsConn)):
-                return lhsConn.id == rhsConn.id
-            case (.__testOnly_connection(let lhsID, let lhsEventLoop), .__testOnly_connection(let rhsID, let rhsEventLoop)):
-                return lhsID == rhsID && lhsEventLoop === rhsEventLoop
-            default:
-                return false
-            }
-        }
-
-        func hash(into hasher: inout Hasher) {
-            switch self._ref {
-            case .http1_1(let conn):
-                hasher.combine(conn.id)
-            case .http2(let conn):
-                hasher.combine(conn.id)
-            case .__testOnly_connection(let id, let eventLoop):
-                hasher.combine(id)
-                hasher.combine(eventLoop.id)
-            }
-        }
-    }
-
     private let stateLock = Lock()
     private var _state: StateMachine
 
@@ -527,6 +420,115 @@ extension HTTPConnectionPool: HTTPRequestScheduler {
             self._state.cancelRequest(requestID)
         }
         self.run(action: action)
+    }
+}
+
+extension HTTPConnectionPool {
+    struct Connection: Hashable {
+        typealias ID = Int
+
+        private enum Reference {
+            case http1_1(HTTP1Connection)
+            case http2(HTTP2Connection)
+            case __testOnly_connection(ID, EventLoop)
+        }
+
+        private let _ref: Reference
+
+        fileprivate static func http1_1(_ conn: HTTP1Connection) -> Self {
+            Connection(_ref: .http1_1(conn))
+        }
+
+        fileprivate static func http2(_ conn: HTTP2Connection) -> Self {
+            Connection(_ref: .http2(conn))
+        }
+
+        static func __testOnly_connection(id: ID, eventLoop: EventLoop) -> Self {
+            Connection(_ref: .__testOnly_connection(id, eventLoop))
+        }
+
+        var id: ID {
+            switch self._ref {
+            case .http1_1(let connection):
+                return connection.id
+            case .http2(let connection):
+                return connection.id
+            case .__testOnly_connection(let id, _):
+                return id
+            }
+        }
+
+        var eventLoop: EventLoop {
+            switch self._ref {
+            case .http1_1(let connection):
+                return connection.channel.eventLoop
+            case .http2(let connection):
+                return connection.channel.eventLoop
+            case .__testOnly_connection(_, let eventLoop):
+                return eventLoop
+            }
+        }
+
+        fileprivate func executeRequest(_ request: HTTPExecutableRequest) {
+            switch self._ref {
+            case .http1_1(let connection):
+                return connection.executeRequest(request)
+            case .http2(let connection):
+                return connection.executeRequest(request)
+            case .__testOnly_connection:
+                break
+            }
+        }
+
+        /// Shutdown cancels any running requests on the connection and then closes the connection
+        fileprivate func shutdown() {
+            switch self._ref {
+            case .http1_1(let connection):
+                return connection.shutdown()
+            case .http2(let connection):
+                return connection.shutdown()
+            case .__testOnly_connection:
+                break
+            }
+        }
+
+        /// Closes the connection without cancelling running requests. Use this when you are sure, that the
+        /// connection is currently idle.
+        fileprivate func close(promise: EventLoopPromise<Void>?) {
+            switch self._ref {
+            case .http1_1(let connection):
+                return connection.close(promise: promise)
+            case .http2(let connection):
+                return connection.close(promise: promise)
+            case .__testOnly_connection:
+                promise?.succeed(())
+            }
+        }
+
+        static func == (lhs: HTTPConnectionPool.Connection, rhs: HTTPConnectionPool.Connection) -> Bool {
+            switch (lhs._ref, rhs._ref) {
+            case (.http1_1(let lhsConn), .http1_1(let rhsConn)):
+                return lhsConn.id == rhsConn.id
+            case (.http2(let lhsConn), .http2(let rhsConn)):
+                return lhsConn.id == rhsConn.id
+            case (.__testOnly_connection(let lhsID, let lhsEventLoop), .__testOnly_connection(let rhsID, let rhsEventLoop)):
+                return lhsID == rhsID && lhsEventLoop === rhsEventLoop
+            default:
+                return false
+            }
+        }
+
+        func hash(into hasher: inout Hasher) {
+            switch self._ref {
+            case .http1_1(let conn):
+                hasher.combine(conn.id)
+            case .http2(let conn):
+                hasher.combine(conn.id)
+            case .__testOnly_connection(let id, let eventLoop):
+                hasher.combine(id)
+                hasher.combine(eventLoop.id)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Just a reorder within the `HTTPConnectionPool.swift` file. We have an internal type that doesn't need to be in the top of the file. 

### Result

Improved readability by moving less important stuff down.