### PR TITLE
Add `XCTAsyncTest` and `XCTAssertThrowsError` from gRPC Swift

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -35,7 +35,7 @@ This product contains derivations of various scripts from SwiftNIO.
     
 ---
     
-This product contains "XCTest+AsyncAwait.swift" from gRPC Swift.
+This product contains a derivation of "XCTest+AsyncAwait.swift" from gRPC Swift.
 
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -27,7 +27,7 @@ components that this product depends on.
 -------------------------------------------------------------------------------
 
 
-This product contains a derivation various scripts from SwiftNIO and contains "XCTest+AsyncAwait.swift" from gRPC Swift.
+This product contains derivations of various scripts from SwiftNIO and contains "XCTest+AsyncAwait.swift" from gRPC Swift.
 
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -24,20 +24,32 @@ Also, please refer to each LICENSE.txt file, which is located in
 the 'license' directory of the distribution file, for the license terms of the
 components that this product depends on.
 
--------------------------------------------------------------------------------
+---
 
-
-This product contains derivations of various scripts from SwiftNIO and contains "XCTest+AsyncAwait.swift" from gRPC Swift.
+This product contains derivations of various scripts from SwiftNIO.
 
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://github.com/apple/swift-nio
     
+---
+    
+This product contains "XCTest+AsyncAwait.swift" from gRPC Swift.
+
   * LICENSE (Apache License 2.0):
     * https://www.apache.org/licenses/LICENSE-2.0
   * HOMEPAGE:
     * https://github.com/grpc/grpc-swift
 
+---
 
--------------------------------------------------------------------------------
+This product contains a derivation of the Tony Stone's 'process_test_files.rb'.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/tonystone/build-tools/commit/6c417b7569df24597a48a9aa7b505b636e8f73a1
+    * https://github.com/tonystone/build-tools/blob/master/source/xctest_tool.rb
+
+---

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,43 @@
+
+                            The AsyncHTTPClient Project
+                            ===========================
+
+Please visit the AsyncHTTPClient web site for more information:
+
+  * https://github.com/swift-server/async-http-client
+
+Copyright 2017-2021 The AsyncHTTPClient Project
+
+The AsyncHTTPClient Project licenses this file to you under the Apache License,
+version 2.0 (the "License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+  https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations
+under the License.
+
+Also, please refer to each LICENSE.txt file, which is located in
+the 'license' directory of the distribution file, for the license terms of the
+components that this product depends on.
+
+-------------------------------------------------------------------------------
+
+
+This product contains a derivation various scripts from SwiftNIO and contains "XCTest+AsyncAwait.swift" from gRPC Swift.
+
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/apple/swift-nio
+    
+  * LICENSE (Apache License 2.0):
+    * https://www.apache.org/licenses/LICENSE-2.0
+  * HOMEPAGE:
+    * https://github.com/grpc/grpc-swift
+
+
+-------------------------------------------------------------------------------

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2021, gRPC Authors All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if compiler(>=5.5)
+import XCTest
+
+extension XCTestCase {
+  @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+  /// Cross-platform XCTest support for async-await tests.
+  ///
+  /// Currently the Linux implementation of XCTest doesn't have async-await support.
+  /// Until it does, we make use of this shim which uses a detached `Task` along with
+  /// `XCTest.wait(for:timeout:)` to wrap the operation.
+  ///
+  /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
+  /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
+  func XCTAsyncTest(
+    expectationDescription: String = "Async operation",
+    timeout: TimeInterval = 30,
+    file: StaticString = #filePath,
+    line: UInt = #line,
+    function: StaticString = #function,
+    operation: @escaping () async throws -> Void
+  ) {
+    let expectation = self.expectation(description: expectationDescription)
+    Task {
+      do {
+        try await operation()
+      } catch {
+        XCTFail("Error thrown while executing \(function): \(error)", file: file, line: line)
+        Thread.callStackSymbols.forEach { print($0) }
+      }
+      expectation.fulfill()
+    }
+    self.wait(for: [expectation], timeout: timeout)
+  }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal func XCTAssertThrowsError<T>(
+  _ expression: @autoclosure () async throws -> T,
+  verify: (Error) -> Void = { _ in },
+  file: StaticString = #file,
+  line: UInt = #line
+) async {
+  do {
+    _ = try await expression()
+    XCTFail("Expression did not throw error", file: file, line: line)
+  } catch {
+    verify(error)
+  }
+}
+
+#endif // compiler(>=5.5)

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 /*
  * Copyright 2021, gRPC Authors All rights reserved.
  *

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -45,7 +45,7 @@ extension XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line,
         function: StaticString = #function,
-        operation: @escaping () async throws -> Void
+        operation: @escaping @Sendable () async throws -> Void
     ) {
         let expectation = self.expectation(description: expectationDescription)
         Task {

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -14,53 +14,53 @@
  * limitations under the License.
  */
 #if compiler(>=5.5)
-import XCTest
+    import XCTest
 
-extension XCTestCase {
-  @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-  /// Cross-platform XCTest support for async-await tests.
-  ///
-  /// Currently the Linux implementation of XCTest doesn't have async-await support.
-  /// Until it does, we make use of this shim which uses a detached `Task` along with
-  /// `XCTest.wait(for:timeout:)` to wrap the operation.
-  ///
-  /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
-  /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
-  func XCTAsyncTest(
-    expectationDescription: String = "Async operation",
-    timeout: TimeInterval = 30,
-    file: StaticString = #filePath,
-    line: UInt = #line,
-    function: StaticString = #function,
-    operation: @escaping () async throws -> Void
-  ) {
-    let expectation = self.expectation(description: expectationDescription)
-    Task {
-      do {
-        try await operation()
-      } catch {
-        XCTFail("Error thrown while executing \(function): \(error)", file: file, line: line)
-        Thread.callStackSymbols.forEach { print($0) }
-      }
-      expectation.fulfill()
+    extension XCTestCase {
+        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+        /// Cross-platform XCTest support for async-await tests.
+        ///
+        /// Currently the Linux implementation of XCTest doesn't have async-await support.
+        /// Until it does, we make use of this shim which uses a detached `Task` along with
+        /// `XCTest.wait(for:timeout:)` to wrap the operation.
+        ///
+        /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
+        /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
+        func XCTAsyncTest(
+            expectationDescription: String = "Async operation",
+            timeout: TimeInterval = 30,
+            file: StaticString = #filePath,
+            line: UInt = #line,
+            function: StaticString = #function,
+            operation: @escaping () async throws -> Void
+        ) {
+            let expectation = self.expectation(description: expectationDescription)
+            Task {
+                do {
+                    try await operation()
+                } catch {
+                    XCTFail("Error thrown while executing \(function): \(error)", file: file, line: line)
+                    Thread.callStackSymbols.forEach { print($0) }
+                }
+                expectation.fulfill()
+            }
+            self.wait(for: [expectation], timeout: timeout)
+        }
     }
-    self.wait(for: [expectation], timeout: timeout)
-  }
-}
 
-@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-internal func XCTAssertThrowsError<T>(
-  _ expression: @autoclosure () async throws -> T,
-  verify: (Error) -> Void = { _ in },
-  file: StaticString = #file,
-  line: UInt = #line
-) async {
-  do {
-    _ = try await expression()
-    XCTFail("Expression did not throw error", file: file, line: line)
-  } catch {
-    verify(error)
-  }
-}
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+    internal func XCTAssertThrowsError<T>(
+        _ expression: @autoclosure () async throws -> T,
+        verify: (Error) -> Void = { _ in },
+        file: StaticString = #file,
+        line: UInt = #line
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail("Expression did not throw error", file: file, line: line)
+        } catch {
+            verify(error)
+        }
+    }
 
 #endif // compiler(>=5.5)

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -27,53 +27,53 @@
  * limitations under the License.
  */
 #if compiler(>=5.5)
-    import XCTest
+import XCTest
 
-    extension XCTestCase {
-        @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-        /// Cross-platform XCTest support for async-await tests.
-        ///
-        /// Currently the Linux implementation of XCTest doesn't have async-await support.
-        /// Until it does, we make use of this shim which uses a detached `Task` along with
-        /// `XCTest.wait(for:timeout:)` to wrap the operation.
-        ///
-        /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
-        /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
-        func XCTAsyncTest(
-            expectationDescription: String = "Async operation",
-            timeout: TimeInterval = 30,
-            file: StaticString = #filePath,
-            line: UInt = #line,
-            function: StaticString = #function,
-            operation: @escaping () async throws -> Void
-        ) {
-            let expectation = self.expectation(description: expectationDescription)
-            Task {
-                do {
-                    try await operation()
-                } catch {
-                    XCTFail("Error thrown while executing \(function): \(error)", file: file, line: line)
-                    Thread.callStackSymbols.forEach { print($0) }
-                }
-                expectation.fulfill()
-            }
-            self.wait(for: [expectation], timeout: timeout)
-        }
-    }
-
+extension XCTestCase {
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    internal func XCTAssertThrowsError<T>(
-        _ expression: @autoclosure () async throws -> T,
-        verify: (Error) -> Void = { _ in },
-        file: StaticString = #file,
-        line: UInt = #line
-    ) async {
-        do {
-            _ = try await expression()
-            XCTFail("Expression did not throw error", file: file, line: line)
-        } catch {
-            verify(error)
+    /// Cross-platform XCTest support for async-await tests.
+    ///
+    /// Currently the Linux implementation of XCTest doesn't have async-await support.
+    /// Until it does, we make use of this shim which uses a detached `Task` along with
+    /// `XCTest.wait(for:timeout:)` to wrap the operation.
+    ///
+    /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
+    /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
+    func XCTAsyncTest(
+        expectationDescription: String = "Async operation",
+        timeout: TimeInterval = 30,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        function: StaticString = #function,
+        operation: @escaping () async throws -> Void
+    ) {
+        let expectation = self.expectation(description: expectationDescription)
+        Task {
+            do {
+                try await operation()
+            } catch {
+                XCTFail("Error thrown while executing \(function): \(error)", file: file, line: line)
+                Thread.callStackSymbols.forEach { print($0) }
+            }
+            expectation.fulfill()
         }
+        self.wait(for: [expectation], timeout: timeout)
     }
+}
+
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
+internal func XCTAssertThrowsError<T>(
+    _ expression: @autoclosure () async throws -> T,
+    verify: (Error) -> Void = { _ in },
+    file: StaticString = #file,
+    line: UInt = #line
+) async {
+    do {
+        _ = try await expression()
+        XCTFail("Expression did not throw error", file: file, line: line)
+    } catch {
+        verify(error)
+    }
+}
 
 #endif // compiler(>=5.5)


### PR DESCRIPTION
### Motivation
We want to add async/await tests soon but the Linux implementation of XCTest doesn't have async-await support in Swift 5.5. In addition, our `generate_linux_tests.rb` script does not like async/await functions either. We therefore need a workaround to still be to test async/await code.

### Changes
- add `XCTAsyncTest` and `XCTAssertThrowsError` from https://raw.githubusercontent.com/grpc/grpc-swift/1.4.1-async-await/Tests/GRPCTests/AsyncAwaitSupport/XCTest%2BAsyncAwait.swift
- add NOTICE.txt and list at least SwiftNIO and gRPC