### PR TITLE
Fix flaky tests in `HTTPClientSOCKSTests`

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
@@ -76,7 +76,7 @@ class HTTPClientSOCKSTests: XCTestCase {
     func testProxySOCKS() throws {
         let socksBin = try MockSOCKSServer(expectedURL: "/socks/test", expectedResponse: "it works!")
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(proxy: .socksServer(host: "localhost")))
+                                     configuration: .init(proxy: .socksServer(host: "localhost", port: socksBin.port)))
 
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
@@ -125,7 +125,7 @@ class HTTPClientSOCKSTests: XCTestCase {
     func testProxySOCKSMisbehavingServer() throws {
         let socksBin = try MockSOCKSServer(expectedURL: "/socks/test", expectedResponse: "it works!", misbehave: true)
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(proxy: .socksServer(host: "localhost")))
+                                     configuration: .init(proxy: .socksServer(host: "localhost", port: socksBin.port)))
 
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())

--- a/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
@@ -35,10 +35,11 @@ class TestSOCKSBadServerHandler: ChannelInboundHandler {
 
 class MockSOCKSServer {
     let channel: Channel
-    
+
     var port: Int {
-        channel.localAddress!.port!
+        self.channel.localAddress!.port!
     }
+
     init(expectedURL: String, expectedResponse: String, misbehave: Bool = false, file: String = #file, line: UInt = #line) throws {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let bootstrap: ServerBootstrap

--- a/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
@@ -35,7 +35,10 @@ class TestSOCKSBadServerHandler: ChannelInboundHandler {
 
 class MockSOCKSServer {
     let channel: Channel
-
+    
+    var port: Int {
+        channel.localAddress!.port!
+    }
     init(expectedURL: String, expectedResponse: String, misbehave: Bool = false, file: String = #file, line: UInt = #line) throws {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let bootstrap: ServerBootstrap
@@ -57,7 +60,7 @@ class MockSOCKSServer {
                     ])
                 }
         }
-        self.channel = try bootstrap.bind(host: "localhost", port: 1080).wait()
+        self.channel = try bootstrap.bind(host: "localhost", port: 0).wait()
     }
 
     func shutdown() throws {


### PR DESCRIPTION
### Motivation
fixes #497 

### Changes
Bind to a port a random free port defined by the operating system instead of using 1080