### PR TITLE
Use release version of 5.5 in CI

### DIFF
--- a/docker/docker-compose.2004.55.yaml
+++ b/docker/docker-compose.2004.55.yaml
@@ -6,7 +6,8 @@ services:
     image: async-http-client:20.04-5.5
     build:
       args:
-        base_image: "swiftlang/swift:nightly-5.5-focal"
+        ubuntu_version: "focal"
+        swift_version: "5.5"
         
 
   test:


### PR DESCRIPTION
motivation: 5.5 release is available

changes: update docker CI setup to use the release version of 5.5