### PR TITLE
bind to loopback only

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
@@ -357,7 +357,7 @@ class HTTP2ClientTests: XCTestCase {
                 channel.close()
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .bind(host: "0.0.0.0", port: serverPort)
+            .bind(host: "127.0.0.1", port: serverPort)
             .wait())
         guard let server = maybeServer else { return }
         defer { XCTAssertNoThrow(try server.close().wait()) }


### PR DESCRIPTION
### Motivation
Binding to all available interface may result in a firewall popup on macOS. We don't want that for our automated tests.

### Changes
Only bind to the local loopback adapter instead of all interfaces.
