### PR TITLE
[RequestBag] Fix consumption error in state machine

### DIFF
--- a/Tests/AsyncHTTPClientTests/RequestBagTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests+XCTest.swift
@@ -32,6 +32,7 @@ extension RequestBagTests {
             ("testCancelFailsTaskWhenTaskIsQueued", testCancelFailsTaskWhenTaskIsQueued),
             ("testFailsTaskWhenTaskIsWaitingForMoreFromServer", testFailsTaskWhenTaskIsWaitingForMoreFromServer),
             ("testHTTPUploadIsCancelledEvenThoughRequestSucceeds", testHTTPUploadIsCancelledEvenThoughRequestSucceeds),
+            ("testRaceBetweenConnectionCloseAndDemandMoreData", testRaceBetweenConnectionCloseAndDemandMoreData),
         ]
     }
 }


### PR DESCRIPTION
### Motivation

If a `RequestBag` was consuming received http body parts in its `HTTPClientResponseDelegate` in the `didReceiveBodyPart` and received a `succeedRequest`, the `didFinishRequest` was called before the `didReceiveBodyPart` future was resolved.

### Changes

- Call `didFinishRequest` only once the `didReceiveBodyPart` future was succeeded.

### Result

- Fixes test failure that surfaced here: https://ci.swiftserver.group/job/async-http-client-swift55-prb/154/console