### PR TITLE
Update swiftformat to 0.48.8

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,14 +1,23 @@
 # file options
 
---swiftversion 5.0
+--swiftversion 5.2
 --exclude .build
 
 # format options
 
 --self insert
 --patternlet inline
---stripunusedargs unnamed-only
 --ranges nospace
---disable typeSugar, andOperator # typeSugar: https://github.com/nicklockwood/SwiftFormat/issues/636
+--stripunusedargs unnamed-only
+--ifdef indent
+--extensionacl on-declarations
+--disable typeSugar # https://github.com/nicklockwood/SwiftFormat/issues/636
+--disable andOperator
+--disable wrapMultilineStatementBraces
+--disable enumNamespaces
+--disable redundantExtensionACL
+--disable redundantReturn
+--disable preferKeyPath
+--disable sortedSwitchCases
 
 # rules

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
@@ -97,7 +97,7 @@ final class HTTP2Connection {
             targetWindowSize: 8 * 1024 * 1024, // 8mb
             outboundBufferSizeHighWatermark: 8196,
             outboundBufferSizeLowWatermark: 4092,
-            inboundStreamInitializer: { (channel) -> EventLoopFuture<Void> in
+            inboundStreamInitializer: { channel -> EventLoopFuture<Void> in
                 channel.eventLoop.makeFailedFuture(HTTP2PushNotSupportedError())
             }
         )

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -115,7 +115,7 @@ extension HTTPConnectionPool.ConnectionFactory {
             deadline: deadline,
             eventLoop: eventLoop,
             logger: logger
-        ).flatMapThrowing { (negotiated) -> Channel in
+        ).flatMapThrowing { negotiated -> Channel in
 
             guard case .http1_1(let channel) = negotiated else {
                 preconditionFailure("Expected to create http/1.1 connections only for now")
@@ -453,7 +453,7 @@ extension HTTPConnectionPool.ConnectionFactory {
         let bootstrap = ClientBootstrap(group: eventLoop)
             .connectTimeout(deadline - NIODeadline.now())
             .channelInitializer { channel in
-                sslContextFuture.flatMap { (sslContext) -> EventLoopFuture<Void> in
+                sslContextFuture.flatMap { sslContext -> EventLoopFuture<Void> in
                     do {
                         let sync = channel.pipeline.syncOperations
                         let sslHandler = try NIOSSLClientHandler(
@@ -497,8 +497,8 @@ extension ConnectionPool.Key.Scheme {
     }
 }
 
-private extension String {
-    var isIPAddress: Bool {
+extension String {
+    fileprivate var isIPAddress: Bool {
         var ipv4Addr = in_addr()
         var ipv6Addr = in6_addr()
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
@@ -191,8 +191,8 @@ struct HTTPRequestStateMachine {
 
     mutating func errorHappened(_ error: Error) -> Action {
         if let error = error as? NIOSSLError,
-            error == .uncleanShutdown,
-            let action = self.handleNIOSSLUncleanShutdownError() {
+           error == .uncleanShutdown,
+           let action = self.handleNIOSSLUncleanShutdownError() {
             return action
         }
         switch self.state {
@@ -435,7 +435,7 @@ struct HTTPRequestStateMachine {
         case .running(let requestState, .receivingBody(let head, var streamState)):
             // This should never happen. But we don't want to precondition this behavior. Let's just
             // pass the read event on
-            return self.avoidingStateMachineCoW { (state) -> Action in
+            return self.avoidingStateMachineCoW { state -> Action in
                 let action = streamState.read()
                 state = .running(requestState, .receivingBody(head, streamState))
                 return action.toRequestAction()
@@ -470,7 +470,7 @@ struct HTTPRequestStateMachine {
         case .running(let requestState, .receivingBody(let head, var streamState)):
             // This should never happen. But we don't want to precondition this behavior. Let's just
             // pass the read event on
-            return self.avoidingStateMachineCoW { (state) -> Action in
+            return self.avoidingStateMachineCoW { state -> Action in
                 let buffer = streamState.channelReadComplete()
                 state = .running(requestState, .receivingBody(head, streamState))
                 if let buffer = buffer {
@@ -542,7 +542,7 @@ struct HTTPRequestStateMachine {
             preconditionFailure("How can we receive a response body, if we haven't received a head. Invalid state: \(self.state)")
 
         case .running(let requestState, .receivingBody(let head, var responseStreamState)):
-            return self.avoidingStateMachineCoW { (state) -> Action in
+            return self.avoidingStateMachineCoW { state -> Action in
                 responseStreamState.receivedBodyPart(body)
                 state = .running(requestState, .receivingBody(head, responseStreamState))
                 return .wait

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
@@ -610,7 +610,7 @@ extension HTTPConnectionPool {
                 uniquingKeysWith: +
             )
             var connectionToCreate = requiredEventLoopOfPendingRequests
-                .flatMap { (eventLoop, requestCount) -> [(Connection.ID, EventLoop)] in
+                .flatMap { eventLoop, requestCount -> [(Connection.ID, EventLoop)] in
                     // We need a connection for each queued request with a required event loop.
                     // Therefore, we look how many request we have queued for a given `eventLoop` and
                     // how many connections we are already starting on the given `eventLoop`.

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -26,7 +26,7 @@ extension HTTPConnectionPool {
                 self.connection = connection
             }
 
-            static let none: Action = Action(request: .none, connection: .none)
+            static let none = Action(request: .none, connection: .none)
         }
 
         enum ConnectionAction {

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -67,7 +67,7 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
         self.reportHead?(head)
 
         if let totalBytesString = head.headers.first(name: "Content-Length"),
-            let totalBytes = Int(totalBytesString) {
+           let totalBytes = Int(totalBytesString) {
             self.progress.totalBytes = totalBytes
         }
 

--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -153,8 +153,8 @@ extension HTTPClient {
     }
 }
 
-private extension String {
-    func omittingQuotes() -> String {
+extension String {
+    fileprivate func omittingQuotes() -> String {
         let dquote = "\""
         if !hasPrefix(dquote) || !hasSuffix(dquote) {
             return self

--- a/Sources/AsyncHTTPClient/RequestValidation.swift
+++ b/Sources/AsyncHTTPClient/RequestValidation.swift
@@ -45,8 +45,8 @@ extension HTTPHeaders {
     }
 
     private func validateFieldNames() throws {
-        let invalidFieldNames = self.compactMap { (name, _) -> String? in
-            let satisfy = name.utf8.allSatisfy { (char) -> Bool in
+        let invalidFieldNames = self.compactMap { name, _ -> String? in
+            let satisfy = name.utf8.allSatisfy { char -> Bool in
                 switch char {
                 case UInt8(ascii: "a")...UInt8(ascii: "z"),
                      UInt8(ascii: "A")...UInt8(ascii: "Z"),

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -342,8 +342,7 @@ extension TestConnectionCreator: HTTPConnectionRequester {
     }
 
     func http1ConnectionCreated(_ connection: HTTP1Connection) {
-        let wrapper = self.lock.withLock {
-            () -> (EitherPromiseWrapper<HTTP1Connection, HTTP2Connection>) in
+        let wrapper = self.lock.withLock { () -> (EitherPromiseWrapper<HTTP1Connection, HTTP2Connection>) in
 
             switch self.state {
             case .waitingForHTTP1Connection(let promise):
@@ -360,8 +359,7 @@ extension TestConnectionCreator: HTTPConnectionRequester {
     }
 
     func http2ConnectionCreated(_ connection: HTTP2Connection, maximumStreams: Int) {
-        let wrapper = self.lock.withLock {
-            () -> (EitherPromiseWrapper<HTTP2Connection, HTTP1Connection>) in
+        let wrapper = self.lock.withLock { () -> (EitherPromiseWrapper<HTTP2Connection, HTTP1Connection>) in
 
             switch self.state {
             case .waitingForHTTP1Connection(let promise):
@@ -392,8 +390,7 @@ extension TestConnectionCreator: HTTPConnectionRequester {
     }
 
     func failedToCreateHTTPConnection(_: HTTPConnectionPool.Connection.ID, error: Swift.Error) {
-        let wrapper = self.lock.withLock {
-            () -> (FailPromiseWrapper<HTTP1Connection, HTTP2Connection>) in
+        let wrapper = self.lock.withLock { () -> (FailPromiseWrapper<HTTP1Connection, HTTP2Connection>) in
 
             switch self.state {
             case .waitingForHTTP1Connection(let promise):

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -40,7 +40,7 @@ func isTestingNIOTS() -> Bool {
 func getDefaultEventLoopGroup(numberOfThreads: Int) -> EventLoopGroup {
     #if canImport(Network)
         if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *),
-            isTestingNIOTS() {
+           isTestingNIOTS() {
             return NIOTSEventLoopGroup(loopCount: numberOfThreads, defaultQoS: .default)
         }
     #endif
@@ -601,7 +601,7 @@ final class HTTPProxySimulator: ChannelInboundHandler, RemovableChannelHandler {
 
             if let expectedAuhorization = self.expectedAuhorization {
                 guard let authorization = head.headers["proxy-authorization"].first,
-                    expectedAuhorization == authorization else {
+                      expectedAuhorization == authorization else {
                     self.head.status = .proxyAuthenticationRequired
                     return
                 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2520,11 +2520,10 @@ class HTTPClientTests: XCTestCase {
             return done
         }
 
-        XCTAssertThrowsError(
-            try self.defaultClient.execute(request:
-                Request(url: url,
-                        body: .stream(length: 1, uploader))).wait()) { error in
-            XCTAssertEqual(HTTPClientError.writeAfterRequestSent, error as? HTTPClientError)
+        var request: HTTPClient.Request?
+        XCTAssertNoThrow(request = try Request(url: url, body: .stream(length: 1, uploader)))
+        XCTAssertThrowsError(try self.defaultClient.execute(request: XCTUnwrap(request)).wait()) {
+            XCTAssertEqual($0 as? HTTPClientError, .writeAfterRequestSent)
         }
 
         // Quickly try another request and check that it works. If we by accident wrote some extra bytes into the

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -951,7 +951,7 @@ class HTTPClientTests: XCTestCase {
                                                     method: .GET,
                                                     uri: "/foo",
                                                     headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
-                                        try web.readInbound()))
+            try web.readInbound()))
         XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                         try web.readInbound()))
         XCTAssertNoThrow(try web.writeOutbound(.head(.init(version: .init(major: 1, minor: 1),
@@ -998,7 +998,7 @@ class HTTPClientTests: XCTestCase {
                                                     method: .GET,
                                                     uri: "/foo",
                                                     headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
-                                        try web.readInbound()))
+            try web.readInbound()))
         XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                         try web.readInbound()))
         XCTAssertNoThrow(try web.stop())
@@ -1021,7 +1021,7 @@ class HTTPClientTests: XCTestCase {
                                                         method: .GET,
                                                         uri: "/foo",
                                                         headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
-                                            try web.readInbound()))
+                try web.readInbound()))
             XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                             try web.readInbound()))
             XCTAssertNoThrow(try web.writeOutbound(.head(.init(version: .init(major: 1, minor: 0),
@@ -1049,7 +1049,7 @@ class HTTPClientTests: XCTestCase {
                                                         method: .GET,
                                                         uri: "/foo",
                                                         headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
-                                            try web.readInbound()))
+                try web.readInbound()))
             XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                             try web.readInbound()))
             XCTAssertNoThrow(try web.writeOutbound(.head(.init(version: .init(major: 1, minor: 0),
@@ -1109,7 +1109,7 @@ class HTTPClientTests: XCTestCase {
                         // errSSLPeerProtocolVersion because the first bytes contain the version.
                         XCTAssert(clientError.status == errSSLHandshakeFail ||
                             clientError.status == errSSLPeerProtocolVersion,
-                                  "unexpected NWTLSError with status \(clientError.status)")
+                            "unexpected NWTLSError with status \(clientError.status)")
                     #endif
                 } else {
                     guard let clientError = error as? NIOSSLError, case NIOSSLError.handshakeFailed = clientError else {
@@ -1226,7 +1226,7 @@ class HTTPClientTests: XCTestCase {
                                                         method: .GET,
                                                         uri: "/foo",
                                                         headers: HTTPHeaders([("Host", "localhost:\(web.serverPort)")]))),
-                                            try web.readInbound()))
+                try web.readInbound()))
             XCTAssertNoThrow(XCTAssertEqual(.end(nil),
                                             try web.readInbound()))
             XCTAssertNoThrow(try web.writeOutbound(.head(.init(version: .init(major: 1, minor: 1),
@@ -1524,7 +1524,7 @@ class HTTPClientTests: XCTestCase {
                 XCTAssertNoThrow(try localHTTPBin.shutdown())
             }
             guard let target = URL(string: "/echo-uri", relativeTo: URL(string: "unix://\(path)")),
-                let request = try? Request(url: target) else {
+                  let request = try? Request(url: target) else {
                 XCTFail("couldn't build URL for request")
                 return
             }
@@ -1541,7 +1541,7 @@ class HTTPClientTests: XCTestCase {
                 XCTAssertNoThrow(try localHTTPBin.shutdown())
             }
             guard let target = URL(httpURLWithSocketPath: path, uri: "/echo-uri"),
-                let request = try? Request(url: target) else {
+                  let request = try? Request(url: target) else {
                 XCTFail("couldn't build URL for request")
                 return
             }
@@ -1561,7 +1561,7 @@ class HTTPClientTests: XCTestCase {
                 XCTAssertNoThrow(try localHTTPBin.shutdown())
             }
             guard let target = URL(httpsURLWithSocketPath: path, uri: "/echo-uri"),
-                let request = try? Request(url: target) else {
+                  let request = try? Request(url: target) else {
                 XCTFail("couldn't build URL for request")
                 return
             }
@@ -1896,12 +1896,12 @@ class HTTPClientTests: XCTestCase {
             return
         }
         guard let statsBytes2 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-            let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
+              let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
             XCTFail("request 2 didn't work")
             return
         }
         guard let statsBytes3 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-            let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
+              let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
             XCTFail("request 3 didn't work")
             return
         }
@@ -1926,12 +1926,12 @@ class HTTPClientTests: XCTestCase {
             return
         }
         guard let statsBytes2 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-            let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
+              let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
             XCTFail("request 2 didn't work")
             return
         }
         guard let statsBytes3 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-            let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
+              let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
             XCTFail("request 3 didn't work")
             return
         }
@@ -1958,12 +1958,12 @@ class HTTPClientTests: XCTestCase {
                 return
             }
             guard let statsBytes2 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-                let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
+                  let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
                 XCTFail("request 2 didn't work")
                 return
             }
             guard let statsBytes3 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-                let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
+                  let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
                 XCTFail("request 3 didn't work")
                 return
             }
@@ -1990,12 +1990,12 @@ class HTTPClientTests: XCTestCase {
                 return
             }
             guard let statsBytes2 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-                let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
+                  let stats2 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes2) else {
                 XCTFail("request 2 didn't work")
                 return
             }
             guard let statsBytes3 = try? self.defaultClient.get(url: self.defaultHTTPBinURLPrefix + "stats").wait().body,
-                let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
+                  let stats3 = try? JSONDecoder().decode(RequestInfo.self, from: statsBytes3) else {
                 XCTFail("request 3 didn't work")
                 return
             }
@@ -2013,20 +2013,20 @@ class HTTPClientTests: XCTestCase {
     func testLoggingCorrectlyAttachesRequestInformation() {
         let logStore = CollectEverythingLogHandler.LogStore()
 
-        var loggerYolo001: Logger = Logger(label: "\(#function)", factory: { _ in
+        var loggerYolo001 = Logger(label: "\(#function)", factory: { _ in
             CollectEverythingLogHandler(logStore: logStore)
         })
         loggerYolo001.logLevel = .trace
         loggerYolo001[metadataKey: "yolo-request-id"] = "yolo-001"
-        var loggerACME002: Logger = Logger(label: "\(#function)", factory: { _ in
+        var loggerACME002 = Logger(label: "\(#function)", factory: { _ in
             CollectEverythingLogHandler(logStore: logStore)
         })
         loggerACME002.logLevel = .trace
         loggerACME002[metadataKey: "acme-request-id"] = "acme-002"
 
         guard let request1 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "get"),
-            let request2 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "stats"),
-            let request3 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "ok") else {
+              let request2 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "stats"),
+              let request3 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "ok") else {
             XCTFail("bad stuff, can't even make request structures")
             return
         }
@@ -2062,7 +2062,7 @@ class HTTPClientTests: XCTestCase {
 
         XCTAssert(logsAfterReq1.allSatisfy { entry in
             if let httpRequestMetadata = entry.metadata["ahc-request-id"],
-                let yoloRequestID = entry.metadata["yolo-request-id"] {
+               let yoloRequestID = entry.metadata["yolo-request-id"] {
                 XCTAssertNil(entry.metadata["acme-request-id"])
                 XCTAssertEqual("yolo-001", yoloRequestID)
                 XCTAssertNotNil(Int(httpRequestMetadata))
@@ -2088,7 +2088,7 @@ class HTTPClientTests: XCTestCase {
 
         XCTAssert(logsAfterReq2.allSatisfy { entry in
             if let httpRequestMetadata = entry.metadata["ahc-request-id"],
-                let yoloRequestID = entry.metadata["yolo-request-id"] {
+               let yoloRequestID = entry.metadata["yolo-request-id"] {
                 XCTAssertNil(entry.metadata["acme-request-id"])
                 XCTAssertEqual("yolo-001", yoloRequestID)
                 XCTAssertNotNil(Int(httpRequestMetadata))
@@ -2109,7 +2109,7 @@ class HTTPClientTests: XCTestCase {
 
         XCTAssert(logsAfterReq3.allSatisfy { entry in
             if let httpRequestMetadata = entry.metadata["ahc-request-id"],
-                let acmeRequestID = entry.metadata["acme-request-id"] {
+               let acmeRequestID = entry.metadata["acme-request-id"] {
                 XCTAssertNil(entry.metadata["yolo-request-id"])
                 XCTAssertEqual("acme-002", acmeRequestID)
                 XCTAssertNotNil(Int(httpRequestMetadata))
@@ -2132,13 +2132,13 @@ class HTTPClientTests: XCTestCase {
     func testNothingIsLoggedAtInfoOrHigher() {
         let logStore = CollectEverythingLogHandler.LogStore()
 
-        var logger: Logger = Logger(label: "\(#function)", factory: { _ in
+        var logger = Logger(label: "\(#function)", factory: { _ in
             CollectEverythingLogHandler(logStore: logStore)
         })
         logger.logLevel = .info
 
         guard let request1 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "get"),
-            let request2 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "stats") else {
+              let request2 = try? HTTPClient.Request(url: self.defaultHTTPBinURLPrefix + "stats") else {
             XCTFail("bad stuff, can't even make request structures")
             return
         }
@@ -2227,7 +2227,7 @@ class HTTPClientTests: XCTestCase {
         func checkExpectationsWithLogger<T>(type: String, _ body: (Logger, String) throws -> T) throws -> T {
             let logStore = CollectEverythingLogHandler.LogStore()
 
-            var logger: Logger = Logger(label: "\(#function)", factory: { _ in
+            var logger = Logger(label: "\(#function)", factory: { _ in
                 CollectEverythingLogHandler(logStore: logStore)
             })
             logger.logLevel = .trace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
 # swiftformat (until part of the toolchain)
 
-ARG swiftformat_version=0.44.6
+ARG swiftformat_version=0.48.8
 RUN git clone --branch $swiftformat_version --depth 1 https://github.com/nicklockwood/SwiftFormat $HOME/.tools/swift-format
 RUN cd $HOME/.tools/swift-format && swift build -c release
 RUN ln -s $HOME/.tools/swift-format/.build/release/swiftformat $HOME/.tools/swiftformat


### PR DESCRIPTION
### Motivation

Our current swiftformat version does not support async/await. Since we want to add support for async/await we must update swiftformat or disable it. I tried my very best to keep the number of changes as small as possible. I assume we want to stick with the new 0.48.8 for some time.

### Changes

- Update swiftformat to 0.48.8

### Result

We can land async/await code.