### PR TITLE
remove umbrella `NIO` imports and add soundness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ httpClient.execute(request: request, deadline: .now() + .milliseconds(1))
 ### Streaming
 When dealing with larger amount of data, it's critical to stream the response body instead of aggregating in-memory. Handling a response stream is done using a delegate protocol. The following example demonstrates how to count the number of bytes in a streaming response body:
 ```swift
-import NIO
+import NIOCore
 import NIOHTTP1
 
 class CountingDelegate: HTTPClientResponseDelegate {

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIOCore
 import NIOConcurrencyHelpers
+import NIOCore
 import NIOHTTP1
 
 extension HTTPConnectionPool {

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIO
+import NIOCore
 import NIOConcurrencyHelpers
 import NIOHTTP1
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 
 extension HTTPConnectionPool {
     struct HTTP1StateMachine {

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import NIO
+import NIOCore
 import NIOHTTP1
 
 extension HTTPConnectionPool {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1StateTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1StateTests.swift
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 @testable import AsyncHTTPClient
-import NIO
+import NIOCore
+import NIOPosix
+import NIOEmbedded
 import NIOHTTP1
 import XCTest
 

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1StateTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1StateTests.swift
@@ -14,9 +14,9 @@
 
 @testable import AsyncHTTPClient
 import NIOCore
-import NIOPosix
 import NIOEmbedded
 import NIOHTTP1
+import NIOPosix
 import XCTest
 
 class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+ManagerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+ManagerTests.swift
@@ -14,8 +14,8 @@
 
 @testable import AsyncHTTPClient
 import NIOCore
-import NIOPosix
 import NIOHTTP1
+import NIOPosix
 import XCTest
 
 class HTTPConnectionPool_ManagerTests: XCTestCase {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+ManagerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+ManagerTests.swift
@@ -13,7 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 @testable import AsyncHTTPClient
-import NIO
+import NIOCore
+import NIOPosix
 import NIOHTTP1
 import XCTest
 

--- a/Tests/AsyncHTTPClientTests/Mocks/MockConnectionPool.swift
+++ b/Tests/AsyncHTTPClientTests/Mocks/MockConnectionPool.swift
@@ -14,7 +14,7 @@
 
 @testable import AsyncHTTPClient
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP1
 import NIOSSL
 

--- a/Tests/AsyncHTTPClientTests/Mocks/MockRequestQueuer.swift
+++ b/Tests/AsyncHTTPClientTests/Mocks/MockRequestQueuer.swift
@@ -14,7 +14,7 @@
 
 @testable import AsyncHTTPClient
 import Logging
-import NIO
+import NIOCore
 import NIOHTTP1
 
 /// A mock request queue (not creating any timers) that is used to validate

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -153,3 +153,12 @@ EOF
 done
 
 rm "$tmp"
+
+# This checks for the umbrella NIO module.
+printf "=> Checking for imports of umbrella NIO module... "
+if git grep --color=never -i "^[ \t]*import \+NIO[ \t]*$" > /dev/null; then
+    printf "\033[0;31mUmbrella imports found.\033[0m\n"
+    git grep -i "^[ \t]*import \+NIO[ \t]*$"
+    exit 1
+fi
+printf "\033[0;32mokay.\033[0m\n"


### PR DESCRIPTION
### Motivation
We do not want to accidentally `import NIO` and instead only import `NIOCore`, `NIOPosix` or `NIOEmbedded`.
### Changes
- replace `import NIO` with corresponding fine-grained import
- add soundness check ([borrowed from `swift-nio-http2`](https://github.com/apple/swift-nio-http2/blob/326f7f9a8c8c8402e3691adac04911cac9f9d87f/scripts/soundness.sh#L55-L62)) so this hopefully never slips in again.