### PR TITLE
[HTTP2StateMachine] test and fix HTTP2 go away

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
@@ -33,6 +33,9 @@ extension HTTPConnectionPool_HTTP2StateMachineTests {
             ("testSchedulingAndCancelingOfIdleTimeout", testSchedulingAndCancelingOfIdleTimeout),
             ("testConnectionTimeout", testConnectionTimeout),
             ("testConnectionEstablishmentFailure", testConnectionEstablishmentFailure),
+            ("testGoAwayOnIdleConnection", testGoAwayOnIdleConnection),
+            ("testGoAwayWithLeasedStream", testGoAwayWithLeasedStream),
+            ("testGoAwayWithPendingRequestsStartsNewConnection", testGoAwayWithPendingRequestsStartsNewConnection),
         ]
     }
 }


### PR DESCRIPTION
### Motivation
- we should not crash if we close a stream after we have received a go away event

### Changes
- rename `AvailableConnectionContext` to `EstablishedConnectionContext` to better communicate that the connection might actually not be available and already in the draining state
- add `connectionID` property to `EstablishedConnectionContext` because we might need to schedule an idle timeout if the connection is idle and we do not execute any new requests
- only lease streams if `count` is great then or equal to one
- add variouse tests to verify correct handling of go away events