### PR TITLE
Remove redundant `RequestFramingMetadata.Body.none` case

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
@@ -673,7 +673,6 @@ struct HTTPRequestStateMachine {
             // length is greater than zero and we therefore have a body to send
             self.state = .running(.streaming(expectedBodyLength: length, sentBodyBytes: 0, producer: .producing), .waitingForHead)
             return .sendRequestHead(head, startBody: true)
-        
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
@@ -665,13 +665,15 @@ struct HTTPRequestStateMachine {
         case .stream:
             self.state = .running(.streaming(expectedBodyLength: nil, sentBodyBytes: 0, producer: .producing), .waitingForHead)
             return .sendRequestHead(head, startBody: true)
-        case .fixedSize(let length) where length > 0:
-            self.state = .running(.streaming(expectedBodyLength: length, sentBodyBytes: 0, producer: .producing), .waitingForHead)
-            return .sendRequestHead(head, startBody: true)
-        case .none, .fixedSize:
-            // fallback if fixed size is 0
+        case .fixedSize(0):
+            // no body
             self.state = .running(.endSent, .waitingForHead)
             return .sendRequestHead(head, startBody: false)
+        case .fixedSize(let length):
+            // length is greater than zero and we therefore have a body to send
+            self.state = .running(.streaming(expectedBodyLength: length, sentBodyBytes: 0, producer: .producing), .waitingForHead)
+            return .sendRequestHead(head, startBody: true)
+        
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestFramingMetadata.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestFramingMetadata.swift
@@ -14,7 +14,6 @@
 
 struct RequestFramingMetadata: Hashable {
     enum Body: Hashable {
-        case none
         case stream
         case fixedSize(Int)
     }

--- a/Sources/AsyncHTTPClient/RequestValidation.swift
+++ b/Sources/AsyncHTTPClient/RequestValidation.swift
@@ -17,7 +17,7 @@ import NIOHTTP1
 
 extension HTTPHeaders {
     mutating func validate(method: HTTPMethod, body: HTTPClient.Body?) throws -> RequestFramingMetadata {
-        var metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        var metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
 
         if self[canonicalForm: "connection"].lazy.map({ $0.lowercased() }).contains("close") {
             metadata.connectionClose = true

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
@@ -62,7 +62,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
 
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
 
@@ -90,7 +90,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/", headers: ["connection": "close"])
-        let metadata = RequestFramingMetadata(connectionClose: true, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: true, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
 
@@ -106,7 +106,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
 
@@ -122,7 +122,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
 
@@ -139,7 +139,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         XCTAssertEqual(state.channelActive(isWritable: false), .fireChannelActive)
         XCTAssertEqual(state.writabilityChanged(writable: true), .wait)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
 
@@ -168,7 +168,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
 
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
 
@@ -233,7 +233,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
         let responseHead = HTTPResponseHead(version: .http1_1, status: .ok)
@@ -248,7 +248,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
         let responseHead = HTTPResponseHead(version: .http1_1, status: .switchingProtocols)
@@ -260,7 +260,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
-        let metadata = RequestFramingMetadata(connectionClose: false, body: .none)
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
         XCTAssertEqual(newRequestAction, .sendRequestHead(requestHead, startBody: false))
         let responseHead = HTTPResponseHead(version: .http1_1, status: .init(statusCode: 103, reasonPhrase: "Early Hints"))

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -23,7 +23,7 @@ class RequestValidationTests: XCTestCase {
         var metadata: RequestFramingMetadata?
         XCTAssertNoThrow(metadata = try headers.validate(method: .GET, body: .none))
         XCTAssertNil(headers.first(name: "Content-Length"))
-        XCTAssertEqual(metadata?.body, .some(.none))
+        XCTAssertEqual(metadata?.body, .fixedSize(0))
     }
 
     func testContentLengthHeaderIsAddedToPOSTAndPUTWithNoBody() {
@@ -31,13 +31,13 @@ class RequestValidationTests: XCTestCase {
         var putMetadata: RequestFramingMetadata?
         XCTAssertNoThrow(putMetadata = try putHeaders.validate(method: .PUT, body: .none))
         XCTAssertEqual(putHeaders.first(name: "Content-Length"), "0")
-        XCTAssertEqual(putMetadata?.body, .some(.none))
+        XCTAssertEqual(putMetadata?.body, .fixedSize(0))
 
         var postHeaders = HTTPHeaders()
         var postMetadata: RequestFramingMetadata?
         XCTAssertNoThrow(postMetadata = try postHeaders.validate(method: .POST, body: .none))
         XCTAssertEqual(postHeaders.first(name: "Content-Length"), "0")
-        XCTAssertEqual(postMetadata?.body, .some(.none))
+        XCTAssertEqual(postMetadata?.body, .fixedSize(0))
     }
 
     func testContentLengthHeaderIsChangedIfBodyHasDifferentLength() {
@@ -124,7 +124,7 @@ class RequestValidationTests: XCTestCase {
             XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
-            XCTAssertEqual(metadata?.body, .some(.none))
+            XCTAssertEqual(metadata?.body, .fixedSize(0))
         }
 
         for method: HTTPMethod in [.POST, .PUT] {
@@ -133,7 +133,7 @@ class RequestValidationTests: XCTestCase {
             XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
             XCTAssertEqual(headers["content-length"].first, "0")
             XCTAssertFalse(headers["transfer-encoding"].contains("chunked"))
-            XCTAssertEqual(metadata?.body, .some(.none))
+            XCTAssertEqual(metadata?.body, .fixedSize(0))
         }
     }
 
@@ -200,7 +200,7 @@ class RequestValidationTests: XCTestCase {
             XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
-            XCTAssertEqual(metadata?.body, .some(.none))
+            XCTAssertEqual(metadata?.body, .fixedSize(0))
         }
 
         for method: HTTPMethod in [.POST, .PUT] {
@@ -209,7 +209,7 @@ class RequestValidationTests: XCTestCase {
             XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
             XCTAssertEqual(headers["content-length"].first, "0")
             XCTAssertTrue(headers["transfer-encoding"].isEmpty)
-            XCTAssertEqual(metadata?.body, .some(.none))
+            XCTAssertEqual(metadata?.body, .fixedSize(0))
         }
     }
 
@@ -248,7 +248,7 @@ class RequestValidationTests: XCTestCase {
             XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
             XCTAssertTrue(headers["content-length"].isEmpty)
             XCTAssertFalse(headers["transfer-encoding"].contains("chunked"))
-            XCTAssertEqual(metadata?.body, .some(.none))
+            XCTAssertEqual(metadata?.body, .fixedSize(0))
         }
 
         for method: HTTPMethod in [.POST, .PUT] {
@@ -257,7 +257,7 @@ class RequestValidationTests: XCTestCase {
             XCTAssertNoThrow(metadata = try headers.validate(method: method, body: nil))
             XCTAssertEqual(headers["content-length"].first, "0")
             XCTAssertFalse(headers["transfer-encoding"].contains("chunked"))
-            XCTAssertEqual(metadata?.body, .some(.none))
+            XCTAssertEqual(metadata?.body, .fixedSize(0))
         }
     }
 


### PR DESCRIPTION
### Motivation
The distinction between no request body (`.none`) and a request body of size `0` (`.fixedSize(0)`) is unnecessary and we explicitly have code to ignore this:
https://github.com/swift-server/async-http-client/blob/ec2e080d7011a81bd67f10bf41efe6104d7799d6/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift#L668-L674
We can therefore just remove it.
### Changes
- replace `.none` with `.fixedSize(0)`
- remove `.none` from the definition of `RequestFramingMetadata.Body`