### PR TITLE
[HTTP2] integrate `HTTP2StateMachine` into `HTTPConnectionPool.StateMachine`

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
@@ -618,9 +618,10 @@ extension HTTPConnectionPool {
             // TODO: improve algorithm to create connections uniformly across all preferred event loops
             // while paying attention to the number of queued request per event loop
             // Currently we start by creating new connections on the event loop with the most queued
-            // requests. If we have create a enough connections to cover all requests for the given
+            // requests. If we have created enough connections to cover all requests for the first
             // event loop we will continue with the event loop with the second most queued requests
-            // and so on and so forth. We do not need to sort the array because
+            // and so on and so forth. The `generalPurposeRequestCountGroupedByPreferredEventLoop`
+            // array is already ordered so we can just iterate over it without sorting by request count.
             let newGeneralPurposeConnections: [(Connection.ID, EventLoop)] = generalPurposeRequestCountGroupedByPreferredEventLoop
                 // we do not want to allocated intermediate arrays.
                 .lazy

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
@@ -46,18 +46,6 @@ extension HTTPConnectionPool {
         }
 
         mutating func migrateFromHTTP2(
-            http2State: HTTP2StateMachine,
-            newHTTP1Connection: Connection
-        ) -> Action {
-            self.migrateFromHTTP2(
-                http1Connections: http2State.http1Connections,
-                http2Connections: http2State.connections,
-                requests: http2State.requests,
-                newHTTP1Connection: newHTTP1Connection
-            )
-        }
-
-        mutating func migrateFromHTTP2(
             http1Connections: HTTP1Connections? = nil,
             http2Connections: HTTP2Connections,
             requests: RequestQueue,

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2Connections.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2Connections.swift
@@ -419,14 +419,14 @@ extension HTTPConnectionPool {
             self.connections.contains { $0.isActive }
         }
 
-        /// used in general purpose connection scenarios to check if at least one connection is starting or active for the given `eventLoop`
+        /// used in general purpose connection scenarios to check if at least one connection is starting, backing off or active
         var hasConnectionThatCanOrWillBeAbleToExecuteRequests: Bool {
             self.connections.contains { $0.canOrWillBeAbleToExecuteRequests }
         }
 
         /// used in eventLoop scenarios. does at least one connection exist for this eventLoop, or should we create a new one?
         /// - Parameter eventLoop: connection `EventLoop` to search for
-        /// - Returns: true if at least one connection is starting or active for the given `eventLoop`
+        /// - Returns: true if at least one connection is starting, backing off or active for the given `eventLoop`
         func hasConnectionThatCanOrWillBeAbleToExecuteRequests(for eventLoop: EventLoop) -> Bool {
             self.connections.contains {
                 $0.eventLoop === eventLoop && $0.canOrWillBeAbleToExecuteRequests

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -50,20 +50,6 @@ extension HTTPConnectionPool {
         }
 
         mutating func migrateFromHTTP1(
-            http1State: HTTP1StateMachine,
-            newHTTP2Connection: Connection,
-            maxConcurrentStreams: Int
-        ) -> Action {
-            self.migrateFromHTTP1(
-                http1Connections: http1State.connections,
-                http2Connections: http1State.http2Connections,
-                requests: http1State.requests,
-                newHTTP2Connection: newHTTP2Connection,
-                maxConcurrentStreams: maxConcurrentStreams
-            )
-        }
-
-        mutating func migrateFromHTTP1(
             http1Connections: HTTP1Connections,
             http2Connections: HTTP2Connections? = nil,
             requests: RequestQueue,

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -216,7 +216,7 @@ extension HTTPConnectionPool {
             self.lastConnectFailure = nil
             if self.connections.hasActiveConnection(for: connection.eventLoop) {
                 guard let (index, _) = self.connections.failConnection(connection.id) else {
-                    preconditionFailure("we connection to a connection which we no nothing about")
+                    preconditionFailure("we have established a new connection that we know nothing about?")
                 }
                 self.connections.removeConnection(at: index)
                 return .init(

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -228,11 +228,22 @@ extension HTTPConnectionPool {
         private mutating func _newHTTP2ConnectionEstablished(_ connection: Connection, maxConcurrentStreams: Int) -> EstablishedAction {
             self.failedConsecutiveConnectionAttempts = 0
             self.lastConnectFailure = nil
-            let (index, context) = self.connections.newHTTP2ConnectionEstablished(
-                connection,
-                maxConcurrentStreams: maxConcurrentStreams
-            )
-            return self.nextActionForAvailableConnection(at: index, context: context)
+            if self.connections.hasActiveConnection(for: connection.eventLoop) {
+                guard let (index, _) = self.connections.failConnection(connection.id) else {
+                    preconditionFailure("we connection to a connection which we no nothing about")
+                }
+                self.connections.removeConnection(at: index)
+                return .init(
+                    request: .none,
+                    connection: .closeConnection(connection, isShutdown: .no)
+                )
+            } else {
+                let (index, context) = self.connections.newHTTP2ConnectionEstablished(
+                    connection,
+                    maxConcurrentStreams: maxConcurrentStreams
+                )
+                return self.nextActionForAvailableConnection(at: index, context: context)
+            }
         }
 
         private mutating func nextActionForAvailableConnection(
@@ -318,8 +329,28 @@ extension HTTPConnectionPool {
         private mutating func nextActionForFailedConnection(at index: Int, on eventLoop: EventLoop) -> Action {
             switch self.state {
             case .running:
-                let hasPendingRequest = !self.requests.isEmpty(for: eventLoop) || !self.requests.isEmpty(for: nil)
-                guard hasPendingRequest else {
+                // we do not know if we have created this connection for a request with a required
+                // event loop or not. However, we do not need this information and can infer
+                // if we need to create a new connection because we will only ever create one connection
+                // per event loop for required event loop requests and only need one connection for
+                // general purpose requests.
+
+                // we need to start a new on connection in two cases:
+                let needGeneralPurposeConnection =
+                    // 1. if we have general purpose requests
+                    !self.requests.isEmpty(for: nil) &&
+                    // and no connection starting or active
+                    !self.connections.hasStartingOrActiveConnection()
+
+                let needRequiredEventLoopConnection =
+                    // 2. or if we have requests for a required event loop
+                    !self.requests.isEmpty(for: eventLoop) &&
+                    // and no connection starting or active for the given event loop
+                    !self.connections.hasStartingOrActiveConnection(for: eventLoop)
+
+                guard needGeneralPurposeConnection || needRequiredEventLoopConnection else {
+                    // otherwise we can remove the connection
+                    self.connections.removeConnection(at: index)
                     return .none
                 }
 
@@ -330,6 +361,7 @@ extension HTTPConnectionPool {
                     request: .none,
                     connection: .createConnection(newConnectionID, on: eventLoop)
                 )
+
             case .shuttingDown(let unclean):
                 assert(self.requests.isEmpty)
                 self.connections.removeConnection(at: index)

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -68,6 +68,23 @@ extension HTTPConnectionPool {
 
         enum HTTPVersionState {
             case http1(HTTP1StateMachine)
+            case http2(HTTP2StateMachine)
+
+            mutating func modify<ReturnValue>(
+                http1: (inout HTTP1StateMachine) -> ReturnValue,
+                http2: (inout HTTP2StateMachine) -> ReturnValue
+            ) -> ReturnValue {
+                let returnValue: ReturnValue
+                switch self {
+                case .http1(var http1State):
+                    returnValue = http1(&http1State)
+                    self = .http1(http1State)
+                case .http2(var http2State):
+                    returnValue = http2(&http2State)
+                    self = .http2(http2State)
+                }
+                return returnValue
+            }
         }
 
         var state: HTTPVersionState
@@ -87,12 +104,11 @@ extension HTTPConnectionPool {
         }
 
         mutating func executeRequest(_ request: Request) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.executeRequest(request)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.executeRequest(request)
+            }, http2: { http2 in
+                http2.executeRequest(request)
+            })
         }
 
         mutating func newHTTP1ConnectionCreated(_ connection: Connection) -> Action {
@@ -101,28 +117,100 @@ extension HTTPConnectionPool {
                 let action = http1StateMachine.newHTTP1ConnectionEstablished(connection)
                 self.state = .http1(http1StateMachine)
                 return action
+
+            case .http2(let http2StateMachine):
+                var http1StateMachine = HTTP1StateMachine(
+                    idGenerator: self.idGenerator,
+                    maximumConcurrentConnections: self.maximumConcurrentHTTP1Connections
+                )
+
+                let newConnectionAction = http1StateMachine.migrateFromHTTP2(
+                    http2State: http2StateMachine,
+                    newHTTP1Connection: connection
+                )
+                self.state = .http1(http1StateMachine)
+                return newConnectionAction
             }
+        }
+
+        mutating func newHTTP2ConnectionCreated(_ connection: Connection, maxConcurrentStreams: Int) -> Action {
+            switch self.state {
+            case .http1(let http1StateMachine):
+
+                var http2StateMachine = HTTP2StateMachine(
+                    idGenerator: self.idGenerator
+                )
+                let migrationAction = http2StateMachine.migrateFromHTTP1(
+                    http1State: http1StateMachine,
+                    newHTTP2Connection: connection,
+                    maxConcurrentStreams: maxConcurrentStreams
+                )
+
+                self.state = .http2(http2StateMachine)
+                return migrationAction
+
+            case .http2(var http2StateMachine):
+                let newConnectionAction = http2StateMachine.newHTTP2ConnectionEstablished(
+                    connection,
+                    maxConcurrentStreams: maxConcurrentStreams
+                )
+                self.state = .http2(http2StateMachine)
+                return newConnectionAction
+            }
+        }
+
+        mutating func newHTTP2MaxConcurrentStreamsReceived(_ connectionID: Connection.ID, newMaxStreams: Int) -> Action {
+            self.state.modify(http1: { http1 in
+                http1.newHTTP2MaxConcurrentStreamsReceived(connectionID, newMaxStreams: newMaxStreams)
+            }, http2: { http2 in
+                http2.newHTTP2MaxConcurrentStreamsReceived(connectionID, newMaxStreams: newMaxStreams)
+            })
+        }
+
+        mutating func http2ConnectionGoAwayReceived(_ connectionID: Connection.ID) -> Action {
+            self.state.modify(http1: { http1 in
+                http1.http2ConnectionGoAwayReceived(connectionID)
+            }, http2: { http2 in
+                http2.http2ConnectionGoAwayReceived(connectionID)
+            })
+        }
+
+        mutating func http2ConnectionClosed(_ connectionID: Connection.ID) -> Action {
+            self.state.modify(http1: { http1 in
+                http1.http2ConnectionClosed(connectionID)
+            }, http2: { http2 in
+                http2.http2ConnectionClosed(connectionID)
+            })
+        }
+
+        mutating func http2ConnectionStreamClosed(_ connectionID: Connection.ID) -> Action {
+            self.state.modify(http1: { http1 in
+                http1.http2ConnectionStreamClosed(connectionID)
+            }, http2: { http2 in
+                http2.http2ConnectionStreamClosed(connectionID)
+            })
         }
 
         mutating func failedToCreateNewConnection(_ error: Error, connectionID: Connection.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.failedToCreateNewConnection(
+            self.state.modify(http1: { http1 in
+                http1.failedToCreateNewConnection(
                     error,
                     connectionID: connectionID
                 )
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            }, http2: { http2 in
+                http2.failedToCreateNewConnection(
+                    error,
+                    connectionID: connectionID
+                )
+            })
         }
 
         mutating func connectionCreationBackoffDone(_ connectionID: Connection.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.connectionCreationBackoffDone(connectionID)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.connectionCreationBackoffDone(connectionID)
+            }, http2: { http2 in
+                http2.connectionCreationBackoffDone(connectionID)
+            })
         }
 
         /// A request has timed out.
@@ -131,12 +219,11 @@ extension HTTPConnectionPool {
         /// request, but don't need to cancel the timer (it already triggered). If a request is cancelled
         /// we don't need to fail it but we need to cancel its timeout timer.
         mutating func timeoutRequest(_ requestID: Request.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.timeoutRequest(requestID)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.timeoutRequest(requestID)
+            }, http2: { http2 in
+                http2.timeoutRequest(requestID)
+            })
         }
 
         /// A request was cancelled.
@@ -145,40 +232,36 @@ extension HTTPConnectionPool {
         /// need to cancel its timeout timer. If a request times out, we need to fail the request, but don't
         /// need to cancel the timer (it already triggered).
         mutating func cancelRequest(_ requestID: Request.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.cancelRequest(requestID)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.cancelRequest(requestID)
+            }, http2: { http2 in
+                http2.cancelRequest(requestID)
+            })
         }
 
         mutating func connectionIdleTimeout(_ connectionID: Connection.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.connectionIdleTimeout(connectionID)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.connectionIdleTimeout(connectionID)
+            }, http2: { http2 in
+                http2.connectionIdleTimeout(connectionID)
+            })
         }
 
         /// A connection has been closed
         mutating func http1ConnectionClosed(_ connectionID: Connection.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.http1ConnectionClosed(connectionID)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.http1ConnectionClosed(connectionID)
+            }, http2: { http2 in
+                http2.http1ConnectionClosed(connectionID)
+            })
         }
 
         mutating func http1ConnectionReleased(_ connectionID: Connection.ID) -> Action {
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.http1ConnectionReleased(connectionID)
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            self.state.modify(http1: { http1 in
+                http1.http1ConnectionReleased(connectionID)
+            }, http2: { http2 in
+                http2.http1ConnectionReleased(connectionID)
+            })
         }
 
         mutating func shutdown() -> Action {
@@ -186,12 +269,11 @@ extension HTTPConnectionPool {
 
             self.isShuttingDown = true
 
-            switch self.state {
-            case .http1(var http1StateMachine):
-                let action = http1StateMachine.shutdown()
-                self.state = .http1(http1StateMachine)
-                return action
-            }
+            return self.state.modify(http1: { http1 in
+                http1.shutdown()
+            }, http2: { http2 in
+                http2.shutdown()
+            })
         }
     }
 }
@@ -221,6 +303,8 @@ extension HTTPConnectionPool.StateMachine: CustomStringConvertible {
         switch self.state {
         case .http1(let http1):
             return ".http1(\(http1))"
+        case .http2(let http2):
+            return ".http2(\(http2))"
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -125,7 +125,9 @@ extension HTTPConnectionPool {
                 )
 
                 let newConnectionAction = http1StateMachine.migrateFromHTTP2(
-                    http2State: http2StateMachine,
+                    http1Connections: http2StateMachine.http1Connections,
+                    http2Connections: http2StateMachine.connections,
+                    requests: http2StateMachine.requests,
                     newHTTP1Connection: connection
                 )
                 self.state = .http1(http1StateMachine)
@@ -141,7 +143,9 @@ extension HTTPConnectionPool {
                     idGenerator: self.idGenerator
                 )
                 let migrationAction = http2StateMachine.migrateFromHTTP1(
-                    http1State: http1StateMachine,
+                    http1Connections: http1StateMachine.connections,
+                    http2Connections: http1StateMachine.http2Connections,
+                    requests: http1StateMachine.requests,
                     newHTTP2Connection: connection,
                     maxConcurrentStreams: maxConcurrentStreams
                 )
@@ -193,15 +197,9 @@ extension HTTPConnectionPool {
 
         mutating func failedToCreateNewConnection(_ error: Error, connectionID: Connection.ID) -> Action {
             self.state.modify(http1: { http1 in
-                http1.failedToCreateNewConnection(
-                    error,
-                    connectionID: connectionID
-                )
+                http1.failedToCreateNewConnection(error, connectionID: connectionID)
             }, http2: { http2 in
-                http2.failedToCreateNewConnection(
-                    error,
-                    connectionID: connectionID
-                )
+                http2.failedToCreateNewConnection(error, connectionID: connectionID)
             })
         }
 

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2ConnectionsTest+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2ConnectionsTest+XCTest.swift
@@ -40,6 +40,7 @@ extension HTTPConnectionPool_HTTP2ConnectionsTests {
             ("testNewMaxConcurrentStreamsSetting", testNewMaxConcurrentStreamsSetting),
             ("testLeaseOnPreferredEventLoopWithoutAnyAvailable", testLeaseOnPreferredEventLoopWithoutAnyAvailable),
             ("testMigrationFromHTTP1", testMigrationFromHTTP1),
+            ("testMigrationToHTTP1", testMigrationToHTTP1),
             ("testMigrationFromHTTP1WithPendingRequestsWithRequiredEventLoop", testMigrationFromHTTP1WithPendingRequestsWithRequiredEventLoop),
             ("testMigrationFromHTTP1WithAlreadyEstablishedHTTP2Connection", testMigrationFromHTTP1WithAlreadyEstablishedHTTP2Connection),
         ]

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
@@ -36,6 +36,9 @@ extension HTTPConnectionPool_HTTP2StateMachineTests {
             ("testGoAwayOnIdleConnection", testGoAwayOnIdleConnection),
             ("testGoAwayWithLeasedStream", testGoAwayWithLeasedStream),
             ("testGoAwayWithPendingRequestsStartsNewConnection", testGoAwayWithPendingRequestsStartsNewConnection),
+            ("testMigrationFromHTTP1ToHTTP2", testMigrationFromHTTP1ToHTTP2),
+            ("testMigrationFromHTTP1ToHTTP2WithAlreadyStartedHTTP1Connections", testMigrationFromHTTP1ToHTTP2WithAlreadyStartedHTTP1Connections),
+            ("testHTTP2toHTTP1Migration", testHTTP2toHTTP1Migration),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests.swift
@@ -312,7 +312,13 @@ class HTTPConnectionPool_HTTP2StateMachineTests: XCTestCase {
         let conn2: HTTPConnectionPool.Connection = .__testOnly_connection(id: conn2ID, eventLoop: el1)
         var http2State = HTTPConnectionPool.HTTP2StateMachine(idGenerator: idGenerator)
 
-        let http2ConnectAction = http2State.migrateFromHTTP1(http1State: http1State, newHTTP2Connection: conn2, maxConcurrentStreams: 100)
+        let http2ConnectAction = http2State.migrateFromHTTP1(
+            http1Connections: http1State.connections,
+            http2Connections: http1State.http2Connections,
+            requests: http1State.requests,
+            newHTTP2Connection: conn2,
+            maxConcurrentStreams: 100
+        )
         XCTAssertEqual(http2ConnectAction.connection, .migration(createConnections: [], closeConnections: [], scheduleTimeout: nil))
         guard case .executeRequestsAndCancelTimeouts([request2], conn2) = http2ConnectAction.request else {
             return XCTFail("Unexpected request action \(http2ConnectAction.request)")


### PR DESCRIPTION
### Motivation
To support HTTP/2 we need to integrate the `HTTP2StateMachine` into the new connection pool.

### Changes
- introduce a new `http2` state case in `HTTPConnectionPool.StateMachine`
- forwards HTTP/1 and HTTP/2 state machine calls to the HTTP2 machine if we are currently in http2 state.
- Fixed a bug in http2 backoff connection creation (created to many connections) 
- Fixed a bug in http2 to http1 migration (returned boolean in `removeAll(_:)` was the inverse of what we actually wanted) which resulted in duplicated connections and lost connections.
Note that we should never hit the `HTTP2StateMachine` or be in the `http2` state because HTTP/2 is still disabled.
- add tests for bug fixes
- add integration tests for `HTTPConnectionPool.StateMachine`