### PR TITLE
Run tests in parallel on CI

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -28,7 +28,7 @@ services:
 
   test:
     <<: *common
-    command: /bin/bash -xcl "swift test -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
+    command: /bin/bash -xcl "swift test --parallel -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
 
   # util
 


### PR DESCRIPTION
### Motivation
I locally use parallel and randomised testing in Xcode since two months and did not yet encounter any flaky tests. I therefore think we can run tests in parallel on CI as well.

### Changes
add `--parallel` to `swift test` invocation 