### PR TITLE
Only crash in debug mode, if HTTPClient was not shutdown

### DIFF
--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -32,3 +32,13 @@ public final class HTTPClientCopyingDelegate: HTTPClientResponseDelegate {
         return ()
     }
 }
+
+/// A utility function that runs the body code only in debug builds, without
+/// emitting compiler warnings.
+///
+/// This is currently the only way to do this in Swift: see
+/// https://forums.swift.org/t/support-debug-only-code/11037 for a discussion.
+@inlinable
+internal func debugOnly(_ body: () -> Void) {
+    assert({ body(); return true }())
+}


### PR DESCRIPTION
### Motivation

Generally we want to inform users that they need to shutdown their HTTPClient. Until `1.6.0` we did this with an assert in HTTPClient's deinit. With `1.6.0` this behavior was raised to a precondition. This could lead to users to discover suddenly crashes in production, where they have seen none before.

### Changes

- This pr reverts the current behavior back to something pre `1.6.0`

### Result

- HTTPClient doesn't crash in production anymore. 
