### PR TITLE
[Tests] Add some basic IPv6 tests

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -38,6 +38,8 @@ extension HTTPClientTests {
             ("testGetHttps", testGetHttps),
             ("testGetHttpsWithIP", testGetHttpsWithIP),
             ("testGetHTTPSWorksOnMTELGWithIP", testGetHTTPSWorksOnMTELGWithIP),
+            ("testGetHttpsWithIPv6", testGetHttpsWithIPv6),
+            ("testGetHTTPSWorksOnMTELGWithIPv6", testGetHTTPSWorksOnMTELGWithIPv6),
             ("testPostHttps", testPostHttps),
             ("testHttpRedirect", testHttpRedirect),
             ("testHttpHostRedirect", testHttpHostRedirect),


### PR DESCRIPTION
While working on the WebURL port, I noticed that there seemed to be no tests at all covering IPv6.

These are just 2 very simple ones, copies of `testGetHttpsWithIP` and `testGetHTTPSWorksOnMTELGWithIP` which use IPv6 rather than IPv4. It would be good to add more (in particular, I think it would be worth testing that the proxy's CONNECT request-target is properly formatted, but I'm not that familiar with the project so I'm unsure how to write proxy tests).