### PR TITLE
Fix bug in migration from HTTP1 to HTTP2 and back to HTTP1

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1ConnectionsTest+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1ConnectionsTest+XCTest.swift
@@ -41,6 +41,7 @@ extension HTTPConnectionPool_HTTP1ConnectionsTests {
             ("testMigrationFromHTTP2WithAlreadyLeasedHTTP1Connection", testMigrationFromHTTP2WithAlreadyLeasedHTTP1Connection),
             ("testMigrationFromHTTP2WithMoreStartingConnectionsThanMaximumAllowedConccurentConnections", testMigrationFromHTTP2WithMoreStartingConnectionsThanMaximumAllowedConccurentConnections),
             ("testMigrationFromHTTP2StartsEnoghOverflowConnectionsForRequiredEventLoopRequests", testMigrationFromHTTP2StartsEnoghOverflowConnectionsForRequiredEventLoopRequests),
+            ("testMigrationFromHTTP1ToHTTP2AndBackToHTTP1", testMigrationFromHTTP1ToHTTP2AndBackToHTTP1),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1ConnectionsTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1ConnectionsTest.swift
@@ -598,10 +598,8 @@ class HTTPConnectionPool_HTTP1ConnectionsTests: XCTestCase {
 
 extension HTTPConnectionPool.HTTP1Connections.HTTP1ToHTTP2MigrationContext: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.close == rhs.close && lhs.starting.elementsEqual(rhs.starting, by: {
-            $0.0 == $1.0 && $0.1 === $1.1
-        }) && lhs.backingOff.elsementsEqual(rhs.backingOff, by: {
-            $0.0 == $1.0 && $0.1 === $1.1
-        })
+        return lhs.close == rhs.close &&
+            lhs.starting.elementsEqual(rhs.starting, by: { $0.0 == $1.0 && $0.1 === $1.1 }) &&
+            lhs.backingOff.elementsEqual(rhs.backingOff, by: { $0.0 == $1.0 && $0.1 === $1.1 })
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1ConnectionsTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP1ConnectionsTest.swift
@@ -598,12 +598,10 @@ class HTTPConnectionPool_HTTP1ConnectionsTests: XCTestCase {
 
 extension HTTPConnectionPool.HTTP1Connections.HTTP1ToHTTP2MigrationContext: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.close == rhs.close &&
-            lhs.starting.elementsEqual(rhs.starting, by: {
-                $0.0 == $1.0 && $0.1 === $1.1
-        }) &&
-            lhs.backingOff.elementsEqual(rhs.backingOff, by: {
-                $0.0 == $1.0 && $0.1 === $1.1
+        lhs.close == rhs.close && lhs.starting.elementsEqual(rhs.starting, by: {
+            $0.0 == $1.0 && $0.1 === $1.1
+        }) && lhs.backingOff.elsementsEqual(rhs.backingOff, by: {
+            $0.0 == $1.0 && $0.1 === $1.1
         })
     }
 }


### PR DESCRIPTION
We forgot to update the `overflowIndex` during migration from HTTP1 to HTTP2. The added test case would crash without the fix.