### PR TITLE
Don't crash when hitting long backoffs.

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+Backoff.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+Backoff.swift
@@ -46,9 +46,12 @@ extension HTTPConnectionPool {
         //   - 29 failed attempts: ~60s (max out)
 
         let start = Double(TimeAmount.milliseconds(100).nanoseconds)
-        let backoffNanoseconds = Int64(start * pow(1.25, Double(attempts - 1)))
+        let backoffNanosecondsDouble = start * pow(1.25, Double(attempts - 1))
 
-        let backoff: TimeAmount = min(.nanoseconds(backoffNanoseconds), .seconds(60))
+        // Cap to 60s _before_ we convert to Int64, to avoid trapping in the Int64 initializer.
+        let backoffNanoseconds = Int64(min(backoffNanosecondsDouble, Double(TimeAmount.seconds(60).nanoseconds)))
+
+        let backoff = TimeAmount.nanoseconds(backoffNanoseconds)
 
         // Calculate a 3% jitter range
         let jitterRange = (backoff.nanoseconds / 100) * 3

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests+XCTest.swift
@@ -33,6 +33,7 @@ extension HTTPConnectionPoolTests {
             ("testConnectionCreationIsRetriedUntilRequestIsCancelled", testConnectionCreationIsRetriedUntilRequestIsCancelled),
             ("testConnectionShutdownIsCalledOnActiveConnections", testConnectionShutdownIsCalledOnActiveConnections),
             ("testConnectionPoolStressResistanceHTTP1", testConnectionPoolStressResistanceHTTP1),
+            ("testBackoffBehavesSensibly", testBackoffBehavesSensibly),
         ]
     }
 }


### PR DESCRIPTION
Motivation:

If we backoff sufficiently far we can overflow Int64, which will cause
us to crash.

Modifications:

Clamp the backoff value before we convert to Int64.

Results:

No crashes!
Resolves #457 