### PR TITLE
Refactor URL component extraction

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -29,6 +29,7 @@ extension HTTPClientTests {
             ("testBadRequestURI", testBadRequestURI),
             ("testSchemaCasing", testSchemaCasing),
             ("testURLSocketPathInitializers", testURLSocketPathInitializers),
+            ("testBadUnixWithBaseURL", testBadUnixWithBaseURL),
             ("testConvenienceExecuteMethods", testConvenienceExecuteMethods),
             ("testConvenienceExecuteMethodsOverSocket", testConvenienceExecuteMethodsOverSocket),
             ("testConvenienceExecuteMethodsOverSecureSocket", testConvenienceExecuteMethodsOverSecureSocket),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -215,6 +215,14 @@ class HTTPClientTests: XCTestCase {
         XCTAssertNil(url10)
     }
 
+    func testBadUnixWithBaseURL() {
+        let badUnixBaseURL = URL(string: "/foo", relativeTo: URL(string: "unix:")!)!
+        XCTAssertEqual(badUnixBaseURL.baseURL?.path, "")
+        XCTAssertThrowsError(try Request(url: badUnixBaseURL), "should throw") { error in
+            XCTAssertEqual(error as! HTTPClientError, HTTPClientError.missingSocketPath)
+        }
+    }
+
     func testConvenienceExecuteMethods() throws {
         XCTAssertNoThrow(XCTAssertEqual(["GET"[...]],
                                         try self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "echo-method").wait().headers[canonicalForm: "X-Method-Used"]))

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -218,7 +218,7 @@ class HTTPClientTests: XCTestCase {
     func testBadUnixWithBaseURL() {
         let badUnixBaseURL = URL(string: "/foo", relativeTo: URL(string: "unix:")!)!
         XCTAssertEqual(badUnixBaseURL.baseURL?.path, "")
-        XCTAssertThrowsError(try Request(url: badUnixBaseURL), "should throw") { error in
+        XCTAssertThrowsError(try Request(url: badUnixBaseURL)) { error in
             XCTAssertEqual(error as! HTTPClientError, HTTPClientError.missingSocketPath)
         }
     }


### PR DESCRIPTION
This is currently split across 4 functions (well, 3 functions and an initialiser). It's much easier to understand how AHC understands these URL formats if it happens in a single function (especially since schemes like `http+unix` are not standardised).

Additionally, this rejects empty HTTP hostnames, as they are invalid per the spec, and empty socket paths, since they are meaningless.