### PR TITLE
[HTTP2] Internal `HTTPVersion` configuration

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -298,14 +298,14 @@ extension HTTPConnectionPool.ConnectionFactory {
             return channel.eventLoop.makeSucceededFuture(.http1_1(channel))
         case .https:
             var tlsConfig = self.tlsConfiguration
-            switch self.clientConfiguration.http2.configuration {
+            switch self.clientConfiguration.httpVersion.configuration {
             case .automatic:
                 // since we can support h2, we need to advertise this in alpn
                 // "ProtocolNameList" contains the list of protocols advertised by the
                 // client, in descending order of preference.
                 // https://datatracker.ietf.org/doc/html/rfc7301#section-3.1
                 tlsConfig.applicationProtocols = ["h2", "http/1.1"]
-            case .disabled:
+            case .http1Only:
                 tlsConfig.applicationProtocols = ["http/1.1"]
             }
             let tlsEventHandler = TLSEventsHandler(deadline: deadline)
@@ -404,14 +404,14 @@ extension HTTPConnectionPool.ConnectionFactory {
     private func makeTLSBootstrap(deadline: NIODeadline, eventLoop: EventLoop, logger: Logger)
         -> EventLoopFuture<NIOClientTCPBootstrapProtocol> {
         var tlsConfig = self.tlsConfiguration
-        switch self.clientConfiguration.http2.configuration {
+        switch self.clientConfiguration.httpVersion.configuration {
         case .automatic:
             // since we can support h2, we need to advertise this in alpn
             // "ProtocolNameList" contains the list of protocols advertised by the
             // client, in descending order of preference.
             // https://datatracker.ietf.org/doc/html/rfc7301#section-3.1
             tlsConfig.applicationProtocols = ["h2", "http/1.1"]
-        case .disabled:
+        case .http1Only:
             tlsConfig.applicationProtocols = ["http/1.1"]
         }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -603,13 +603,66 @@ public class HTTPClient {
         /// Ignore TLS unclean shutdown error, defaults to `false`.
         public var ignoreUncleanSSLShutdown: Bool
 
-        public init(tlsConfiguration: TLSConfiguration? = nil,
-                    redirectConfiguration: RedirectConfiguration? = nil,
-                    timeout: Timeout = Timeout(),
-                    connectionPool: ConnectionPool = ConnectionPool(),
-                    proxy: Proxy? = nil,
-                    ignoreUncleanSSLShutdown: Bool = false,
-                    decompression: Decompression = .disabled) {
+        // TODO: make public
+        // TODO: set to automatic by default
+        /// HTTP/2 is by default disabled
+        internal var http2: HTTP2
+
+        // TODO: make public
+        internal init(
+            certificateVerification: CertificateVerification,
+            redirectConfiguration: RedirectConfiguration? = nil,
+            timeout: Timeout = Timeout(),
+            connectionPool: TimeAmount = .seconds(60),
+            proxy: Proxy? = nil,
+            ignoreUncleanSSLShutdown: Bool = false,
+            decompression: Decompression = .disabled,
+            backgroundActivityLogger: Logger? = nil,
+            http2: HTTP2
+        ) {
+            self.init(
+                certificateVerification: certificateVerification,
+                redirectConfiguration: redirectConfiguration,
+                timeout: timeout,
+                connectionPool: connectionPool,
+                proxy: proxy,
+                ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
+                decompression: decompression,
+                backgroundActivityLogger: backgroundActivityLogger
+            )
+        }
+
+        public init(
+            tlsConfiguration: TLSConfiguration? = nil,
+            redirectConfiguration: RedirectConfiguration? = nil,
+            timeout: Timeout = Timeout(),
+            connectionPool: ConnectionPool = ConnectionPool(),
+            proxy: Proxy? = nil,
+            ignoreUncleanSSLShutdown: Bool = false,
+            decompression: Decompression = .disabled
+        ) {
+            self.init(
+                tlsConfiguration: tlsConfiguration,
+                redirectConfiguration: redirectConfiguration,
+                timeout: timeout, connectionPool: connectionPool,
+                proxy: proxy,
+                ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
+                decompression: decompression,
+                // TODO: set to automatic by default
+                http2: .disabled
+            )
+        }
+
+        internal init(
+            tlsConfiguration: TLSConfiguration? = nil,
+            redirectConfiguration: RedirectConfiguration? = nil,
+            timeout: Timeout = Timeout(),
+            connectionPool: ConnectionPool = ConnectionPool(),
+            proxy: Proxy? = nil,
+            ignoreUncleanSSLShutdown: Bool = false,
+            decompression: Decompression = .disabled,
+            http2: HTTP2
+        ) {
             self.tlsConfiguration = tlsConfiguration
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
             self.timeout = timeout
@@ -617,6 +670,7 @@ public class HTTPClient {
             self.proxy = proxy
             self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
             self.decompression = decompression
+            self.http2 = http2
         }
 
         public init(tlsConfiguration: TLSConfiguration? = nil,
@@ -829,6 +883,22 @@ extension HTTPClient.Configuration {
             self.idleTimeout = idleTimeout
             self.concurrentHTTP1ConnectionsPerHostSoftLimit = concurrentHTTP1ConnectionsPerHostSoftLimit
         }
+    }
+
+    // TODO: make this struct and its static properties public
+    internal struct HTTP2 {
+        internal enum Configuration {
+            case disabled
+            case automatic
+        }
+
+        /// HTTP/2 is completely disabled
+        internal static let disabled: Self = .init(configuration: .disabled)
+
+        /// HTTP/2 is used if we connect to a server with HTTPS and the server supports HTTP/2
+        internal static let automatic: Self = .init(configuration: .automatic)
+
+        internal var configuration: Configuration
     }
 }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -606,31 +606,7 @@ public class HTTPClient {
         // TODO: make public
         // TODO: set to automatic by default
         /// HTTP/2 is by default disabled
-        internal var http2: HTTP2
-
-        // TODO: make public
-        internal init(
-            certificateVerification: CertificateVerification,
-            redirectConfiguration: RedirectConfiguration? = nil,
-            timeout: Timeout = Timeout(),
-            connectionPool: TimeAmount = .seconds(60),
-            proxy: Proxy? = nil,
-            ignoreUncleanSSLShutdown: Bool = false,
-            decompression: Decompression = .disabled,
-            backgroundActivityLogger: Logger? = nil,
-            http2: HTTP2
-        ) {
-            self.init(
-                certificateVerification: certificateVerification,
-                redirectConfiguration: redirectConfiguration,
-                timeout: timeout,
-                connectionPool: connectionPool,
-                proxy: proxy,
-                ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
-                decompression: decompression,
-                backgroundActivityLogger: backgroundActivityLogger
-            )
-        }
+        internal var httpVersion: HTTPVersion
 
         public init(
             tlsConfiguration: TLSConfiguration? = nil,
@@ -649,10 +625,11 @@ public class HTTPClient {
                 ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                 decompression: decompression,
                 // TODO: set to automatic by default
-                http2: .disabled
+                httpVersion: .http1Only
             )
         }
-
+        
+        // TODO: make public
         internal init(
             tlsConfiguration: TLSConfiguration? = nil,
             redirectConfiguration: RedirectConfiguration? = nil,
@@ -661,7 +638,7 @@ public class HTTPClient {
             proxy: Proxy? = nil,
             ignoreUncleanSSLShutdown: Bool = false,
             decompression: Decompression = .disabled,
-            http2: HTTP2
+            httpVersion: HTTPVersion
         ) {
             self.tlsConfiguration = tlsConfiguration
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
@@ -670,7 +647,7 @@ public class HTTPClient {
             self.proxy = proxy
             self.ignoreUncleanSSLShutdown = ignoreUncleanSSLShutdown
             self.decompression = decompression
-            self.http2 = http2
+            self.httpVersion = httpVersion
         }
 
         public init(tlsConfiguration: TLSConfiguration? = nil,
@@ -886,16 +863,16 @@ extension HTTPClient.Configuration {
     }
 
     // TODO: make this struct and its static properties public
-    internal struct HTTP2 {
+    internal struct HTTPVersion {
         internal enum Configuration {
-            case disabled
+            case http1Only
             case automatic
         }
 
-        /// HTTP/2 is completely disabled
-        internal static let disabled: Self = .init(configuration: .disabled)
+        /// we only use HTTP/1, even if the server would supports HTTP/2
+        internal static let http1Only: Self = .init(configuration: .http1Only)
 
-        /// HTTP/2 is used if we connect to a server with HTTPS and the server supports HTTP/2
+        /// HTTP/2 is used if we connect to a server with HTTPS and the server supports HTTP/2, otherwise we use HTTP/1
         internal static let automatic: Self = .init(configuration: .automatic)
 
         internal var configuration: Configuration

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -628,7 +628,7 @@ public class HTTPClient {
                 httpVersion: .http1Only
             )
         }
-        
+
         // TODO: make public
         internal init(
             tlsConfiguration: TLSConfiguration? = nil,

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -254,7 +254,7 @@ class TestConnectionCreator {
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
             // TODO: use default client configuration once http/2 is enabled by default
-            clientConfiguration: .init(http2: .automatic),
+            clientConfiguration: .init(httpVersion: .automatic),
             sslContextCache: .init()
         )
 
@@ -296,7 +296,7 @@ class TestConnectionCreator {
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
             // TODO: use default client configuration once http/2 is enabled by default
-            clientConfiguration: .init(http2: .automatic),
+            clientConfiguration: .init(httpVersion: .automatic),
             sslContextCache: .init()
         )
 

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -253,7 +253,6 @@ class TestConnectionCreator {
         let factory = HTTPConnectionPool.ConnectionFactory(
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
-            // TODO: use default client configuration once http/2 is enabled by default
             clientConfiguration: .init(httpVersion: .automatic),
             sslContextCache: .init()
         )
@@ -295,7 +294,6 @@ class TestConnectionCreator {
         let factory = HTTPConnectionPool.ConnectionFactory(
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
-            // TODO: use default client configuration once http/2 is enabled by default
             clientConfiguration: .init(httpVersion: .automatic),
             sslContextCache: .init()
         )

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -253,9 +253,9 @@ class TestConnectionCreator {
         let factory = HTTPConnectionPool.ConnectionFactory(
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
-            clientConfiguration: .init(),
-            sslContextCache: .init(),
-            allowHTTP2Connections: true
+            // TODO: use default client configuration once http/2 is enabled by default
+            clientConfiguration: .init(http2: .automatic),
+            sslContextCache: .init()
         )
 
         let promise = try self.lock.withLock { () -> EventLoopPromise<HTTP1Connection> in
@@ -295,9 +295,9 @@ class TestConnectionCreator {
         let factory = HTTPConnectionPool.ConnectionFactory(
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
-            clientConfiguration: .init(),
-            sslContextCache: .init(),
-            allowHTTP2Connections: true
+            // TODO: use default client configuration once http/2 is enabled by default
+            clientConfiguration: .init(http2: .automatic),
+            sslContextCache: .init()
         )
 
         let promise = try self.lock.withLock { () -> EventLoopPromise<HTTP2Connection> in


### PR DESCRIPTION
### Motivation
We want to be able to write HTTP/2 integration test for `HTTPClient` and need an option to enable HTTP/2 support without making it available to our adopters yet.

### Changes
- add internal `HTTP2` Configuration to `HTTPClient.Configuration` and disable it by default