### PR TITLE
Always overwrite `Transport-Encoding` and `Content-Length`

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
@@ -1,0 +1,20 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+enum RequestBodyLength: Equatable {
+    /// size of the reuqest body is not known before starting the request
+    case dynamic
+    /// size of the request body is fixed and exactly `length` bytes
+    case fixed(length: Int)
+}

--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 enum RequestBodyLength: Equatable {
-    /// size of the reuqest body is not known before starting the request
+    /// size of the request body is not known before starting the request
     case dynamic
     /// size of the request body is fixed and exactly `length` bytes
     case fixed(length: Int)

--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-enum RequestBodyLength: Equatable {
+enum RequestBodyLength: Hashable {
     /// size of the request body is not known before starting the request
     case dynamic
     /// size of the request body is fixed and exactly `length` bytes

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -883,7 +883,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case remoteConnectionClosed
         case cancelled
         case identityCodingIncorrectlyPresent
-        @available(*, deprecated)
+        @available(*, deprecated, message: "AsyncHTTPClient now silently corrects this invalid header.")
         case chunkedSpecifiedMultipleTimes
         case invalidProxyResponse
         case contentLengthMissing
@@ -895,7 +895,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case invalidHeaderFieldNames([String])
         case bodyLengthMismatch
         case writeAfterRequestSent
-        @available(*, deprecated)
+        @available(*, deprecated, message: "AsyncHTTPClient now silently corrects invalid headers.")
         case incompatibleHeaders
         case connectTimeout
         case socksHandshakeTimeout
@@ -939,7 +939,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     /// Request contains invalid identity encoding.
     public static let identityCodingIncorrectlyPresent = HTTPClientError(code: .identityCodingIncorrectlyPresent)
     /// Request contains multiple chunks definitions.
-    @available(*, deprecated)
+    @available(*, deprecated, message: "AsyncHTTPClient now silently corrects this invalid header.")
     public static let chunkedSpecifiedMultipleTimes = HTTPClientError(code: .chunkedSpecifiedMultipleTimes)
     /// Proxy response was invalid.
     public static let invalidProxyResponse = HTTPClientError(code: .invalidProxyResponse)
@@ -962,7 +962,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     /// Body part was written after request was fully sent.
     public static let writeAfterRequestSent = HTTPClientError(code: .writeAfterRequestSent)
     /// Incompatible headers specified, for example `Transfer-Encoding` and `Content-Length`.
-    @available(*, deprecated)
+    @available(*, deprecated, message: "AsyncHTTPClient now silently corrects invalid headers.")
     public static let incompatibleHeaders = HTTPClientError(code: .incompatibleHeaders)
     /// Creating a new tcp connection timed out
     public static let connectTimeout = HTTPClientError(code: .connectTimeout)

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -884,6 +884,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case cancelled
         case identityCodingIncorrectlyPresent
         case chunkedSpecifiedMultipleTimes
+        case transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding
         case invalidProxyResponse
         case contentLengthMissing
         case proxyAuthenticationRequired
@@ -938,6 +939,8 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     public static let identityCodingIncorrectlyPresent = HTTPClientError(code: .identityCodingIncorrectlyPresent)
     /// Request contains multiple chunks definitions.
     public static let chunkedSpecifiedMultipleTimes = HTTPClientError(code: .chunkedSpecifiedMultipleTimes)
+    /// Request specifies `Transfer-Encoding` but `chunked` is not the final encoding
+    public static let transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding = HTTPClientError(code: .transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding)
     /// Proxy response was invalid.
     public static let invalidProxyResponse = HTTPClientError(code: .invalidProxyResponse)
     /// Request does not contain `Content-Length` header.

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -883,8 +883,8 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case remoteConnectionClosed
         case cancelled
         case identityCodingIncorrectlyPresent
+        @available(*, deprecated)
         case chunkedSpecifiedMultipleTimes
-        case transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding
         case invalidProxyResponse
         case contentLengthMissing
         case proxyAuthenticationRequired
@@ -895,6 +895,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
         case invalidHeaderFieldNames([String])
         case bodyLengthMismatch
         case writeAfterRequestSent
+        @available(*, deprecated)
         case incompatibleHeaders
         case connectTimeout
         case socksHandshakeTimeout
@@ -938,9 +939,8 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     /// Request contains invalid identity encoding.
     public static let identityCodingIncorrectlyPresent = HTTPClientError(code: .identityCodingIncorrectlyPresent)
     /// Request contains multiple chunks definitions.
+    @available(*, deprecated)
     public static let chunkedSpecifiedMultipleTimes = HTTPClientError(code: .chunkedSpecifiedMultipleTimes)
-    /// Request specifies `Transfer-Encoding` but `chunked` is not the final encoding
-    public static let transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding = HTTPClientError(code: .transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding)
     /// Proxy response was invalid.
     public static let invalidProxyResponse = HTTPClientError(code: .invalidProxyResponse)
     /// Request does not contain `Content-Length` header.
@@ -962,6 +962,7 @@ public struct HTTPClientError: Error, Equatable, CustomStringConvertible {
     /// Body part was written after request was fully sent.
     public static let writeAfterRequestSent = HTTPClientError(code: .writeAfterRequestSent)
     /// Incompatible headers specified, for example `Transfer-Encoding` and `Content-Length`.
+    @available(*, deprecated)
     public static let incompatibleHeaders = HTTPClientError(code: .incompatibleHeaders)
     /// Creating a new tcp connection timed out
     public static let connectTimeout = HTTPClientError(code: .connectTimeout)

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -62,7 +62,7 @@ extension HTTPClient {
         /// Create and stream body using `StreamWriter`.
         ///
         /// - parameters:
-        ///     - length: Body size. If nil, `Transfer-Encoding` will be automatically be set to `chunked`. Otherwise a `Content-Length`
+        ///     - length: Body size. If nil, `Transfer-Encoding` will automatically be set to `chunked`. Otherwise a `Content-Length`
         /// header is set with the given `length`.
         ///     - stream: Body chunk provider.
         public static func stream(length: Int? = nil, _ stream: @escaping (StreamWriter) -> EventLoopFuture<Void>) -> Body {

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -43,7 +43,8 @@ extension HTTPClient {
             }
         }
 
-        /// Body size. if nil and `Transfer-Encoding` header is **not** set, `Transfer-Encoding` will be automatically be set to `chunked`
+        /// Body size. if nil,`Transfer-Encoding` will automatically be set to `chunked`. Otherwise a `Content-Length`
+        /// header is set with the given `length`.
         public var length: Int?
         /// Body chunk provider.
         public var stream: (StreamWriter) -> EventLoopFuture<Void>
@@ -61,8 +62,8 @@ extension HTTPClient {
         /// Create and stream body using `StreamWriter`.
         ///
         /// - parameters:
-        ///     - length: Body size. Request validation will be failed with `HTTPClientErrors.contentLengthMissing` if nil,
-        ///               unless `Transfer-Encoding: chunked` header is set.
+        ///     - length: Body size. If nil, `Transfer-Encoding` will be automatically be set to `chunked`. Otherwise a `Content-Length`
+        /// header is set with the given `length`.
         ///     - stream: Body chunk provider.
         public static func stream(length: Int? = nil, _ stream: @escaping (StreamWriter) -> EventLoopFuture<Void>) -> Body {
             return Body(length: length, stream: stream)

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -308,7 +308,7 @@ extension HTTPClient {
                 head.headers.add(name: "host", value: host)
             }
 
-            let metadata = try head.headers.validateAndFixTransportFraming(method: self.method, bodyLength: .init(self.body))
+            let metadata = try head.headers.validateAndSetTransportFraming(method: self.method, bodyLength: .init(self.body))
 
             return (head, metadata)
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -128,7 +128,7 @@ extension HTTPClientTests {
             ("testErrorAfterCloseWhileBackpressureExerted", testErrorAfterCloseWhileBackpressureExerted),
             ("testRequestSpecificTLS", testRequestSpecificTLS),
             ("testConnectionPoolSizeConfigValueIsRespected", testConnectionPoolSizeConfigValueIsRespected),
-            ("testRequestWithHeaderTransferEncodingIdentityFails", testRequestWithHeaderTransferEncodingIdentityFails),
+            ("testRequestWithHeaderTransferEncodingIdentityDoesNotFail", testRequestWithHeaderTransferEncodingIdentityDoesNotFail),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
@@ -45,7 +45,7 @@ extension RequestValidationTests {
             ("testHostHeaderIsSetCorrectlyInCreateRequestHead", testHostHeaderIsSetCorrectlyInCreateRequestHead),
             ("testTraceMethodIsNotAllowedToHaveAFixedLengthBody", testTraceMethodIsNotAllowedToHaveAFixedLengthBody),
             ("testTraceMethodIsNotAllowedToHaveADynamicLengthBody", testTraceMethodIsNotAllowedToHaveADynamicLengthBody),
-            ("testTransferEncodingsAreOverwritteIfBodyLengthIsFixed", testTransferEncodingsAreOverwritteIfBodyLengthIsFixed),
+            ("testTransferEncodingsAreOverwrittenIfBodyLengthIsFixed", testTransferEncodingsAreOverwrittenIfBodyLengthIsFixed),
             ("testTransferEncodingsAreOverwrittenIfBodyLengthIsDynamic", testTransferEncodingsAreOverwrittenIfBodyLengthIsDynamic),
         ]
     }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
@@ -45,9 +45,8 @@ extension RequestValidationTests {
             ("testHostHeaderIsSetCorrectlyInCreateRequestHead", testHostHeaderIsSetCorrectlyInCreateRequestHead),
             ("testTraceMethodIsNotAllowedToHaveAFixedLengthBody", testTraceMethodIsNotAllowedToHaveAFixedLengthBody),
             ("testTraceMethodIsNotAllowedToHaveADynamicLengthBody", testTraceMethodIsNotAllowedToHaveADynamicLengthBody),
-            ("testTransferEncodingsArePreservedIfBodyLengthIsFixed", testTransferEncodingsArePreservedIfBodyLengthIsFixed),
-            ("testTransferEncodingsArePreservedIfBodyLengthIsDynamic", testTransferEncodingsArePreservedIfBodyLengthIsDynamic),
-            ("testTransferEncodingValidation", testTransferEncodingValidation),
+            ("testTransferEncodingsAreOverwritteIfBodyLengthIsFixed", testTransferEncodingsAreOverwritteIfBodyLengthIsFixed),
+            ("testTransferEncodingsAreOverwrittenIfBodyLengthIsDynamic", testTransferEncodingsAreOverwrittenIfBodyLengthIsDynamic),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests+XCTest.swift
@@ -43,6 +43,11 @@ extension RequestValidationTests {
             ("testBothHeadersNoBody", testBothHeadersNoBody),
             ("testBothHeadersHasBody", testBothHeadersHasBody),
             ("testHostHeaderIsSetCorrectlyInCreateRequestHead", testHostHeaderIsSetCorrectlyInCreateRequestHead),
+            ("testTraceMethodIsNotAllowedToHaveAFixedLengthBody", testTraceMethodIsNotAllowedToHaveAFixedLengthBody),
+            ("testTraceMethodIsNotAllowedToHaveADynamicLengthBody", testTraceMethodIsNotAllowedToHaveADynamicLengthBody),
+            ("testTransferEncodingsArePreservedIfBodyLengthIsFixed", testTransferEncodingsArePreservedIfBodyLengthIsFixed),
+            ("testTransferEncodingsArePreservedIfBodyLengthIsDynamic", testTransferEncodingsArePreservedIfBodyLengthIsDynamic),
+            ("testTransferEncodingValidation", testTransferEncodingValidation),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -21,7 +21,7 @@ class RequestValidationTests: XCTestCase {
     func testContentLengthHeaderIsRemovedFromGETIfNoBody() {
         var headers = HTTPHeaders([("Content-Length", "0")])
         var metadata: RequestFramingMetadata?
-        XCTAssertNoThrow(metadata = try headers.validate(method: .GET, body: .none))
+        XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: .GET, bodyLength: .fixed(length: 0)))
         XCTAssertNil(headers.first(name: "Content-Length"))
         XCTAssertEqual(metadata?.body, .fixedSize(0))
     }
@@ -29,23 +29,21 @@ class RequestValidationTests: XCTestCase {
     func testContentLengthHeaderIsAddedToPOSTAndPUTWithNoBody() {
         var putHeaders = HTTPHeaders()
         var putMetadata: RequestFramingMetadata?
-        XCTAssertNoThrow(putMetadata = try putHeaders.validate(method: .PUT, body: .none))
+        XCTAssertNoThrow(putMetadata = try putHeaders.validateAndFixTransportFraming(method: .PUT, bodyLength: .fixed(length: 0)))
         XCTAssertEqual(putHeaders.first(name: "Content-Length"), "0")
         XCTAssertEqual(putMetadata?.body, .fixedSize(0))
 
         var postHeaders = HTTPHeaders()
         var postMetadata: RequestFramingMetadata?
-        XCTAssertNoThrow(postMetadata = try postHeaders.validate(method: .POST, body: .none))
+        XCTAssertNoThrow(postMetadata = try postHeaders.validateAndFixTransportFraming(method: .POST, bodyLength: .fixed(length: 0)))
         XCTAssertEqual(postHeaders.first(name: "Content-Length"), "0")
         XCTAssertEqual(postMetadata?.body, .fixedSize(0))
     }
 
     func testContentLengthHeaderIsChangedIfBodyHasDifferentLength() {
         var headers = HTTPHeaders([("Content-Length", "0")])
-        var buffer = ByteBufferAllocator().buffer(capacity: 200)
-        buffer.writeBytes([UInt8](repeating: 12, count: 200))
         var metadata: RequestFramingMetadata?
-        XCTAssertNoThrow(metadata = try headers.validate(method: .PUT, body: .byteBuffer(buffer)))
+        XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: .PUT, bodyLength: .fixed(length: 200)))
         XCTAssertEqual(headers.first(name: "Content-Length"), "200")
         XCTAssertEqual(metadata?.body, .fixedSize(200))
     }
@@ -53,23 +51,18 @@ class RequestValidationTests: XCTestCase {
     func testTRACERequestMustNotHaveBody() {
         for header in [("Content-Length", "200"), ("Transfer-Encoding", "chunked")] {
             var headers = HTTPHeaders([header])
-            var buffer = ByteBufferAllocator().buffer(capacity: 200)
-            buffer.writeBytes([UInt8](repeating: 12, count: 200))
-            XCTAssertThrowsError(try headers.validate(method: .TRACE, body: .byteBuffer(buffer))) {
+            XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: .TRACE, bodyLength: .fixed(length: 200))) {
                 XCTAssertEqual($0 as? HTTPClientError, .traceRequestWithBody)
             }
         }
     }
 
     func testGET_HEAD_DELETE_CONNECTRequestCanHaveBody() {
-        var buffer = ByteBufferAllocator().buffer(capacity: 100)
-        buffer.writeBytes([UInt8](repeating: 12, count: 100))
-
         // GET, HEAD, DELETE and CONNECT requests can have a payload. (though uncommon)
         let allowedMethods: [HTTPMethod] = [.GET, .HEAD, .DELETE, .CONNECT]
         var headers = HTTPHeaders()
         for method in allowedMethods {
-            XCTAssertNoThrow(try headers.validate(method: method, body: .byteBuffer(buffer)))
+            XCTAssertNoThrow(try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 100)))
         }
     }
 
@@ -79,7 +72,7 @@ class RequestValidationTests: XCTestCase {
             ("User Agent", "Haha"),
         ])
 
-        XCTAssertThrowsError(try headers.validate(method: .GET, body: nil)) { error in
+        XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: .GET, bodyLength: .fixed(length: 0))) { error in
             XCTAssertEqual(error as? HTTPClientError, HTTPClientError.invalidHeaderFieldNames(["User Agent"]))
         }
     }
@@ -92,7 +85,7 @@ class RequestValidationTests: XCTestCase {
             ("!#$%&'*+-.^_`|~", "Haha"),
         ])
 
-        XCTAssertNoThrow(try headers.validate(method: .GET, body: nil))
+        XCTAssertNoThrow(try headers.validateAndFixTransportFraming(method: .GET, bodyLength: .fixed(length: 0)))
     }
 
     func testMetadataDetectConnectionClose() {
@@ -100,14 +93,14 @@ class RequestValidationTests: XCTestCase {
             ("Connection", "close"),
         ])
         var metadata: RequestFramingMetadata?
-        XCTAssertNoThrow(metadata = try headers.validate(method: .GET, body: nil))
+        XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: .GET, bodyLength: .fixed(length: 0)))
         XCTAssertEqual(metadata?.connectionClose, true)
     }
 
     func testMetadataDefaultIsConnectionCloseIsFalse() {
         var headers = HTTPHeaders([])
         var metadata: RequestFramingMetadata?
-        XCTAssertNoThrow(metadata = try headers.validate(method: .GET, body: nil))
+        XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: .GET, bodyLength: .fixed(length: 0)))
         XCTAssertEqual(metadata?.connectionClose, false)
     }
 
@@ -121,7 +114,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT, .TRACE] {
             var headers: HTTPHeaders = .init()
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(0))
@@ -130,7 +123,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init()
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
             XCTAssertEqual(headers["content-length"].first, "0")
             XCTAssertFalse(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .fixedSize(0))
@@ -146,7 +139,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT] {
             var headers: HTTPHeaders = .init()
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
             XCTAssertEqual(headers["content-length"].first, "1")
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(1))
@@ -155,11 +148,8 @@ class RequestValidationTests: XCTestCase {
         // Body length is _not_ known
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT] {
             var headers: HTTPHeaders = .init()
-            let body: HTTPClient.Body = .stream { writer in
-                writer.write(.byteBuffer(ByteBuffer(bytes: [0])))
-            }
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: body))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .dynamic))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .stream)
@@ -169,7 +159,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init()
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
             XCTAssertEqual(headers["content-length"].first, "1")
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(1))
@@ -178,11 +168,8 @@ class RequestValidationTests: XCTestCase {
         // Body length is _not_ known
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init()
-            let body: HTTPClient.Body = .stream { writer in
-                writer.write(.byteBuffer(ByteBuffer(bytes: [0])))
-            }
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: body))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .dynamic))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .stream)
@@ -197,7 +184,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT, .TRACE] {
             var headers: HTTPHeaders = .init([("Content-Length", "1")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(0))
@@ -206,7 +193,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init([("Content-Length", "1")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
             XCTAssertEqual(headers["content-length"].first, "0")
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(0))
@@ -221,7 +208,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT] {
             var headers: HTTPHeaders = .init([("Content-Length", "1")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
             XCTAssertEqual(headers["content-length"].first, "1")
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(1))
@@ -230,7 +217,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init([("Content-Length", "1")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
             XCTAssertEqual(headers["content-length"].first, "1")
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
             XCTAssertEqual(metadata?.body, .fixedSize(1))
@@ -245,7 +232,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT, .TRACE] {
             var headers: HTTPHeaders = .init([("Transfer-Encoding", "chunked")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertFalse(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .fixedSize(0))
@@ -254,7 +241,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init([("Transfer-Encoding", "chunked")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
             XCTAssertEqual(headers["content-length"].first, "0")
             XCTAssertFalse(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .fixedSize(0))
@@ -269,7 +256,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT] {
             var headers: HTTPHeaders = .init([("Transfer-Encoding", "chunked")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .stream)
@@ -278,7 +265,7 @@ class RequestValidationTests: XCTestCase {
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init([("Transfer-Encoding", "chunked")])
             var metadata: RequestFramingMetadata?
-            XCTAssertNoThrow(metadata = try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertNoThrow(metadata = try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].contains("chunked"))
             XCTAssertEqual(metadata?.body, .stream)
@@ -292,12 +279,12 @@ class RequestValidationTests: XCTestCase {
     func testBothHeadersNoBody() throws {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT, .TRACE] {
             var headers: HTTPHeaders = .init([("Content-Length", "1"), ("Transfer-Encoding", "chunked")])
-            XCTAssertThrowsError(try headers.validate(method: method, body: nil))
+            XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
         }
 
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init([("Content-Length", "1"), ("Transfer-Encoding", "chunked")])
-            XCTAssertThrowsError(try headers.validate(method: method, body: nil))
+            XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 0)))
         }
     }
 
@@ -308,12 +295,12 @@ class RequestValidationTests: XCTestCase {
     func testBothHeadersHasBody() throws {
         for method: HTTPMethod in [.GET, .HEAD, .DELETE, .CONNECT, .TRACE] {
             var headers: HTTPHeaders = .init([("Content-Length", "1"), ("Transfer-Encoding", "chunked")])
-            XCTAssertThrowsError(try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
         }
 
         for method: HTTPMethod in [.POST, .PUT] {
             var headers: HTTPHeaders = .init([("Content-Length", "1"), ("Transfer-Encoding", "chunked")])
-            XCTAssertThrowsError(try headers.validate(method: method, body: .byteBuffer(ByteBuffer(bytes: [0]))))
+            XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: method, bodyLength: .fixed(length: 1)))
         }
     }
 
@@ -335,5 +322,64 @@ class RequestValidationTests: XCTestCase {
 
         let req6 = try! HTTPClient.Request(url: "https://localhost/get", headers: ["host": "foo"])
         XCTAssertEqual(try req6.createRequestHead().0.headers["host"].first, "foo")
+    }
+
+    func testTraceMethodIsNotAllowedToHaveAFixedLengthBody() {
+        var headers = HTTPHeaders()
+        XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: .TRACE, bodyLength: .fixed(length: 10)))
+    }
+
+    func testTraceMethodIsNotAllowedToHaveADynamicLengthBody() {
+        var headers = HTTPHeaders()
+        XCTAssertThrowsError(try headers.validateAndFixTransportFraming(method: .TRACE, bodyLength: .dynamic))
+    }
+
+    func testTransferEncodingsArePreservedIfBodyLengthIsFixed() {
+        var headers: HTTPHeaders = [
+            "Transfer-Encoding": "gzip, chunked",
+        ]
+        XCTAssertNoThrow(try headers.validateAndFixTransportFraming(method: .POST, bodyLength: .fixed(length: 1)))
+        XCTAssertEqual(headers, [
+            "Transfer-Encoding": "gzip, chunked",
+        ])
+    }
+
+    func testTransferEncodingsArePreservedIfBodyLengthIsDynamic() {
+        var headers: HTTPHeaders = [
+            "Transfer-Encoding": "gzip, chunked",
+        ]
+        XCTAssertNoThrow(try headers.validateAndFixTransportFraming(method: .POST, bodyLength: .dynamic))
+        XCTAssertEqual(headers, [
+            "Transfer-Encoding": "gzip, chunked",
+        ])
+    }
+
+    func testTransferEncodingValidation() {
+        XCTAssertNoThrow(try HTTPHeaders.validateTransferEncoding([String]()))
+        XCTAssertNoThrow(try HTTPHeaders.validateTransferEncoding(["Chunked"]))
+        XCTAssertNoThrow(try HTTPHeaders.validateTransferEncoding(["chunked"]))
+        XCTAssertNoThrow(try HTTPHeaders.validateTransferEncoding(["gzip", "chunked"]))
+        XCTAssertNoThrow(try HTTPHeaders.validateTransferEncoding(["deflat", "chunked"]))
+
+        XCTAssertThrowsError(try HTTPHeaders.validateTransferEncoding(["gzip"])) {
+            XCTAssertEqual($0 as? HTTPClientError, .transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding)
+        }
+        XCTAssertThrowsError(try HTTPHeaders.validateTransferEncoding(["chunked", "Chunked"])) {
+            XCTAssertEqual($0 as? HTTPClientError, .chunkedSpecifiedMultipleTimes)
+        }
+        XCTAssertThrowsError(try HTTPHeaders.validateTransferEncoding(["chunked", "chunked"])) {
+            XCTAssertEqual($0 as? HTTPClientError, .chunkedSpecifiedMultipleTimes)
+        }
+        XCTAssertThrowsError(try HTTPHeaders.validateTransferEncoding(["chunked", "gzip"])) {
+            XCTAssertEqual($0 as? HTTPClientError, .transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding)
+        }
+        XCTAssertThrowsError(try HTTPHeaders.validateTransferEncoding(["chunked", "gzip", "chunked"])) {
+            let error = $0 as? HTTPClientError
+            XCTAssertTrue(
+                error == .chunkedSpecifiedMultipleTimes ||
+                    error == .transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding,
+                "\(error as Any) must be \(HTTPClientError.chunkedSpecifiedMultipleTimes) or \(HTTPClientError.transferEncodingSpecifiedButChunkedIsNotTheFinalEncoding)"
+            )
+        }
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -323,15 +323,19 @@ class RequestValidationTests: XCTestCase {
 
     func testTraceMethodIsNotAllowedToHaveAFixedLengthBody() {
         var headers = HTTPHeaders()
-        XCTAssertThrowsError(try headers.validateAndSetTransportFraming(method: .TRACE, bodyLength: .fixed(length: 10)))
+        XCTAssertThrowsError(try headers.validateAndSetTransportFraming(method: .TRACE, bodyLength: .fixed(length: 10))) {
+            XCTAssertEqual($0 as? HTTPClientError, .traceRequestWithBody)
+        }
     }
 
     func testTraceMethodIsNotAllowedToHaveADynamicLengthBody() {
         var headers = HTTPHeaders()
-        XCTAssertThrowsError(try headers.validateAndSetTransportFraming(method: .TRACE, bodyLength: .dynamic))
+        XCTAssertThrowsError(try headers.validateAndSetTransportFraming(method: .TRACE, bodyLength: .dynamic)) {
+            XCTAssertEqual($0 as? HTTPClientError, .traceRequestWithBody)
+        }
     }
 
-    func testTransferEncodingsAreOverwritteIfBodyLengthIsFixed() {
+    func testTransferEncodingsAreOverwrittenIfBodyLengthIsFixed() {
         var headers: HTTPHeaders = [
             "Transfer-Encoding": "gzip, chunked",
         ]


### PR DESCRIPTION
### Motivation
We want to reuse request validation in the upcoming async/await implementation. During refactoring we noticed some inconsistency in the current implementation on how user defined `Transport-Encoding` and `Content-Length` headers are processed. We concluded that a user should not be allowed to set `Transport-Encoding` or `Content-Length` headers themselves. A user can only communicate its intend through the `body` property on a request. We infer the correct and most optimal `Transport-Encoding` or `Content-Length` header for them.

### Changes
- `Transport-Encoding` and `Content-Length` or no longer validated and always removed or replaced
- rename `validate` to `validateAndSetTransportFraming` because it does not only validate but also mutate the `HTTPHeaders` to include the correct headers for the given request body.
- introduce a new enum `RequestBodyLength` which can be either `.dynamic` if we do not now the size of a request in advance or `.fixed(length: Int)` if the user has specified the length of the body.
- refactor implementation to no longer expect a `HTTPClient.Request.Body?` but rather a new type `RequestBodyLength`. This allows use to reuse the function for async/await because we will not use `HTTPClient.Request.Body` but rather a new type `HTTPRequest.Body`. 
- no request body (where `HTTPClient.Request.body` is set to nil) and a request body with a length of `0` (e.g where body is `.byteBuffer(ByteBuffer())` are now processed the same way.

### Alternatives
We could also remove `RequestBodyLength` and just use and optional `Int`.