### PR TITLE
[HTTPConnectionPool] StateMachine has explicit function for HTTP1 connection close

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -456,7 +456,7 @@ extension HTTPConnectionPool: HTTP1ConnectionDelegate {
             "ahc-http-version": "http/1.1",
         ])
         self.modifyStateAndRunActions {
-            $0.connectionClosed(connection.id)
+            $0.http1ConnectionClosed(connection.id)
         }
     }
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
@@ -214,7 +214,7 @@ extension HTTPConnectionPool {
         }
 
         /// A connection has been unexpectedly closed
-        mutating func connectionClosed(_ connectionID: Connection.ID) -> Action {
+        mutating func http1ConnectionClosed(_ connectionID: Connection.ID) -> Action {
             guard let (index, context) = self.connections.failConnection(connectionID) else {
                 // When a connection close is initiated by the connection pool, the connection will
                 // still report its close to the state machine. In those cases we must ignore the

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -157,10 +157,10 @@ extension HTTPConnectionPool {
         }
 
         /// A connection has been closed
-        mutating func connectionClosed(_ connectionID: Connection.ID) -> Action {
+        mutating func http1ConnectionClosed(_ connectionID: Connection.ID) -> Action {
             switch self.state {
             case .http1(var http1StateMachine):
-                let action = http1StateMachine.connectionClosed(connectionID)
+                let action = http1StateMachine.http1ConnectionClosed(connectionID)
                 self.state = .http1(http1StateMachine)
                 return action
             }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1StateTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1StateTests.swift
@@ -250,7 +250,7 @@ class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {
         XCTAssertEqual(failAction.request, .failRequest(finalRequest, HTTPClientError.alreadyShutdown, cancelTimeout: false))
 
         // 5. close open connection
-        let closeAction = state.connectionClosed(connectionID)
+        let closeAction = state.http1ConnectionClosed(connectionID)
         XCTAssertEqual(closeAction.connection, .cleanupConnections(.init(), isShutdown: .yes(unclean: true)))
         XCTAssertEqual(closeAction.request, .none)
     }
@@ -371,7 +371,7 @@ class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {
                 let doneAction = state.http1ConnectionReleased(connectionID)
                 XCTAssertEqual(doneAction.request, .none)
                 XCTAssertEqual(doneAction.connection, .closeConnection(connection, isShutdown: .no))
-                XCTAssertEqual(state.connectionClosed(connectionID), .none)
+                XCTAssertEqual(state.http1ConnectionClosed(connectionID), .none)
 
             case .cancelTimeoutTimer(let connectionID):
                 guard let expectedConnection = connections.newestParkedConnection(for: reqEventLoop) ?? connections.newestParkedConnection else {
@@ -428,7 +428,7 @@ class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {
         XCTAssertEqual(connections.parked, 7)
         XCTAssertEqual(connections.used, 1)
         XCTAssertNoThrow(try connections.abortConnection(connectionToAbort.id))
-        XCTAssertEqual(state.connectionClosed(connectionToAbort.id), .none)
+        XCTAssertEqual(state.http1ConnectionClosed(connectionToAbort.id), .none)
         XCTAssertEqual(connections.parked, 7)
         XCTAssertEqual(connections.used, 0)
     }
@@ -448,7 +448,7 @@ class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {
             return XCTFail("Expected to have a parked connection")
         }
         XCTAssertNoThrow(try connections.closeConnection(connectionToClose))
-        XCTAssertEqual(state.connectionClosed(connectionToClose.id), .none)
+        XCTAssertEqual(state.http1ConnectionClosed(connectionToClose.id), .none)
         XCTAssertEqual(connections.parked, 7)
     }
 
@@ -499,7 +499,7 @@ class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {
         while let closedConnection = connections.randomLeasedConnection() {
             XCTAssertNoThrow(try connections.abortConnection(closedConnection.id))
             XCTAssertEqual(connections.parked, 0)
-            let action = state.connectionClosed(closedConnection.id)
+            let action = state.http1ConnectionClosed(closedConnection.id)
 
             switch action.connection {
             case .createConnection(let newConnectionID, on: let eventLoop):
@@ -584,7 +584,7 @@ class HTTPConnectionPool_HTTP1StateMachineTests: XCTestCase {
 
         // triggered by remote peer
         XCTAssertNoThrow(try connections.abortConnection(connection.id))
-        XCTAssertEqual(state.connectionClosed(connection.id), .none)
+        XCTAssertEqual(state.http1ConnectionClosed(connection.id), .none)
 
         // triggered by timer
         XCTAssertEqual(state.connectionIdleTimeout(connection.id), .none)


### PR DESCRIPTION
Renamed generic function `connectionClosed` to specific `http1ConnectionClose`. We should have specific callbacks for http1 and http2.