### PR TITLE
Replace tests that depend on `TaskHandler`

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests+XCTest.swift
@@ -34,6 +34,8 @@ extension HTTP1ConnectionTests {
             ("testConnectionClosesAfterTheRequestWithoutHavingSentAnCloseHeader", testConnectionClosesAfterTheRequestWithoutHavingSentAnCloseHeader),
             ("testConnectionIsClosedAfterSwitchingProtocols", testConnectionIsClosedAfterSwitchingProtocols),
             ("testConnectionDoesntCrashAfterConnectionCloseAndEarlyHints", testConnectionDoesntCrashAfterConnectionCloseAndEarlyHints),
+            ("testConnectionIsClosedIfResponseIsReceivedBeforeRequest", testConnectionIsClosedIfResponseIsReceivedBeforeRequest),
+            ("testDoubleHTTPResponseLine", testDoubleHTTPResponseLine),
             ("testDownloadStreamingBackpressure", testDownloadStreamingBackpressure),
         ]
     }

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
@@ -490,6 +490,93 @@ class HTTP1ConnectionTests: XCTestCase {
         }
     }
 
+    func testConnectionIsClosedIfResponseIsReceivedBeforeRequest() {
+        let embedded = EmbeddedChannel()
+        let logger = Logger(label: "test.http1.connection")
+
+        XCTAssertNoThrow(try embedded.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait())
+
+        let connectionDelegate = MockConnectionDelegate()
+        XCTAssertNoThrow(try HTTP1Connection.start(
+            channel: embedded,
+            connectionID: 0,
+            delegate: connectionDelegate,
+            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            logger: logger
+        ))
+
+        let responseString = """
+        HTTP/1.1 200 OK\r\n\
+        date: Mon, 27 Sep 2021 17:53:14 GMT\r\n\
+        \r\n\
+        \r\n
+        """
+
+        XCTAssertEqual(connectionDelegate.hitConnectionClosed, 0)
+        XCTAssertEqual(connectionDelegate.hitConnectionReleased, 0)
+
+        XCTAssertThrowsError(try embedded.writeInbound(ByteBuffer(string: responseString))) {
+            XCTAssertEqual($0 as? NIOHTTPDecoderError, .unsolicitedResponse)
+        }
+        XCTAssertFalse(embedded.isActive)
+        (embedded.eventLoop as! EmbeddedEventLoop).run() // tick once to run futures.
+        XCTAssertEqual(connectionDelegate.hitConnectionClosed, 1)
+        XCTAssertEqual(connectionDelegate.hitConnectionReleased, 0)
+    }
+
+    func testDoubleHTTPResponseLine() {
+        let embedded = EmbeddedChannel()
+        let logger = Logger(label: "test.http1.connection")
+
+        XCTAssertNoThrow(try embedded.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 0)).wait())
+
+        var maybeConnection: HTTP1Connection?
+        let connectionDelegate = MockConnectionDelegate()
+        XCTAssertNoThrow(maybeConnection = try HTTP1Connection.start(
+            channel: embedded,
+            connectionID: 0,
+            delegate: connectionDelegate,
+            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            logger: logger
+        ))
+        guard let connection = maybeConnection else { return XCTFail("Expected to have a connection at this point.") }
+
+        var maybeRequest: HTTPClient.Request?
+        XCTAssertNoThrow(maybeRequest = try HTTPClient.Request(url: "http://swift.org/"))
+        guard let request = maybeRequest else { return XCTFail("Expected to be able to create a request") }
+
+        let delegate = ResponseAccumulator(request: request)
+        var maybeRequestBag: RequestBag<ResponseAccumulator>?
+        XCTAssertNoThrow(maybeRequestBag = try RequestBag(
+            request: request,
+            eventLoopPreference: .delegate(on: embedded.eventLoop),
+            task: .init(eventLoop: embedded.eventLoop, logger: logger),
+            redirectHandler: nil,
+            connectionDeadline: .now() + .seconds(30),
+            requestOptions: .forTests(),
+            delegate: delegate
+        ))
+        guard let requestBag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag") }
+
+        connection.executeRequest(requestBag)
+
+        let responseString = """
+        HTTP/1.0 200 OK\r\n\
+        HTTP/1.0 200 OK\r\n\r\n
+        """
+
+        XCTAssertNoThrow(try embedded.readOutbound(as: ByteBuffer.self)) // head
+        XCTAssertNoThrow(try embedded.readOutbound(as: ByteBuffer.self)) // end
+
+        XCTAssertEqual(connectionDelegate.hitConnectionClosed, 0)
+        XCTAssertEqual(connectionDelegate.hitConnectionReleased, 0)
+        XCTAssertNoThrow(try embedded.writeInbound(ByteBuffer(string: responseString)))
+        XCTAssertFalse(embedded.isActive)
+        (embedded.eventLoop as! EmbeddedEventLoop).run() // tick once to run futures.
+        XCTAssertEqual(connectionDelegate.hitConnectionClosed, 1)
+        XCTAssertEqual(connectionDelegate.hitConnectionReleased, 0)
+    }
+
     // In order to test backpressure we need to make sure that reads will not happen
     // until the backpressure promise is succeeded. Since we cannot guarantee when
     // messages will be delivered to a client pipeline and we need this test to be

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests+XCTest.swift
@@ -26,11 +26,7 @@ extension HTTPClientInternalTests {
     static var allTests: [(String, (HTTPClientInternalTests) -> () throws -> Void)] {
         return [
             ("testHTTPPartsHandler", testHTTPPartsHandler),
-            ("testBadHTTPRequest", testBadHTTPRequest),
-            ("testHostPort", testHostPort),
             ("testHTTPPartsHandlerMultiBody", testHTTPPartsHandlerMultiBody),
-            ("testHTTPResponseHeadBeforeRequestHead", testHTTPResponseHeadBeforeRequestHead),
-            ("testHTTPResponseDoubleHead", testHTTPResponseDoubleHead),
             ("testRequestFinishesAfterRedirectIfServerRespondsBeforeClientFinishes", testRequestFinishesAfterRedirectIfServerRespondsBeforeClientFinishes),
             ("testProxyStreaming", testProxyStreaming),
             ("testProxyStreamingFailure", testProxyStreamingFailure),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -136,6 +136,7 @@ extension HTTPClientTests {
             ("testErrorAfterCloseWhileBackpressureExerted", testErrorAfterCloseWhileBackpressureExerted),
             ("testRequestSpecificTLS", testRequestSpecificTLS),
             ("testConnectionPoolSizeConfigValueIsRespected", testConnectionPoolSizeConfigValueIsRespected),
+            ("testRequestWithHeaderTransferEncodingIdentityFails", testRequestWithHeaderTransferEncodingIdentityFails),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
@@ -42,6 +42,7 @@ extension RequestValidationTests {
             ("testTransferEncodingHeaderHasBody", testTransferEncodingHeaderHasBody),
             ("testBothHeadersNoBody", testBothHeadersNoBody),
             ("testBothHeadersHasBody", testBothHeadersHasBody),
+            ("testHostHeaderIsSetCorrectlyInCreateRequestHead", testHostHeaderIsSetCorrectlyInCreateRequestHead),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -316,4 +316,24 @@ class RequestValidationTests: XCTestCase {
             XCTAssertThrowsError(try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
         }
     }
+
+    func testHostHeaderIsSetCorrectlyInCreateRequestHead() {
+        let req1 = try! HTTPClient.Request(url: "http://localhost:80/get")
+        XCTAssertEqual(try req1.createRequestHead().0.headers["host"].first, "localhost")
+
+        let req2 = try! HTTPClient.Request(url: "https://localhost/get")
+        XCTAssertEqual(try req2.createRequestHead().0.headers["host"].first, "localhost")
+
+        let req3 = try! HTTPClient.Request(url: "http://localhost:8080/get")
+        XCTAssertEqual(try req3.createRequestHead().0.headers["host"].first, "localhost:8080")
+
+        let req4 = try! HTTPClient.Request(url: "http://localhost:443/get")
+        XCTAssertEqual(try req4.createRequestHead().0.headers["host"].first, "localhost:443")
+
+        let req5 = try! HTTPClient.Request(url: "https://localhost:80/get")
+        XCTAssertEqual(try req5.createRequestHead().0.headers["host"].first, "localhost:80")
+
+        let req6 = try! HTTPClient.Request(url: "https://localhost/get", headers: ["host": "foo"])
+        XCTAssertEqual(try req6.createRequestHead().0.headers["host"].first, "foo")
+    }
 }


### PR DESCRIPTION
### Motivation

After #427, we now want to make sure, we can eventually remove now unused code. Some tests depend on `TaskHandler`, that actually test other functionality. Work that needs to be merged before #443.

### Changes

- Replicate four test that depended on `TaskHandler`

### Result

- Code can be removed, but tests continue to test.