### PR TITLE
[HTTP2] Make HTTPVersion public and set to .automatic by default

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -607,10 +607,8 @@ public class HTTPClient {
             set {}
         }
 
-        // TODO: make public
-        // TODO: set to automatic by default
-        /// HTTP/2 is by default disabled
-        internal var httpVersion: HTTPVersion
+        /// is set to `.automatic` by default which will use HTTP/2 if run over https and the server supports it, otherwise HTTP/1
+        public var httpVersion: HTTPVersion
 
         public init(
             tlsConfiguration: TLSConfiguration? = nil,
@@ -628,13 +626,11 @@ public class HTTPClient {
                 proxy: proxy,
                 ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                 decompression: decompression,
-                // TODO: set to automatic by default
-                httpVersion: .http1Only
+                httpVersion: .automatic
             )
         }
 
-        // TODO: make public
-        internal init(
+        public init(
             tlsConfiguration: TLSConfiguration? = nil,
             redirectConfiguration: RedirectConfiguration? = nil,
             timeout: Timeout = Timeout(),
@@ -865,18 +861,17 @@ extension HTTPClient.Configuration {
         }
     }
 
-    // TODO: make this struct and its static properties public
-    internal struct HTTPVersion {
+    public struct HTTPVersion {
         internal enum Configuration {
             case http1Only
             case automatic
         }
 
         /// we only use HTTP/1, even if the server would supports HTTP/2
-        internal static let http1Only: Self = .init(configuration: .http1Only)
+        public static let http1Only: Self = .init(configuration: .http1Only)
 
         /// HTTP/2 is used if we connect to a server with HTTPS and the server supports HTTP/2, otherwise we use HTTP/1
-        internal static let automatic: Self = .init(configuration: .automatic)
+        public static let automatic: Self = .init(configuration: .automatic)
 
         internal var configuration: Configuration
     }

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -630,7 +630,7 @@ public class HTTPClient {
             )
         }
 
-        public init(
+        internal init(
             tlsConfiguration: TLSConfiguration? = nil,
             redirectConfiguration: RedirectConfiguration? = nil,
             timeout: Timeout = Timeout(),

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -619,34 +619,13 @@ public class HTTPClient {
             ignoreUncleanSSLShutdown: Bool = false,
             decompression: Decompression = .disabled
         ) {
-            self.init(
-                tlsConfiguration: tlsConfiguration,
-                redirectConfiguration: redirectConfiguration,
-                timeout: timeout, connectionPool: connectionPool,
-                proxy: proxy,
-                ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
-                decompression: decompression,
-                httpVersion: .automatic
-            )
-        }
-
-        internal init(
-            tlsConfiguration: TLSConfiguration? = nil,
-            redirectConfiguration: RedirectConfiguration? = nil,
-            timeout: Timeout = Timeout(),
-            connectionPool: ConnectionPool = ConnectionPool(),
-            proxy: Proxy? = nil,
-            ignoreUncleanSSLShutdown: Bool = false,
-            decompression: Decompression = .disabled,
-            httpVersion: HTTPVersion
-        ) {
             self.tlsConfiguration = tlsConfiguration
             self.redirectConfiguration = redirectConfiguration ?? RedirectConfiguration()
             self.timeout = timeout
             self.connectionPool = connectionPool
             self.proxy = proxy
             self.decompression = decompression
-            self.httpVersion = httpVersion
+            self.httpVersion = .automatic
         }
 
         public init(tlsConfiguration: TLSConfiguration? = nil,

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
@@ -27,14 +27,13 @@ class HTTP2ClientTests: XCTestCase {
     func makeDefaultHTTPClient(
         eventLoopGroupProvider: HTTPClient.EventLoopGroupProvider = .createNew
     ) -> HTTPClient {
-        var tlsConfig = TLSConfiguration.makeClientConfiguration()
-        tlsConfig.certificateVerification = .none
+        var config = HTTPClient.Configuration()
+        config.tlsConfiguration = .clientDefault
+        config.tlsConfiguration?.certificateVerification = .none
+        config.httpVersion = .automatic
         return HTTPClient(
             eventLoopGroupProvider: eventLoopGroupProvider,
-            configuration: HTTPClient.Configuration(
-                tlsConfiguration: tlsConfig,
-                httpVersion: .automatic
-            ),
+            configuration: config,
             backgroundActivityLogger: Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
         )
     }
@@ -137,14 +136,13 @@ class HTTP2ClientTests: XCTestCase {
 
         let localHTTPBin = HTTPBin(.http2(compress: false))
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: numberOfWorkers)
-        var tlsConfig = TLSConfiguration.makeClientConfiguration()
-        tlsConfig.certificateVerification = .none
+        var config = HTTPClient.Configuration()
+        config.tlsConfiguration = .clientDefault
+        config.tlsConfiguration?.certificateVerification = .none
+        config.httpVersion = .automatic
         let localClient = HTTPClient(
             eventLoopGroupProvider: .shared(elg),
-            configuration: HTTPClient.Configuration(
-                tlsConfiguration: tlsConfig,
-                httpVersion: .automatic
-            ),
+            configuration: config,
             backgroundActivityLogger: Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
         )
         defer {
@@ -302,15 +300,14 @@ class HTTP2ClientTests: XCTestCase {
         let el1 = clientGroup.next()
         let el2 = clientGroup.next()
         defer { XCTAssertNoThrow(try clientGroup.syncShutdownGracefully()) }
-        var tlsConfig = TLSConfiguration.makeClientConfiguration()
-        tlsConfig.certificateVerification = .none
+        var config = HTTPClient.Configuration()
+        config.tlsConfiguration = .clientDefault
+        config.tlsConfiguration?.certificateVerification = .none
+        config.httpVersion = .automatic
+        config.timeout.connect = .milliseconds(1000)
         let client = HTTPClient(
             eventLoopGroupProvider: .shared(clientGroup),
-            configuration: HTTPClient.Configuration(
-                tlsConfiguration: tlsConfig,
-                timeout: .init(connect: .milliseconds(1000)),
-                httpVersion: .automatic
-            ),
+            configuration: config,
             backgroundActivityLogger: Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
         )
         defer { XCTAssertNoThrow(try client.syncShutdown()) }

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
@@ -12,8 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: remove @testable once we officially support HTTP/2
-@testable import AsyncHTTPClient // Tests that really need @testable go into HTTP2ClientInternalTests.swift
+/* NOT @testable */ import AsyncHTTPClient // Tests that really need @testable go into HTTP2ClientInternalTests.swift
 #if canImport(Network)
     import Network
 #endif

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -250,10 +250,12 @@ class TestConnectionCreator {
 
         var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
         tlsConfiguration.certificateVerification = .none
+        var config = HTTPClient.Configuration()
+        config.httpVersion = .automatic
         let factory = HTTPConnectionPool.ConnectionFactory(
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
-            clientConfiguration: .init(httpVersion: .automatic),
+            clientConfiguration: config,
             sslContextCache: .init()
         )
 
@@ -291,10 +293,12 @@ class TestConnectionCreator {
 
         var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
         tlsConfiguration.certificateVerification = .none
+        var config = HTTPClient.Configuration()
+        config.httpVersion = .automatic
         let factory = HTTPConnectionPool.ConnectionFactory(
             key: .init(request),
             tlsConfiguration: tlsConfiguration,
-            clientConfiguration: .init(httpVersion: .automatic),
+            clientConfiguration: config,
             sslContextCache: .init()
         )
 


### PR DESCRIPTION
This PR does two things:
- makes it possible to enabling and disabling HTTP/2 by making `HTTPVersion` public
- set `HTTPVersion` to `.automatic` by default

HTTP/2 will then be used if we connect to a server with HTTPS and the server supports HTTP/2, otherwise we will continue to use HTTP/1.

A user will still be able to disable HTTP/2 if they want to by setting `HTTPVersion` to `.http1Only` on `HTTPClient.Configuration` e.g.:
```
var configuration = HTTPClient.Configuration()
configuration.httpVersion = .http1Only
let client = HTTPClient(
    eventLoopGroupProvider: .createNew,
    configuration: configuration
)
```