### PR TITLE
[HTTP2] Improve performance for backoff timer

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2Connections.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2Connections.swift
@@ -48,7 +48,7 @@ extension HTTPConnectionPool {
                 return false
             }
         }
-        
+
         var isStartingOrActive: Bool {
             switch self.state {
             case .starting, .active:
@@ -459,7 +459,7 @@ extension HTTPConnectionPool {
         ) -> (onAnyEventLoop: Bool, onSpecifiedEventLoop: Bool) {
             var onAnyEventLoop: Bool = false
             var onSpecifiedEventLoop: Bool = false
-            for connection in connections {
+            for connection in self.connections {
                 guard connection.isStartingOrActive else { continue }
                 onAnyEventLoop = true
                 guard connection.eventLoop === eventLoop else { continue }

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -322,20 +322,20 @@ extension HTTPConnectionPool {
                 // general purpose requests.
 
                 // precompute if we have starting or active connections to only iterate once over `self.connections`
-                let startingOrActiveConnection = self.connections.hasAnyStartingOrActiveConnectionAnd(for: eventLoop)
+                let context = self.connections.backingOffTimerDone(for: eventLoop)
 
                 // we need to start a new on connection in two cases:
                 let needGeneralPurposeConnection =
                     // 1. if we have general purpose requests
                     !self.requests.isEmpty(for: nil) &&
                     // and no connection starting or active
-                    !startingOrActiveConnection.onAnyEventLoop
+                    !context.hasGeneralPurposeConnection
 
                 let needRequiredEventLoopConnection =
                     // 2. or if we have requests for a required event loop
                     !self.requests.isEmpty(for: eventLoop) &&
                     // and no connection starting or active for the given event loop
-                    !startingOrActiveConnection.onSpecifiedEventLoop
+                    !context.hasConnectionOnSpecifiedEventLoop
 
                 guard needGeneralPurposeConnection || needRequiredEventLoopConnection else {
                     // otherwise we can remove the connection

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -320,7 +320,7 @@ extension HTTPConnectionPool {
                 // if we need to create a new connection because we will only ever create one connection
                 // per event loop for required event loop requests and only need one connection for
                 // general purpose requests.
-                
+
                 // precompute if we have starting or active connections to only iterate once over `self.connections`
                 let startingOrActiveConnection = self.connections.hasAnyStartingOrActiveConnectionAnd(for: eventLoop)
 

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
@@ -39,6 +39,7 @@ extension HTTPConnectionPool_HTTP2StateMachineTests {
             ("testMigrationFromHTTP1ToHTTP2", testMigrationFromHTTP1ToHTTP2),
             ("testMigrationFromHTTP1ToHTTP2WithAlreadyStartedHTTP1Connections", testMigrationFromHTTP1ToHTTP2WithAlreadyStartedHTTP1Connections),
             ("testHTTP2toHTTP1Migration", testHTTP2toHTTP1Migration),
+            ("testConnectionIsImmediatelyCreatedAfterBackoffTimerFires", testConnectionIsImmediatelyCreatedAfterBackoffTimerFires),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests.swift
@@ -892,7 +892,7 @@ class HTTPConnectionPool_HTTP2StateMachineTests: XCTestCase {
             XCTAssertNoThrow(try connections.createConnection(connID, on: el))
             XCTAssertNoThrow(try queuer.queue(mockRequest, id: request.id))
         }
-        
+
         // fail the two connections for el2
         for connectionID in connectionIDs.dropFirst() {
             struct SomeError: Error {}


### PR DESCRIPTION
Follow up PR for #462 to improve performance as proposed in https://github.com/swift-server/async-http-client/pull/462#discussion_r740921074

This also fixes a bug where we would not create a new connection after a backoff timer fires if we have other connections backing off. (in `hasAnyStartingOrActiveConnectionAnd` we also returned true if a connection is in the backing off state)