### PR TITLE
Refactor `deconstructURL ` and `scheme` parsing

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -19,16 +19,13 @@ enum ConnectionPool {
     /// used by the `providers` dictionary to allow retrieving and creating
     /// connection providers associated to a certain request in constant time.
     struct Key: Hashable, CustomStringConvertible {
-        var scheme: Scheme
+        var scheme: Endpoint.Scheme
         var connectionTarget: ConnectionTarget
         private var tlsConfiguration: BestEffortHashableTLSConfiguration?
 
         init(_ request: HTTPClient.Request) {
-            self.connectionTarget = request.connectionTarget
             self.scheme = request.endpoint.scheme
-            self.port = request.endpoint.port
-            self.host = request.endpoint.host
-            self.unixPath = request.endpoint.socketPath
+            self.connectionTarget = request.endpoint.connectionTarget
             if let tls = request.tlsConfiguration {
                 self.tlsConfiguration = BestEffortHashableTLSConfiguration(wrapping: tls)
             }

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -20,20 +20,7 @@ enum ConnectionPool {
     /// connection providers associated to a certain request in constant time.
     struct Key: Hashable, CustomStringConvertible {
         init(_ request: HTTPClient.Request) {
-            switch request.scheme {
-            case "http":
-                self.scheme = .http
-            case "https":
-                self.scheme = .https
-            case "unix":
-                self.scheme = .unix
-            case "http+unix":
-                self.scheme = .http_unix
-            case "https+unix":
-                self.scheme = .https_unix
-            default:
-                fatalError("HTTPClient.Request scheme should already be a valid one")
-            }
+            self.scheme = request._scheme
             self.port = request.port
             self.host = request.host
             self.unixPath = request.socketPath
@@ -42,28 +29,11 @@ enum ConnectionPool {
             }
         }
 
-        var scheme: Scheme
+        var scheme: SupportedScheme
         var host: String
         var port: Int
         var unixPath: String
         private var tlsConfiguration: BestEffortHashableTLSConfiguration?
-
-        enum Scheme: Hashable {
-            case http
-            case https
-            case unix
-            case http_unix
-            case https_unix
-
-            var requiresTLS: Bool {
-                switch self {
-                case .https, .https_unix:
-                    return true
-                default:
-                    return false
-                }
-            }
-        }
 
         /// Returns a key-specific `HTTPClient.Configuration` by overriding the properties of `base`
         func config(overriding base: HTTPClient.Configuration) -> HTTPClient.Configuration {

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -19,25 +19,16 @@ enum ConnectionPool {
     /// used by the `providers` dictionary to allow retrieving and creating
     /// connection providers associated to a certain request in constant time.
     struct Key: Hashable, CustomStringConvertible {
-        var scheme: Endpoint.Scheme
+        var scheme: DeconstructedURL.Scheme
         var connectionTarget: ConnectionTarget
         private var tlsConfiguration: BestEffortHashableTLSConfiguration?
 
         init(_ request: HTTPClient.Request) {
-            self.scheme = request.endpoint.scheme
-            self.connectionTarget = request.endpoint.connectionTarget
+            self.scheme = request.deconstructedURL.scheme
+            self.connectionTarget = request.deconstructedURL.connectionTarget
             if let tls = request.tlsConfiguration {
                 self.tlsConfiguration = BestEffortHashableTLSConfiguration(wrapping: tls)
             }
-        }
-
-        /// Returns a key-specific `HTTPClient.Configuration` by overriding the properties of `base`
-        func config(overriding base: HTTPClient.Configuration) -> HTTPClient.Configuration {
-            var config = base
-            if let tlsConfiguration = self.tlsConfiguration {
-                config.tlsConfiguration = tlsConfiguration.base
-            }
-            return config
         }
 
         var description: String {

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -20,10 +20,10 @@ enum ConnectionPool {
     /// connection providers associated to a certain request in constant time.
     struct Key: Hashable, CustomStringConvertible {
         init(_ request: HTTPClient.Request) {
-            self.scheme = request._scheme
-            self.port = request.port
-            self.host = request.host
-            self.unixPath = request.socketPath
+            self.scheme = request.endpoint.scheme
+            self.port = request.endpoint.port
+            self.host = request.endpoint.host
+            self.unixPath = request.endpoint.socketPath
             if let tls = request.tlsConfiguration {
                 self.tlsConfiguration = BestEffortHashableTLSConfiguration(wrapping: tls)
             }

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -19,7 +19,7 @@ enum ConnectionPool {
     /// used by the `providers` dictionary to allow retrieving and creating
     /// connection providers associated to a certain request in constant time.
     struct Key: Hashable, CustomStringConvertible {
-        var scheme: DeconstructedURL.Scheme
+        var scheme: Scheme
         var connectionTarget: ConnectionTarget
         private var tlsConfiguration: BestEffortHashableTLSConfiguration?
 

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -29,7 +29,7 @@ enum ConnectionPool {
             }
         }
 
-        var scheme: SupportedScheme
+        var scheme: Endpoint.Scheme
         var host: String
         var port: Int
         var unixPath: String

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -185,9 +185,9 @@ extension HTTPConnectionPool.ConnectionFactory {
         logger: Logger
     ) -> EventLoopFuture<NegotiatedProtocol> {
         switch self.key.scheme {
-        case .http, .http_unix, .unix:
+        case .http, .httpUnix, .unix:
             return self.makePlainChannel(deadline: deadline, eventLoop: eventLoop).map { .http1_1($0) }
-        case .https, .https_unix:
+        case .https, .httpsUnix:
             return self.makeTLSChannel(deadline: deadline, eventLoop: eventLoop, logger: logger).flatMapThrowing {
                 channel, negotiated in
 
@@ -202,9 +202,9 @@ extension HTTPConnectionPool.ConnectionFactory {
         switch self.key.scheme {
         case .http:
             return bootstrap.connect(host: self.key.host, port: self.key.port)
-        case .http_unix, .unix:
+        case .httpUnix, .unix:
             return bootstrap.connect(unixDomainSocketPath: self.key.unixPath)
-        case .https, .https_unix:
+        case .https, .httpsUnix:
             preconditionFailure("Unexpected scheme")
         }
     }
@@ -292,7 +292,7 @@ extension HTTPConnectionPool.ConnectionFactory {
         logger: Logger
     ) -> EventLoopFuture<NegotiatedProtocol> {
         switch self.key.scheme {
-        case .unix, .http_unix, .https_unix:
+        case .unix, .httpUnix, .httpsUnix:
             preconditionFailure("Unexpected scheme. Not supported for proxy!")
         case .http:
             return channel.eventLoop.makeSucceededFuture(.http1_1(channel))
@@ -374,9 +374,9 @@ extension HTTPConnectionPool.ConnectionFactory {
             switch self.key.scheme {
             case .https:
                 return bootstrap.connect(host: self.key.host, port: self.key.port)
-            case .https_unix:
+            case .httpsUnix:
                 return bootstrap.connect(unixDomainSocketPath: self.key.unixPath)
-            case .http, .http_unix, .unix:
+            case .http, .httpUnix, .unix:
                 preconditionFailure("Unexpected scheme")
             }
         }.flatMap { channel -> EventLoopFuture<(Channel, String?)> in
@@ -486,12 +486,12 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 }
 
-extension ConnectionPool.Key.Scheme {
+extension SupportedScheme {
     var isProxyable: Bool {
         switch self {
         case .http, .https:
             return true
-        case .unix, .http_unix, .https_unix:
+        case .unix, .httpUnix, .httpsUnix:
             return false
         }
     }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -197,7 +197,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 
     private func makePlainChannel(deadline: NIODeadline, eventLoop: EventLoop) -> EventLoopFuture<Channel> {
-        precondition(!self.key.scheme.useTLS, "Unexpected scheme")
+        precondition(!self.key.scheme.usesTLS, "Unexpected scheme")
         return self.makePlainBootstrap(deadline: deadline, eventLoop: eventLoop).connect(target: self.key.connectionTarget)
     }
 
@@ -356,7 +356,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 
     private func makeTLSChannel(deadline: NIODeadline, eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<(Channel, String?)> {
-        precondition(self.key.scheme.useTLS, "Unexpected scheme")
+        precondition(self.key.scheme.usesTLS, "Unexpected scheme")
         let bootstrapFuture = self.makeTLSBootstrap(
             deadline: deadline,
             eventLoop: eventLoop,
@@ -470,7 +470,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 }
 
-extension DeconstructedURL.Scheme {
+extension Scheme {
     var isProxyable: Bool {
         switch self {
         case .http, .https:

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -470,7 +470,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 }
 
-extension Endpoint.Scheme {
+extension DeconstructedURL.Scheme {
     var isProxyable: Bool {
         switch self {
         case .http, .https:

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -486,7 +486,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 }
 
-extension SupportedScheme {
+extension Endpoint.Scheme {
     var isProxyable: Bool {
         switch self {
         case .http, .https:

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -356,7 +356,7 @@ extension HTTPConnectionPool.ConnectionFactory {
     }
 
     private func makeTLSChannel(deadline: NIODeadline, eventLoop: EventLoop, logger: Logger) -> EventLoopFuture<(Channel, String?)> {
-        precondition(self.key.scheme.requiresTLS, "Unexpected scheme")
+        precondition(self.key.scheme.useTLS, "Unexpected scheme")
         let bootstrapFuture = self.makeTLSBootstrap(
             deadline: deadline,
             eventLoop: eventLoop,

--- a/Sources/AsyncHTTPClient/DeconstructedURL.swift
+++ b/Sources/AsyncHTTPClient/DeconstructedURL.swift
@@ -22,10 +22,11 @@ struct DeconstructedURL {
         case httpUnix = "http+unix"
         case httpsUnix = "https+unix"
     }
+
     let scheme: Scheme
     let connectionTarget: ConnectionTarget
     let uri: String
-    
+
     internal init(
         scheme: DeconstructedURL.Scheme,
         connectionTarget: ConnectionTarget,
@@ -45,7 +46,7 @@ extension DeconstructedURL {
         guard let scheme = Scheme(rawValue: schemeString.lowercased()) else {
             throw HTTPClientError.unsupportedScheme(schemeString)
         }
-        
+
         switch scheme {
         case .http, .https:
             guard let host = url.host, !host.isEmpty else {
@@ -56,7 +57,7 @@ extension DeconstructedURL {
                 connectionTarget: .init(remoteHost: host, port: url.port ?? scheme.defaultPort),
                 uri: url.uri
             )
-            
+
         case .httpUnix, .httpsUnix:
             guard let socketPath = url.host, !socketPath.isEmpty else {
                 throw HTTPClientError.missingSocketPath
@@ -66,7 +67,7 @@ extension DeconstructedURL {
                 connectionTarget: .unixSocket(path: socketPath),
                 uri: url.uri
             )
-            
+
         case .unix:
             let socketPath = url.baseURL?.path ?? url.path
             let uri = url.baseURL != nil ? url.uri : "/"
@@ -91,7 +92,8 @@ extension DeconstructedURL.Scheme {
             return true
         }
     }
+
     var defaultPort: Int {
-        useTLS ? 443 : 80
+        self.useTLS ? 443 : 80
     }
 }

--- a/Sources/AsyncHTTPClient/DeconstructedURL.swift
+++ b/Sources/AsyncHTTPClient/DeconstructedURL.swift
@@ -14,7 +14,7 @@
 
 import Foundation
 
-struct Endpoint {
+struct DeconstructedURL {
     enum Scheme: String {
         case http
         case https
@@ -27,7 +27,7 @@ struct Endpoint {
     let uri: String
     
     internal init(
-        scheme: Endpoint.Scheme,
+        scheme: DeconstructedURL.Scheme,
         connectionTarget: ConnectionTarget,
         uri: String
     ) {
@@ -37,7 +37,7 @@ struct Endpoint {
     }
 }
 
-extension Endpoint {
+extension DeconstructedURL {
     init(url: URL) throws {
         guard let schemeString = url.scheme else {
             throw HTTPClientError.emptyScheme
@@ -51,7 +51,6 @@ extension Endpoint {
             guard let host = url.host, !host.isEmpty else {
                 throw HTTPClientError.emptyHost
             }
-            
             self.init(
                 scheme: scheme,
                 connectionTarget: .init(remoteHost: host, port: url.port ?? scheme.defaultPort),
@@ -62,7 +61,6 @@ extension Endpoint {
             guard let socketPath = url.host, !socketPath.isEmpty else {
                 throw HTTPClientError.missingSocketPath
             }
-            
             self.init(
                 scheme: scheme,
                 connectionTarget: .unixSocket(path: socketPath),
@@ -75,7 +73,6 @@ extension Endpoint {
             guard !socketPath.isEmpty else {
                 throw HTTPClientError.missingSocketPath
             }
-        
             self.init(
                 scheme: scheme,
                 connectionTarget: .unixSocket(path: socketPath),
@@ -85,7 +82,7 @@ extension Endpoint {
     }
 }
 
-extension Endpoint.Scheme {
+extension DeconstructedURL.Scheme {
     var useTLS: Bool {
         switch self {
         case .http, .httpUnix, .unix:

--- a/Sources/AsyncHTTPClient/DeconstructedURL.swift
+++ b/Sources/AsyncHTTPClient/DeconstructedURL.swift
@@ -12,23 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
+import struct Foundation.URL
 
 struct DeconstructedURL {
-    enum Scheme: String {
-        case http
-        case https
-        case unix
-        case httpUnix = "http+unix"
-        case httpsUnix = "https+unix"
-    }
-
     var scheme: Scheme
     var connectionTarget: ConnectionTarget
     var uri: String
 
     init(
-        scheme: DeconstructedURL.Scheme,
+        scheme: Scheme,
         connectionTarget: ConnectionTarget,
         uri: String
     ) {
@@ -80,20 +72,5 @@ extension DeconstructedURL {
                 uri: uri
             )
         }
-    }
-}
-
-extension DeconstructedURL.Scheme {
-    var useTLS: Bool {
-        switch self {
-        case .http, .httpUnix, .unix:
-            return false
-        case .https, .httpsUnix:
-            return true
-        }
-    }
-
-    var defaultPort: Int {
-        self.useTLS ? 443 : 80
     }
 }

--- a/Sources/AsyncHTTPClient/DeconstructedURL.swift
+++ b/Sources/AsyncHTTPClient/DeconstructedURL.swift
@@ -23,11 +23,11 @@ struct DeconstructedURL {
         case httpsUnix = "https+unix"
     }
 
-    let scheme: Scheme
-    let connectionTarget: ConnectionTarget
-    let uri: String
+    var scheme: Scheme
+    var connectionTarget: ConnectionTarget
+    var uri: String
 
-    internal init(
+    init(
         scheme: DeconstructedURL.Scheme,
         connectionTarget: ConnectionTarget,
         uri: String

--- a/Sources/AsyncHTTPClient/Endpoint.swift
+++ b/Sources/AsyncHTTPClient/Endpoint.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+struct Endpoint {
+    enum Scheme: String {
+        case http
+        case https
+        case unix
+        case httpUnix = "http+unix"
+        case httpsUnix = "https+unix"
+    }
+    let scheme: Scheme
+    let host: String
+    let socketPath: String
+    let port: Int
+    let uri: String
+    init(url: URL) throws {
+        guard let schemeString = url.scheme else {
+            throw HTTPClientError.emptyScheme
+        }
+        guard let scheme = Scheme(rawValue: schemeString.lowercased()) else {
+            throw HTTPClientError.unsupportedScheme(schemeString)
+        }
+        self.scheme = scheme
+        self.port = url.port ?? scheme.defaultPort
+        switch scheme {
+        case .http, .https:
+            guard let host = url.host, !host.isEmpty else {
+                throw HTTPClientError.emptyHost
+            }
+            self.host = host
+            self.uri = url.uri
+            self.socketPath = ""
+            
+        case .httpUnix, .httpsUnix:
+            guard let socketPath = url.host, !socketPath.isEmpty else {
+                throw HTTPClientError.missingSocketPath
+            }
+            self.host = ""
+            self.uri = url.uri
+            self.socketPath = socketPath
+            
+        case .unix:
+            let socketPath = url.baseURL?.path ?? url.path
+            let uri = url.baseURL != nil ? url.uri : "/"
+            guard !socketPath.isEmpty else {
+                throw HTTPClientError.missingSocketPath
+            }
+            self.host = ""
+            self.uri = uri
+            self.socketPath = socketPath
+        }
+    }
+}
+
+extension Endpoint.Scheme {
+    var useTLS: Bool {
+        switch self {
+        case .http, .httpUnix, .unix:
+            return false
+        case .https, .httpsUnix:
+            return true
+        }
+    }
+    var defaultPort: Int {
+        useTLS ? 443 : 80
+    }
+}

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -97,9 +97,6 @@ extension HTTPClient {
         /// Remote URL.
         public let url: URL
 
-        /// Parsed, validated and deconstructed URL.
-        internal let deconstructedURL: DeconstructedURL
-
         /// Remote HTTP scheme, resolved from `URL`.
         public var scheme: String {
             self.deconstructedURL.scheme.rawValue
@@ -116,6 +113,9 @@ extension HTTPClient {
             var count: Int
             var visited: Set<URL>?
         }
+
+        /// Parsed, validated and deconstructed URL.
+        let deconstructedURL: DeconstructedURL
 
         var redirectState: RedirectState?
 
@@ -744,32 +744,6 @@ internal struct RedirectHandler<ResponseType> {
             }
         } catch {
             promise.fail(error)
-        }
-    }
-}
-
-extension Scheme {
-    func supportsRedirects(to destinationScheme: String?) -> Bool {
-        guard
-            let destinationSchemeString = destinationScheme?.lowercased(),
-            let destinationScheme = Self(rawValue: destinationSchemeString)
-        else {
-            return false
-        }
-        return self.supportsRedirects(to: destinationScheme)
-    }
-
-    func supportsRedirects(to destinationScheme: Self) -> Bool {
-        switch self {
-        case .http, .https:
-            switch destinationScheme {
-            case .http, .https:
-                return true
-            case .unix, .httpUnix, .httpsUnix:
-                return false
-            }
-        case .unix, .httpUnix, .httpsUnix:
-            return true
         }
     }
 }

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -92,18 +92,17 @@ extension HTTPClient {
 
     /// Represent HTTP request.
     public struct Request {
-
         /// Request HTTP method, defaults to `GET`.
         public let method: HTTPMethod
         /// Remote URL.
         public let url: URL
-        
+
         /// Parsed, validated and deconstructed URL.
         internal let deconstructedURL: DeconstructedURL
-        
+
         /// Remote HTTP scheme, resolved from `URL`.
         public var scheme: String {
-            deconstructedURL.scheme.rawValue
+            self.deconstructedURL.scheme.rawValue
         }
 
         /// Request custom HTTP Headers, defaults to no headers.
@@ -190,7 +189,7 @@ extension HTTPClient {
         ///     - `missingSocketPath` if URL does not contains a socketPath as an encoded host.
         public init(url: URL, method: HTTPMethod = .GET, headers: HTTPHeaders = HTTPHeaders(), body: Body? = nil, tlsConfiguration: TLSConfiguration?) throws {
             self.deconstructedURL = try DeconstructedURL(url: url)
-        
+
             self.redirectState = nil
             self.url = url
             self.method = method
@@ -198,7 +197,7 @@ extension HTTPClient {
             self.body = body
             self.tlsConfiguration = tlsConfiguration
         }
-        
+
         /// Remote host, resolved from `URL`.
         public var host: String {
             switch self.deconstructedURL.connectionTarget {
@@ -207,16 +206,16 @@ extension HTTPClient {
             case .unixSocket: return ""
             }
         }
-        
+
         /// Resolved port.
         public var port: Int {
             switch self.deconstructedURL.connectionTarget {
             case .ipAddress(_, let address): return address.port!
             case .domain(_, let port): return port
-            case .unixSocket: return deconstructedURL.scheme.defaultPort
+            case .unixSocket: return self.deconstructedURL.scheme.defaultPort
             }
         }
-        
+
         /// Whether request will be executed using secure socket.
         public var useTLS: Bool { self.deconstructedURL.scheme.useTLS }
 
@@ -757,9 +756,9 @@ extension DeconstructedURL.Scheme {
         else {
             return false
         }
-        return supportsRedirects(to: destinationScheme)
+        return self.supportsRedirects(to: destinationScheme)
     }
-    
+
     func supportsRedirects(to destinationScheme: Self) -> Bool {
         switch self {
         case .http, .https:

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -217,7 +217,7 @@ extension HTTPClient {
         }
 
         /// Whether request will be executed using secure socket.
-        public var useTLS: Bool { self.deconstructedURL.scheme.useTLS }
+        public var useTLS: Bool { self.deconstructedURL.scheme.usesTLS }
 
         func createRequestHead() throws -> (HTTPRequestHead, RequestFramingMetadata) {
             var head = HTTPRequestHead(
@@ -748,7 +748,7 @@ internal struct RedirectHandler<ResponseType> {
     }
 }
 
-extension DeconstructedURL.Scheme {
+extension Scheme {
     func supportsRedirects(to destinationScheme: String?) -> Bool {
         guard
             let destinationSchemeString = destinationScheme?.lowercased(),

--- a/Sources/AsyncHTTPClient/Scheme.swift
+++ b/Sources/AsyncHTTPClient/Scheme.swift
@@ -35,3 +35,29 @@ extension Scheme {
         self.usesTLS ? 443 : 80
     }
 }
+
+extension Scheme {
+    func supportsRedirects(to destinationScheme: String?) -> Bool {
+        guard
+            let destinationSchemeString = destinationScheme?.lowercased(),
+            let destinationScheme = Self(rawValue: destinationSchemeString)
+        else {
+            return false
+        }
+        return self.supportsRedirects(to: destinationScheme)
+    }
+
+    func supportsRedirects(to destinationScheme: Self) -> Bool {
+        switch self {
+        case .http, .https:
+            switch destinationScheme {
+            case .http, .https:
+                return true
+            case .unix, .httpUnix, .httpsUnix:
+                return false
+            }
+        case .unix, .httpUnix, .httpsUnix:
+            return true
+        }
+    }
+}

--- a/Sources/AsyncHTTPClient/Scheme.swift
+++ b/Sources/AsyncHTTPClient/Scheme.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// List of schemes `HTTPClient` currently supports
+enum Scheme: String {
+    case http
+    case https
+    case unix
+    case httpUnix = "http+unix"
+    case httpsUnix = "https+unix"
+}
+
+extension Scheme {
+    var usesTLS: Bool {
+        switch self {
+        case .http, .httpUnix, .unix:
+            return false
+        case .https, .httpsUnix:
+            return true
+        }
+    }
+
+    var defaultPort: Int {
+        self.usesTLS ? 443 : 80
+    }
+}

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -446,77 +446,77 @@ class HTTPClientInternalTests: XCTestCase {
 
     func testInternalRequestURI() throws {
         let request1 = try Request(url: "https://someserver.com:8888/some/path?foo=bar")
-        XCTAssertEqual(request1.kind, .host)
-        XCTAssertEqual(request1.connectionTarget, .domain(name: "someserver.com", port: 8888))
-        XCTAssertEqual(request1.uri, "/some/path?foo=bar")
+        XCTAssertEqual(request1.endpoint.scheme, .https)
+        XCTAssertEqual(request1.endpoint.connectionTarget, .domain(name: "someserver.com", port: 8888))
+        XCTAssertEqual(request1.endpoint.uri, "/some/path?foo=bar")
+
+        let request2 = try Request(url: "https://someserver.com")
+        XCTAssertEqual(request2.endpoint.scheme, .https)
+        XCTAssertEqual(request2.endpoint.connectionTarget, .domain(name: "someserver.com", port: 443))
         XCTAssertEqual(request2.endpoint.uri, "/")
 
-        XCTAssertEqual(request2.kind, .host)
-        XCTAssertEqual(request2.connectionTarget, .domain(name: "someserver.com", port: 443))
-        XCTAssertEqual(request2.uri, "/")
+        let request3 = try Request(url: "unix:///tmp/file")
+        XCTAssertEqual(request3.endpoint.scheme, .unix)
+        XCTAssertEqual(request3.endpoint.connectionTarget, .unixSocket(path: "/tmp/file"))
         XCTAssertEqual(request3.endpoint.uri, "/")
 
-        XCTAssertEqual(request3.kind, .unixSocket(.baseURL))
-        XCTAssertEqual(request3.connectionTarget, .unixSocket(path: "/tmp/file"))
-        XCTAssertEqual(request3.uri, "/")
+        let request4 = try Request(url: "http+unix://%2Ftmp%2Ffile/file/path")
+        XCTAssertEqual(request4.endpoint.scheme, .httpUnix)
+        XCTAssertEqual(request4.endpoint.connectionTarget, .unixSocket(path: "/tmp/file"))
         XCTAssertEqual(request4.endpoint.uri, "/file/path")
 
-        XCTAssertEqual(request4.kind, .unixSocket(.http_unix))
-        XCTAssertEqual(request4.connectionTarget, .unixSocket(path: "/tmp/file"))
-        XCTAssertEqual(request4.uri, "/file/path")
+        let request5 = try Request(url: "https+unix://%2Ftmp%2Ffile/file/path")
+        XCTAssertEqual(request5.endpoint.scheme, .httpsUnix)
+        XCTAssertEqual(request5.endpoint.connectionTarget, .unixSocket(path: "/tmp/file"))
         XCTAssertEqual(request5.endpoint.uri, "/file/path")
-    
-        XCTAssertEqual(request5.kind, .unixSocket(.https_unix))
-        XCTAssertEqual(request5.connectionTarget, .unixSocket(path: "/tmp/file"))
-        XCTAssertEqual(request5.uri, "/file/path")
 
         let request6 = try Request(url: "https://127.0.0.1")
-        XCTAssertEqual(request6.kind, .host)
-        XCTAssertEqual(request6.connectionTarget, .ipAddress(
+        XCTAssertEqual(request6.endpoint.scheme, .https)
+        XCTAssertEqual(request6.endpoint.connectionTarget, .ipAddress(
             serialization: "127.0.0.1",
             address: try! SocketAddress(ipAddress: "127.0.0.1", port: 443)
         ))
-        XCTAssertEqual(request6.uri, "/")
+        XCTAssertEqual(request6.endpoint.uri, "/")
 
         let request7 = try Request(url: "https://0x7F.1:9999")
-        XCTAssertEqual(request7.kind, .host)
-        XCTAssertEqual(request7.connectionTarget, .domain(name: "0x7F.1", port: 9999))
-        XCTAssertEqual(request7.uri, "/")
+        XCTAssertEqual(request7.endpoint.scheme, .https)
+        XCTAssertEqual(request7.endpoint.connectionTarget, .domain(name: "0x7F.1", port: 9999))
+        XCTAssertEqual(request7.endpoint.uri, "/")
 
         let request8 = try Request(url: "http://[::1]")
-        XCTAssertEqual(request8.kind, .host)
-        XCTAssertEqual(request8.connectionTarget, .ipAddress(
+        XCTAssertEqual(request8.endpoint.scheme, .http)
+        XCTAssertEqual(request8.endpoint.connectionTarget, .ipAddress(
             serialization: "[::1]",
             address: try! SocketAddress(ipAddress: "::1", port: 80)
         ))
-        XCTAssertEqual(request8.uri, "/")
+        XCTAssertEqual(request8.endpoint.uri, "/")
 
         let request9 = try Request(url: "http://[763e:61d9::6ACA:3100:6274]:4242/foo/bar?baz")
-        XCTAssertEqual(request9.kind, .host)
-        XCTAssertEqual(request9.connectionTarget, .ipAddress(
+        XCTAssertEqual(request9.endpoint.scheme, .http)
+        XCTAssertEqual(request9.endpoint.connectionTarget, .ipAddress(
             serialization: "[763e:61d9::6ACA:3100:6274]",
             address: try! SocketAddress(ipAddress: "763e:61d9::6aca:3100:6274", port: 4242)
         ))
-        XCTAssertEqual(request9.uri, "/foo/bar?baz")
+        XCTAssertEqual(request9.endpoint.uri, "/foo/bar?baz")
 
         // Some systems have quirks in their implementations of 'ntop' which cause them to write
         // certain IPv6 addresses with embedded IPv4 parts (e.g. "::192.168.0.1" vs "::c0a8:1").
         // We want to make sure that our request formatting doesn't depend on the platform's quirks,
         // so the serialization must be kept verbatim as it was given in the request.
         let request10 = try Request(url: "http://[::c0a8:1]:4242/foo/bar?baz")
-        XCTAssertEqual(request10.kind, .host)
-        XCTAssertEqual(request10.connectionTarget, .ipAddress(
+        XCTAssertEqual(request10.endpoint.scheme, .http)
+        XCTAssertEqual(request10.endpoint.connectionTarget, .ipAddress(
             serialization: "[::c0a8:1]",
             address: try! SocketAddress(ipAddress: "::c0a8:1", port: 4242)
         ))
-        XCTAssertEqual(request9.uri, "/foo/bar?baz")
+        XCTAssertEqual(request10.endpoint.uri, "/foo/bar?baz")
 
         let request11 = try Request(url: "http://[::192.168.0.1]:4242/foo/bar?baz")
-        XCTAssertEqual(request11.kind, .host)
-        XCTAssertEqual(request11.connectionTarget, .ipAddress(
+        XCTAssertEqual(request11.endpoint.scheme, .http)
+        XCTAssertEqual(request11.endpoint.connectionTarget, .ipAddress(
             serialization: "[::192.168.0.1]",
             address: try! SocketAddress(ipAddress: "::192.168.0.1", port: 4242)
         ))
-        XCTAssertEqual(request11.uri, "/foo/bar?baz")
+        XCTAssertEqual(request11.endpoint.uri, "/foo/bar?baz")
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -446,28 +446,28 @@ class HTTPClientInternalTests: XCTestCase {
 
     func testInternalRequestURI() throws {
         let request1 = try Request(url: "http://someserver.com:8888/some/path?foo=bar")
-        XCTAssertEqual(request1._scheme, .http)
-        XCTAssertEqual(request1.socketPath, "")
-        XCTAssertEqual(request1.uri, "/some/path?foo=bar")
+        XCTAssertEqual(request1.endpoint.scheme, .http)
+        XCTAssertEqual(request1.endpoint.socketPath, "")
+        XCTAssertEqual(request1.endpoint.uri, "/some/path?foo=bar")
 
         let request2 = try Request(url: "https://someserver.com")
-        XCTAssertEqual(request2._scheme, .https)
-        XCTAssertEqual(request2.socketPath, "")
-        XCTAssertEqual(request2.uri, "/")
+        XCTAssertEqual(request2.endpoint.scheme, .https)
+        XCTAssertEqual(request2.endpoint.socketPath, "")
+        XCTAssertEqual(request2.endpoint.uri, "/")
 
         let request3 = try Request(url: "unix:///tmp/file")
-        XCTAssertEqual(request3._scheme, .unix)
-        XCTAssertEqual(request3.socketPath, "/tmp/file")
-        XCTAssertEqual(request3.uri, "/")
+        XCTAssertEqual(request3.endpoint.scheme, .unix)
+        XCTAssertEqual(request3.endpoint.socketPath, "/tmp/file")
+        XCTAssertEqual(request3.endpoint.uri, "/")
 
         let request4 = try Request(url: "http+unix://%2Ftmp%2Ffile/file/path")
-        XCTAssertEqual(request4._scheme, .httpUnix)
-        XCTAssertEqual(request4.socketPath, "/tmp/file")
-        XCTAssertEqual(request4.uri, "/file/path")
+        XCTAssertEqual(request4.endpoint.scheme, .httpUnix)
+        XCTAssertEqual(request4.endpoint.socketPath, "/tmp/file")
+        XCTAssertEqual(request4.endpoint.uri, "/file/path")
 
         let request5 = try Request(url: "https+unix://%2Ftmp%2Ffile/file/path")
-        XCTAssertEqual(request5._scheme, .httpsUnix)
-        XCTAssertEqual(request5.socketPath, "/tmp/file")
-        XCTAssertEqual(request5.uri, "/file/path")
+        XCTAssertEqual(request5.endpoint.scheme, .httpsUnix)
+        XCTAssertEqual(request5.endpoint.socketPath, "/tmp/file")
+        XCTAssertEqual(request5.endpoint.uri, "/file/path")
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -445,28 +445,28 @@ class HTTPClientInternalTests: XCTestCase {
     }
 
     func testInternalRequestURI() throws {
-        let request1 = try Request(url: "https://someserver.com:8888/some/path?foo=bar")
-        XCTAssertEqual(request1.kind, .host)
+        let request1 = try Request(url: "http://someserver.com:8888/some/path?foo=bar")
+        XCTAssertEqual(request1._scheme, .http)
         XCTAssertEqual(request1.socketPath, "")
         XCTAssertEqual(request1.uri, "/some/path?foo=bar")
 
         let request2 = try Request(url: "https://someserver.com")
-        XCTAssertEqual(request2.kind, .host)
+        XCTAssertEqual(request2._scheme, .https)
         XCTAssertEqual(request2.socketPath, "")
         XCTAssertEqual(request2.uri, "/")
 
         let request3 = try Request(url: "unix:///tmp/file")
-        XCTAssertEqual(request3.kind, .unixSocket(.baseURL))
+        XCTAssertEqual(request3._scheme, .unix)
         XCTAssertEqual(request3.socketPath, "/tmp/file")
         XCTAssertEqual(request3.uri, "/")
 
         let request4 = try Request(url: "http+unix://%2Ftmp%2Ffile/file/path")
-        XCTAssertEqual(request4.kind, .unixSocket(.http_unix))
+        XCTAssertEqual(request4._scheme, .httpUnix)
         XCTAssertEqual(request4.socketPath, "/tmp/file")
         XCTAssertEqual(request4.uri, "/file/path")
 
         let request5 = try Request(url: "https+unix://%2Ftmp%2Ffile/file/path")
-        XCTAssertEqual(request5.kind, .unixSocket(.https_unix))
+        XCTAssertEqual(request5._scheme, .httpsUnix)
         XCTAssertEqual(request5.socketPath, "/tmp/file")
         XCTAssertEqual(request5.uri, "/file/path")
     }

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -446,77 +446,77 @@ class HTTPClientInternalTests: XCTestCase {
 
     func testInternalRequestURI() throws {
         let request1 = try Request(url: "https://someserver.com:8888/some/path?foo=bar")
-        XCTAssertEqual(request1.endpoint.scheme, .https)
-        XCTAssertEqual(request1.endpoint.connectionTarget, .domain(name: "someserver.com", port: 8888))
-        XCTAssertEqual(request1.endpoint.uri, "/some/path?foo=bar")
+        XCTAssertEqual(request1.deconstructedURL.scheme, .https)
+        XCTAssertEqual(request1.deconstructedURL.connectionTarget, .domain(name: "someserver.com", port: 8888))
+        XCTAssertEqual(request1.deconstructedURL.uri, "/some/path?foo=bar")
 
         let request2 = try Request(url: "https://someserver.com")
-        XCTAssertEqual(request2.endpoint.scheme, .https)
-        XCTAssertEqual(request2.endpoint.connectionTarget, .domain(name: "someserver.com", port: 443))
-        XCTAssertEqual(request2.endpoint.uri, "/")
+        XCTAssertEqual(request2.deconstructedURL.scheme, .https)
+        XCTAssertEqual(request2.deconstructedURL.connectionTarget, .domain(name: "someserver.com", port: 443))
+        XCTAssertEqual(request2.deconstructedURL.uri, "/")
 
         let request3 = try Request(url: "unix:///tmp/file")
-        XCTAssertEqual(request3.endpoint.scheme, .unix)
-        XCTAssertEqual(request3.endpoint.connectionTarget, .unixSocket(path: "/tmp/file"))
-        XCTAssertEqual(request3.endpoint.uri, "/")
+        XCTAssertEqual(request3.deconstructedURL.scheme, .unix)
+        XCTAssertEqual(request3.deconstructedURL.connectionTarget, .unixSocket(path: "/tmp/file"))
+        XCTAssertEqual(request3.deconstructedURL.uri, "/")
 
         let request4 = try Request(url: "http+unix://%2Ftmp%2Ffile/file/path")
-        XCTAssertEqual(request4.endpoint.scheme, .httpUnix)
-        XCTAssertEqual(request4.endpoint.connectionTarget, .unixSocket(path: "/tmp/file"))
-        XCTAssertEqual(request4.endpoint.uri, "/file/path")
+        XCTAssertEqual(request4.deconstructedURL.scheme, .httpUnix)
+        XCTAssertEqual(request4.deconstructedURL.connectionTarget, .unixSocket(path: "/tmp/file"))
+        XCTAssertEqual(request4.deconstructedURL.uri, "/file/path")
 
         let request5 = try Request(url: "https+unix://%2Ftmp%2Ffile/file/path")
-        XCTAssertEqual(request5.endpoint.scheme, .httpsUnix)
-        XCTAssertEqual(request5.endpoint.connectionTarget, .unixSocket(path: "/tmp/file"))
-        XCTAssertEqual(request5.endpoint.uri, "/file/path")
+        XCTAssertEqual(request5.deconstructedURL.scheme, .httpsUnix)
+        XCTAssertEqual(request5.deconstructedURL.connectionTarget, .unixSocket(path: "/tmp/file"))
+        XCTAssertEqual(request5.deconstructedURL.uri, "/file/path")
 
         let request6 = try Request(url: "https://127.0.0.1")
-        XCTAssertEqual(request6.endpoint.scheme, .https)
-        XCTAssertEqual(request6.endpoint.connectionTarget, .ipAddress(
+        XCTAssertEqual(request6.deconstructedURL.scheme, .https)
+        XCTAssertEqual(request6.deconstructedURL.connectionTarget, .ipAddress(
             serialization: "127.0.0.1",
             address: try! SocketAddress(ipAddress: "127.0.0.1", port: 443)
         ))
-        XCTAssertEqual(request6.endpoint.uri, "/")
+        XCTAssertEqual(request6.deconstructedURL.uri, "/")
 
         let request7 = try Request(url: "https://0x7F.1:9999")
-        XCTAssertEqual(request7.endpoint.scheme, .https)
-        XCTAssertEqual(request7.endpoint.connectionTarget, .domain(name: "0x7F.1", port: 9999))
-        XCTAssertEqual(request7.endpoint.uri, "/")
+        XCTAssertEqual(request7.deconstructedURL.scheme, .https)
+        XCTAssertEqual(request7.deconstructedURL.connectionTarget, .domain(name: "0x7F.1", port: 9999))
+        XCTAssertEqual(request7.deconstructedURL.uri, "/")
 
         let request8 = try Request(url: "http://[::1]")
-        XCTAssertEqual(request8.endpoint.scheme, .http)
-        XCTAssertEqual(request8.endpoint.connectionTarget, .ipAddress(
+        XCTAssertEqual(request8.deconstructedURL.scheme, .http)
+        XCTAssertEqual(request8.deconstructedURL.connectionTarget, .ipAddress(
             serialization: "[::1]",
             address: try! SocketAddress(ipAddress: "::1", port: 80)
         ))
-        XCTAssertEqual(request8.endpoint.uri, "/")
+        XCTAssertEqual(request8.deconstructedURL.uri, "/")
 
         let request9 = try Request(url: "http://[763e:61d9::6ACA:3100:6274]:4242/foo/bar?baz")
-        XCTAssertEqual(request9.endpoint.scheme, .http)
-        XCTAssertEqual(request9.endpoint.connectionTarget, .ipAddress(
+        XCTAssertEqual(request9.deconstructedURL.scheme, .http)
+        XCTAssertEqual(request9.deconstructedURL.connectionTarget, .ipAddress(
             serialization: "[763e:61d9::6ACA:3100:6274]",
             address: try! SocketAddress(ipAddress: "763e:61d9::6aca:3100:6274", port: 4242)
         ))
-        XCTAssertEqual(request9.endpoint.uri, "/foo/bar?baz")
+        XCTAssertEqual(request9.deconstructedURL.uri, "/foo/bar?baz")
 
         // Some systems have quirks in their implementations of 'ntop' which cause them to write
         // certain IPv6 addresses with embedded IPv4 parts (e.g. "::192.168.0.1" vs "::c0a8:1").
         // We want to make sure that our request formatting doesn't depend on the platform's quirks,
         // so the serialization must be kept verbatim as it was given in the request.
         let request10 = try Request(url: "http://[::c0a8:1]:4242/foo/bar?baz")
-        XCTAssertEqual(request10.endpoint.scheme, .http)
-        XCTAssertEqual(request10.endpoint.connectionTarget, .ipAddress(
+        XCTAssertEqual(request10.deconstructedURL.scheme, .http)
+        XCTAssertEqual(request10.deconstructedURL.connectionTarget, .ipAddress(
             serialization: "[::c0a8:1]",
             address: try! SocketAddress(ipAddress: "::c0a8:1", port: 4242)
         ))
-        XCTAssertEqual(request10.endpoint.uri, "/foo/bar?baz")
+        XCTAssertEqual(request10.deconstructedURL.uri, "/foo/bar?baz")
 
         let request11 = try Request(url: "http://[::192.168.0.1]:4242/foo/bar?baz")
-        XCTAssertEqual(request11.endpoint.scheme, .http)
-        XCTAssertEqual(request11.endpoint.connectionTarget, .ipAddress(
+        XCTAssertEqual(request11.deconstructedURL.scheme, .http)
+        XCTAssertEqual(request11.deconstructedURL.connectionTarget, .ipAddress(
             serialization: "[::192.168.0.1]",
             address: try! SocketAddress(ipAddress: "::192.168.0.1", port: 4242)
         ))
-        XCTAssertEqual(request11.endpoint.uri, "/foo/bar?baz")
+        XCTAssertEqual(request11.deconstructedURL.uri, "/foo/bar?baz")
     }
 }


### PR DESCRIPTION
### Motivation
We want to reuse our URL parsing, validation and deconstruction logic for the upcoming new `HTTPClientRequest` from the async/await proposal.

### Changes
- Introduce a new `DeconstructedURL` struct which hold a `scheme`, `connectionTarget` and `uri`.
- Introduce a new `DeconstructedURL.Scheme` enum which replaced the previous `String` in `HTTPClient.Request` and `ConnectionPool.Scheme` enum
- move `deconstructURL` logic to an initialiser of  `DeconstructedURL`
- use `DeconstructedURL` instead of separate `scheme`, `connectionTarget`, and `uri` properties in `HTTPClient.Request`
- remove `HTTPClient.Request.Kind` because it is almost a replica of the `DeconstructedURL.Scheme` enum where the only difference is that `http` and `https` are represented as one case called `host`. As we now represent `scheme` as an enum instead of a `String` we can safely replace it with an exhaustive switch over `scheme` instead.
- refactor tests to use `scheme` instead of `kind`
- remove unused `config(overriding:)` from `ConnectionPool.Key`