### PR TITLE
Introduce a `ConnectionTarget` enum

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -12,63 +12,30 @@
 //
 //===----------------------------------------------------------------------===//
 
-import enum NIOCore.SocketAddress
-
 enum ConnectionPool {
-    enum Host: Hashable {
-        // We keep the IP address serialization precisely as it is in the URL.
-        // Some platforms have quirks in their implementations of 'ntop', for example
-        // writing IPv6 addresses as having embedded IPv4 sections (e.g. [::192.168.0.1] vs [::c0a8:1]).
-        // This serialization includes square brackets, so it is safe to write next to a port number.
-        // Note: `address` must always have a non-nil port.
-        case ipAddress(serialization: String, address: SocketAddress)
-        case domain(name: String, port: Int)
-        case unixSocket(path: String)
-
-        init(remoteHost: String, port: Int) {
-            if let addr = try? SocketAddress(ipAddress: remoteHost, port: port) {
-                switch addr {
-                case .v6:
-                    self = .ipAddress(serialization: "[\(remoteHost)]", address: addr)
-                case .v4:
-                    self = .ipAddress(serialization: remoteHost, address: addr)
-                case .unixDomainSocket:
-                    fatalError("Expected a remote host")
-                }
-            } else {
-                precondition(!remoteHost.isEmpty, "HTTPClient.Request should already reject empty remote hostnames")
-                self = .domain(name: remoteHost, port: port)
-            }
-        }
-    }
-
     /// Used by the `ConnectionPool` to index its `HTTP1ConnectionProvider`s
     ///
-    /// A key is initialized from a `URL`, it uses the components to derive a hashed value
+    /// A key is initialized from a `Request`, it uses the components to derive a hashed value
     /// used by the `providers` dictionary to allow retrieving and creating
     /// connection providers associated to a certain request in constant time.
     struct Key: Hashable, CustomStringConvertible {
         var scheme: Scheme
-        var host: Host
+        var connectionTarget: ConnectionTarget
         private var tlsConfiguration: BestEffortHashableTLSConfiguration?
 
         init(_ request: HTTPClient.Request) {
+            self.connectionTarget = request.connectionTarget
             switch request.scheme {
             case "http":
                 self.scheme = .http
-                self.host = Host(remoteHost: request.host, port: request.port)
             case "https":
                 self.scheme = .https
-                self.host = Host(remoteHost: request.host, port: request.port)
             case "unix":
                 self.scheme = .unix
-                self.host = .unixSocket(path: request.socketPath)
             case "http+unix":
                 self.scheme = .http_unix
-                self.host = .unixSocket(path: request.socketPath)
             case "https+unix":
                 self.scheme = .https_unix
-                self.host = .unixSocket(path: request.socketPath)
             default:
                 fatalError("HTTPClient.Request scheme should already be a valid one")
             }
@@ -108,7 +75,7 @@ enum ConnectionPool {
             self.tlsConfiguration?.hash(into: &hasher)
             let hash = hasher.finalize()
             var hostDescription = ""
-            switch host {
+            switch self.connectionTarget {
             case .ipAddress(let serialization, let addr):
                 hostDescription = "\(serialization):\(addr.port!)"
             case .domain(let domain, port: let port):

--- a/Sources/AsyncHTTPClient/ConnectionPool/ChannelHandler/HTTP1ProxyConnectHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/ChannelHandler/HTTP1ProxyConnectHandler.swift
@@ -46,7 +46,7 @@ final class HTTP1ProxyConnectHandler: ChannelDuplexHandler, RemovableChannelHand
     }
 
     convenience
-    init(target: ConnectionPool.Host,
+    init(target: ConnectionTarget,
          proxyAuthorization: HTTPClient.Authorization?,
          deadline: NIODeadline) {
         let targetHost: String

--- a/Sources/AsyncHTTPClient/ConnectionPool/ChannelHandler/HTTP1ProxyConnectHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/ChannelHandler/HTTP1ProxyConnectHandler.swift
@@ -45,6 +45,30 @@ final class HTTP1ProxyConnectHandler: ChannelDuplexHandler, RemovableChannelHand
         return self.proxyEstablishedPromise?.futureResult
     }
 
+    convenience
+    init(target: ConnectionPool.Host,
+         proxyAuthorization: HTTPClient.Authorization?,
+         deadline: NIODeadline) {
+        let targetHost: String
+        let targetPort: Int
+        switch target {
+        case .ipAddress(serialization: let serialization, address: let address):
+            targetHost = serialization
+            targetPort = address.port!
+        case .domain(name: let domain, port: let port):
+            targetHost = domain
+            targetPort = port
+        case .unixSocket:
+            fatalError("Unix Domain Sockets do not support proxies")
+        }
+        self.init(
+            targetHost: targetHost,
+            targetPort: targetPort,
+            proxyAuthorization: proxyAuthorization,
+            deadline: deadline
+        )
+    }
+
     init(targetHost: String,
          targetPort: Int,
          proxyAuthorization: HTTPClient.Authorization?,

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -197,16 +197,8 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 
     private func makePlainChannel(deadline: NIODeadline, eventLoop: EventLoop) -> EventLoopFuture<Channel> {
-        let bootstrap = self.makePlainBootstrap(deadline: deadline, eventLoop: eventLoop)
-
-        switch self.key.scheme {
-        case .http:
-            return bootstrap.connect(host: self.key.host, port: self.key.port)
-        case .http_unix, .unix:
-            return bootstrap.connect(unixDomainSocketPath: self.key.unixPath)
-        case .https, .https_unix:
-            preconditionFailure("Unexpected scheme")
-        }
+        precondition(!self.key.scheme.requiresTLS, "Unexpected scheme")
+        return self.makePlainBootstrap(deadline: deadline, eventLoop: eventLoop).connect(host: self.key.host)
     }
 
     private func makeHTTPProxyChannel(
@@ -224,8 +216,7 @@ extension HTTPConnectionPool.ConnectionFactory {
             let encoder = HTTPRequestEncoder()
             let decoder = ByteToMessageHandler(HTTPResponseDecoder(leftOverBytesStrategy: .dropBytes))
             let proxyHandler = HTTP1ProxyConnectHandler(
-                targetHost: self.key.host,
-                targetPort: self.key.port,
+                target: self.key.host,
                 proxyAuthorization: proxy.authorization,
                 deadline: deadline
             )
@@ -264,7 +255,7 @@ extension HTTPConnectionPool.ConnectionFactory {
         // upgraded to TLS before we send our first request.
         let bootstrap = self.makePlainBootstrap(deadline: deadline, eventLoop: eventLoop)
         return bootstrap.connect(host: proxy.host, port: proxy.port).flatMap { channel in
-            let socksConnectHandler = SOCKSClientHandler(targetAddress: .domain(self.key.host, port: self.key.port))
+            let socksConnectHandler = SOCKSClientHandler(targetAddress: SOCKSAddress(self.key.host))
             let socksEventHandler = SOCKSEventsHandler(deadline: deadline)
 
             do {
@@ -310,6 +301,7 @@ extension HTTPConnectionPool.ConnectionFactory {
             }
             let tlsEventHandler = TLSEventsHandler(deadline: deadline)
 
+            let sslServerHostname = self.key.host.sslServerHostname
             let sslContextFuture = self.sslContextCache.sslContext(
                 tlsConfiguration: tlsConfig,
                 eventLoop: channel.eventLoop,
@@ -320,7 +312,7 @@ extension HTTPConnectionPool.ConnectionFactory {
                 do {
                     let sslHandler = try NIOSSLClientHandler(
                         context: sslContext,
-                        serverHostname: self.key.host
+                        serverHostname: sslServerHostname
                     )
                     try channel.pipeline.syncOperations.addHandler(sslHandler)
                     try channel.pipeline.syncOperations.addHandler(tlsEventHandler)
@@ -364,6 +356,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 
     private func makeTLSChannel(deadline: NIODeadline, eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<(Channel, String?)> {
+        precondition(self.key.scheme.requiresTLS, "Unexpected scheme")
         let bootstrapFuture = self.makeTLSBootstrap(
             deadline: deadline,
             eventLoop: eventLoop,
@@ -371,14 +364,7 @@ extension HTTPConnectionPool.ConnectionFactory {
         )
 
         var channelFuture = bootstrapFuture.flatMap { bootstrap -> EventLoopFuture<Channel> in
-            switch self.key.scheme {
-            case .https:
-                return bootstrap.connect(host: self.key.host, port: self.key.port)
-            case .https_unix:
-                return bootstrap.connect(unixDomainSocketPath: self.key.unixPath)
-            case .http, .http_unix, .unix:
-                preconditionFailure("Unexpected scheme")
-            }
+            return bootstrap.connect(host: self.key.host)
         }.flatMap { channel -> EventLoopFuture<(Channel, String?)> in
             // It is save to use `try!` here, since we are sure, that a `TLSEventsHandler` exists
             // within the pipeline. It is added in `makeTLSBootstrap`.
@@ -441,9 +427,7 @@ extension HTTPConnectionPool.ConnectionFactory {
         }
         #endif
 
-        let host = self.key.host
-        let hostname = (host.isIPAddress || host.isEmpty) ? nil : host
-
+        let sslServerHostname = self.key.host.sslServerHostname
         let sslContextFuture = sslContextCache.sslContext(
             tlsConfiguration: tlsConfig,
             eventLoop: eventLoop,
@@ -458,7 +442,7 @@ extension HTTPConnectionPool.ConnectionFactory {
                         let sync = channel.pipeline.syncOperations
                         let sslHandler = try NIOSSLClientHandler(
                             context: sslContext,
-                            serverHostname: hostname
+                            serverHostname: sslServerHostname
                         )
                         let tlsEventHandler = TLSEventsHandler(deadline: deadline)
 
@@ -497,14 +481,34 @@ extension ConnectionPool.Key.Scheme {
     }
 }
 
-extension String {
-    fileprivate var isIPAddress: Bool {
-        var ipv4Addr = in_addr()
-        var ipv6Addr = in6_addr()
+extension ConnectionPool.Host {
+    fileprivate var sslServerHostname: String? {
+        switch self {
+        case .domain(let domain, _): return domain
+        case .ipAddress, .unixSocket: return nil
+        }
+    }
+}
 
-        return self.withCString { ptr in
-            inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
-                inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
+extension SOCKSAddress {
+    fileprivate init(_ host: ConnectionPool.Host) {
+        switch host {
+        case .ipAddress(_, let address): self = .address(address)
+        case .domain(let domain, let port): self = .domain(domain, port: port)
+        case .unixSocket: fatalError("Unix Domain Sockets are not supported by SOCKSAddress")
+        }
+    }
+}
+
+extension NIOClientTCPBootstrapProtocol {
+    func connect(host: ConnectionPool.Host) -> EventLoopFuture<Channel> {
+        switch host {
+        case .ipAddress(_, let socketAddress):
+            return self.connect(to: socketAddress)
+        case .domain(let domain, let port):
+            return self.connect(host: domain, port: port)
+        case .unixSocket(let path):
+            return self.connect(unixDomainSocketPath: path)
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionTarget.swift
+++ b/Sources/AsyncHTTPClient/ConnectionTarget.swift
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2019-2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import enum NIOCore.SocketAddress
+
+enum ConnectionTarget: Equatable, Hashable {
+    // We keep the IP address serialization precisely as it is in the URL.
+    // Some platforms have quirks in their implementations of 'ntop', for example
+    // writing IPv6 addresses as having embedded IPv4 sections (e.g. [::192.168.0.1] vs [::c0a8:1]).
+    // This serialization includes square brackets, so it is safe to write next to a port number.
+    // Note: `address` must have an explicit port.
+    case ipAddress(serialization: String, address: SocketAddress)
+    case domain(name: String, port: Int)
+    case unixSocket(path: String)
+
+    init(remoteHost: String, port: Int) {
+        if let addr = try? SocketAddress(ipAddress: remoteHost, port: port) {
+            switch addr {
+            case .v6:
+                self = .ipAddress(serialization: "[\(remoteHost)]", address: addr)
+            case .v4:
+                self = .ipAddress(serialization: remoteHost, address: addr)
+            case .unixDomainSocket:
+                fatalError("Expected a remote host")
+            }
+        } else {
+            precondition(!remoteHost.isEmpty, "HTTPClient.Request should already reject empty remote hostnames")
+            self = .domain(name: remoteHost, port: port)
+        }
+    }
+}

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -447,27 +447,76 @@ class HTTPClientInternalTests: XCTestCase {
     func testInternalRequestURI() throws {
         let request1 = try Request(url: "https://someserver.com:8888/some/path?foo=bar")
         XCTAssertEqual(request1.kind, .host)
-        XCTAssertEqual(request1.socketPath, "")
+        XCTAssertEqual(request1.connectionTarget, .domain(name: "someserver.com", port: 8888))
         XCTAssertEqual(request1.uri, "/some/path?foo=bar")
 
         let request2 = try Request(url: "https://someserver.com")
         XCTAssertEqual(request2.kind, .host)
-        XCTAssertEqual(request2.socketPath, "")
+        XCTAssertEqual(request2.connectionTarget, .domain(name: "someserver.com", port: 443))
         XCTAssertEqual(request2.uri, "/")
 
         let request3 = try Request(url: "unix:///tmp/file")
         XCTAssertEqual(request3.kind, .unixSocket(.baseURL))
-        XCTAssertEqual(request3.socketPath, "/tmp/file")
+        XCTAssertEqual(request3.connectionTarget, .unixSocket(path: "/tmp/file"))
         XCTAssertEqual(request3.uri, "/")
 
         let request4 = try Request(url: "http+unix://%2Ftmp%2Ffile/file/path")
         XCTAssertEqual(request4.kind, .unixSocket(.http_unix))
-        XCTAssertEqual(request4.socketPath, "/tmp/file")
+        XCTAssertEqual(request4.connectionTarget, .unixSocket(path: "/tmp/file"))
         XCTAssertEqual(request4.uri, "/file/path")
 
         let request5 = try Request(url: "https+unix://%2Ftmp%2Ffile/file/path")
         XCTAssertEqual(request5.kind, .unixSocket(.https_unix))
-        XCTAssertEqual(request5.socketPath, "/tmp/file")
+        XCTAssertEqual(request5.connectionTarget, .unixSocket(path: "/tmp/file"))
         XCTAssertEqual(request5.uri, "/file/path")
+
+        let request6 = try Request(url: "https://127.0.0.1")
+        XCTAssertEqual(request6.kind, .host)
+        XCTAssertEqual(request6.connectionTarget, .ipAddress(
+            serialization: "127.0.0.1",
+            address: try! SocketAddress(ipAddress: "127.0.0.1", port: 443)
+        ))
+        XCTAssertEqual(request6.uri, "/")
+
+        let request7 = try Request(url: "https://0x7F.1:9999")
+        XCTAssertEqual(request7.kind, .host)
+        XCTAssertEqual(request7.connectionTarget, .domain(name: "0x7F.1", port: 9999))
+        XCTAssertEqual(request7.uri, "/")
+
+        let request8 = try Request(url: "http://[::1]")
+        XCTAssertEqual(request8.kind, .host)
+        XCTAssertEqual(request8.connectionTarget, .ipAddress(
+            serialization: "[::1]",
+            address: try! SocketAddress(ipAddress: "::1", port: 80)
+        ))
+        XCTAssertEqual(request8.uri, "/")
+
+        let request9 = try Request(url: "http://[763e:61d9::6ACA:3100:6274]:4242/foo/bar?baz")
+        XCTAssertEqual(request9.kind, .host)
+        XCTAssertEqual(request9.connectionTarget, .ipAddress(
+            serialization: "[763e:61d9::6ACA:3100:6274]",
+            address: try! SocketAddress(ipAddress: "763e:61d9::6aca:3100:6274", port: 4242)
+        ))
+        XCTAssertEqual(request9.uri, "/foo/bar?baz")
+
+        // Some systems have quirks in their implementations of 'ntop' which cause them to write
+        // certain IPv6 addresses with embedded IPv4 parts (e.g. "::192.168.0.1" vs "::c0a8:1").
+        // We want to make sure that our request formatting doesn't depend on the platform's quirks,
+        // so the serialization must be kept verbatim as it was given in the request.
+        let request10 = try Request(url: "http://[::c0a8:1]:4242/foo/bar?baz")
+        XCTAssertEqual(request10.kind, .host)
+        XCTAssertEqual(request10.connectionTarget, .ipAddress(
+            serialization: "[::c0a8:1]",
+            address: try! SocketAddress(ipAddress: "::c0a8:1", port: 4242)
+        ))
+        XCTAssertEqual(request9.uri, "/foo/bar?baz")
+
+        let request11 = try Request(url: "http://[::192.168.0.1]:4242/foo/bar?baz")
+        XCTAssertEqual(request11.kind, .host)
+        XCTAssertEqual(request11.connectionTarget, .ipAddress(
+            serialization: "[::192.168.0.1]",
+            address: try! SocketAddress(ipAddress: "::192.168.0.1", port: 4242)
+        ))
+        XCTAssertEqual(request11.uri, "/foo/bar?baz")
     }
 }


### PR DESCRIPTION
I added this as part of the WebURL port, because it can provide specific host kinds and doesn't need to re-parse the hostname, but I think it is generally a useful thing to model.

Currently, `ConnectionPool.Key` stores a `host`, `port`, and `socketPath` string, even though only one of (host + port) and (socketPath) can be populated. This lends itself well to an enum. Additionally, we can extract what kind of host we're dealing with, so we don't need to re-parse the hostname later.

One thing I'd like comments on is whether this should perhaps be moved up to `Request`. This would also allows us to stop pretending that unix domain sockets have ports. As I see it, this should really be `Request`'s business; a part of how it extracts information from the URL should be parsing the hostname string (perhaps using APIs from the URL type, if it provides that). 

The async redesign simplifies `Request` somewhat, but I couldn't see any mention of hosts or hostnames on the new request type. One idea worth exploring would be making this public API as part of that redesign.