### PR TITLE
[HTTP2] Forward HTTP/2 events to `StateMachine`

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -86,8 +86,8 @@ extension HTTPConnectionPool.ConnectionFactory {
                     logger: logger
                 ).whenComplete { result in
                     switch result {
-                    case .success(let connection):
-                        requester.http2ConnectionCreated(connection, maximumStreams: 0)
+                    case .success((let connection, let maximumStreams)):
+                        requester.http2ConnectionCreated(connection, maximumStreams: maximumStreams)
                     case .failure(let error):
                         requester.failedToCreateHTTPConnection(connectionID, error: error)
                     }


### PR DESCRIPTION
### Motivations
We want to start writing HTTP/2 integration tests
### Changes
- `HTTP2Connection` now forwards the initial `maxConccurentStreams` settings
- `HTTP2Connection` events are forwarded to `HTTPConnectionPool.StateMachine`
- HTTP/2 events are logged