### PR TITLE
Make `http1Connections` and `http2Connections` non-optional

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
@@ -537,6 +537,9 @@ extension HTTPConnectionPool {
             self.connections = self.connections.enumerated().compactMap { index, connectionState in
                 switch connectionState.migrateToHTTP2(&migrationContext) {
                 case .removeConnection:
+                    // If the connection has an index smaller than the previous overflow index,
+                    // we deal with a general purpose connection.
+                    // For this reason we need to decrement the overflow index.
                     if index < initialOverflowIndex {
                         self.overflowIndex = self.connections.index(before: self.overflowIndex)
                     }
@@ -660,6 +663,9 @@ extension HTTPConnectionPool {
             self.connections = self.connections.enumerated().compactMap { index, connectionState in
                 switch connectionState.cleanup(&cleanupContext) {
                 case .removeConnection:
+                    // If the connection has an index smaller than the previous overflow index,
+                    // we deal with a general purpose connection.
+                    // For this reason we need to decrement the overflow index.
                     if index < initialOverflowIndex {
                         self.overflowIndex = self.connections.index(before: self.overflowIndex)
                     }

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
@@ -546,8 +546,6 @@ extension HTTPConnectionPool {
         }
 
         mutating func http2ConnectionStreamClosed(_ connectionID: Connection.ID) -> Action {
-            // It is save to bang the http2Connections here. If we get this callback but we don't have
-            // http2 connections something has gone terribly wrong.
             switch self.state {
             case .running:
                 let (index, context) = self.http2Connections.releaseStream(connectionID)

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
@@ -511,19 +511,11 @@ extension HTTPConnectionPool {
         // MARK: HTTP2
 
         mutating func newHTTP2MaxConcurrentStreamsReceived(_ connectionID: Connection.ID, newMaxStreams: Int) -> Action {
-            // The `http2Connections` are optional here:
-            // Connections report events back to us, if they are in a shutdown that was
-            // initiated by the state machine. For this reason this callback might be invoked
-            // even though all references to HTTP2Connections have already been cleared.
             _ = self.http2Connections.newHTTP2MaxConcurrentStreamsReceived(connectionID, newMaxStreams: newMaxStreams)
             return .none
         }
 
         mutating func http2ConnectionGoAwayReceived(_ connectionID: Connection.ID) -> Action {
-            // The `http2Connections` are optional here:
-            // Connections report events back to us, if they are in a shutdown that was
-            // initiated by the state machine. For this reason this callback might be invoked
-            // even though all references to HTTP2Connections have already been cleared.
             _ = self.http2Connections.goAwayReceived(connectionID)
             return .none
         }

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -521,8 +521,6 @@ extension HTTPConnectionPool {
         }
 
         mutating func http1ConnectionReleased(_ connectionID: Connection.ID) -> Action {
-            // It is save to bang the http1Connections here. If we get this callback but we don't have
-            // http1 connections something has gone terribly wrong.
             let (index, _) = self.http1Connections.releaseConnection(connectionID)
             // Any http1 connection that becomes idle should be closed right away after the transition
             // to http2.

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -139,11 +139,8 @@ extension HTTPConnectionPool {
             switch self.state {
             case .http1(let http1StateMachine):
 
-                var http2StateMachine = HTTP2StateMachine(
+                let (http2StateMachine, migrationAction) = HTTP2StateMachine.migrateFromHTTP1(
                     idGenerator: self.idGenerator,
-                    maximumConcurrentHTTP1Connections: self.maximumConcurrentHTTP1Connections
-                )
-                let migrationAction = http2StateMachine.migrateFromHTTP1(
                     http1Connections: http1StateMachine.connections,
                     http2Connections: http1StateMachine.http2Connections,
                     requests: http1StateMachine.requests,

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -140,7 +140,8 @@ extension HTTPConnectionPool {
             case .http1(let http1StateMachine):
 
                 var http2StateMachine = HTTP2StateMachine(
-                    idGenerator: self.idGenerator
+                    idGenerator: self.idGenerator,
+                    maximumConcurrentHTTP1Connections: self.maximumConcurrentHTTP1Connections
                 )
                 let migrationAction = http2StateMachine.migrateFromHTTP1(
                     http1Connections: http1StateMachine.connections,


### PR DESCRIPTION
Follow up from https://github.com/swift-server/async-http-client/pull/481#discussion_r753034593