### PR TITLE
Add HTTPClientReuqest.Prepared

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+import NIOHTTP1
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HTTPClientRequest {
+    struct Prepared {
+        let poolKey: ConnectionPool.Key
+        let requestFramingMetadata: RequestFramingMetadata
+        let head: HTTPRequestHead
+        let body: Body?
+    }
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HTTPClientRequest {
+    func prepared() throws -> Prepared {
+        let url = try DeconstructedURL(url: self.url)
+
+        var headers = self.headers
+        headers.addHostIfNeeded(for: url)
+        let metadata = try headers.validateAndSetTransportFraming(
+            method: self.method,
+            bodyLength: .init(self.body)
+        )
+
+        return .init(
+            poolKey: .init(url: url, tlsConfiguration: nil),
+            requestFramingMetadata: metadata,
+            head: .init(
+                version: .http1_1,
+                method: self.method,
+                uri: url.uri,
+                headers: headers
+            ),
+            body: self.body
+        )
+    }
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension RequestBodyLength {
+    init(_ body: HTTPClientRequest.Body?) {
+        switch body?.mode {
+        case .none:
+            self = .fixed(length: 0)
+        case .byteBuffer(let buffer):
+            self = .fixed(length: buffer.readableBytes)
+        case .sequence(nil, _), .asyncSequence(nil, _):
+            self = .dynamic
+        case .sequence(.some(let length), _), .asyncSequence(.some(let length), _):
+            self = .fixed(length: length)
+        }
+    }
+}
+
+#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -18,10 +18,10 @@ import NIOHTTP1
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 extension HTTPClientRequest {
     struct Prepared {
-        let poolKey: ConnectionPool.Key
-        let requestFramingMetadata: RequestFramingMetadata
-        let head: HTTPRequestHead
-        let body: Body?
+        var poolKey: ConnectionPool.Key
+        var requestFramingMetadata: RequestFramingMetadata
+        var head: HTTPRequestHead
+        var body: Body?
     }
 }
 

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -26,27 +26,27 @@ extension HTTPClientRequest {
 }
 
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-extension HTTPClientRequest {
-    func prepared() throws -> Prepared {
-        let url = try DeconstructedURL(url: self.url)
+extension HTTPClientRequest.Prepared {
+    init(_ request: HTTPClientRequest) throws {
+        let url = try DeconstructedURL(url: request.url)
 
-        var headers = self.headers
+        var headers = request.headers
         headers.addHostIfNeeded(for: url)
         let metadata = try headers.validateAndSetTransportFraming(
-            method: self.method,
-            bodyLength: .init(self.body)
+            method: request.method,
+            bodyLength: .init(request.body)
         )
 
-        return .init(
+        self.init(
             poolKey: .init(url: url, tlsConfiguration: nil),
             requestFramingMetadata: metadata,
             head: .init(
                 version: .http1_1,
-                method: self.method,
+                method: request.method,
                 uri: url.uri,
                 headers: headers
             ),
-            body: self.body
+            body: request.body
         )
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionTarget.swift
+++ b/Sources/AsyncHTTPClient/ConnectionTarget.swift
@@ -40,3 +40,25 @@ enum ConnectionTarget: Equatable, Hashable {
         }
     }
 }
+
+extension ConnectionTarget {
+    /// The host name which will be send as an HTTP `Host` header.
+    /// Only returns nil if the `self` is a `unixSocket`.
+    var host: String? {
+        switch self {
+        case .ipAddress(let serialization, _): return serialization
+        case .domain(let name, _): return name
+        case .unixSocket: return nil
+        }
+    }
+
+    /// The host name which will be send as an HTTP host header.
+    /// Only returns nil if the `self` is a `unixSocket`.
+    var port: Int? {
+        switch self {
+        case .ipAddress(_, let address): return address.port!
+        case .domain(_, let port): return port
+        case .unixSocket: return nil
+        }
+    }
+}

--- a/Sources/AsyncHTTPClient/DeconstructedURL.swift
+++ b/Sources/AsyncHTTPClient/DeconstructedURL.swift
@@ -31,6 +31,13 @@ struct DeconstructedURL {
 }
 
 extension DeconstructedURL {
+    init(url: String) throws {
+        guard let url = URL(string: url) else {
+            throw HTTPClientError.invalidURL
+        }
+        try self.init(url: url)
+    }
+
     init(url: URL) throws {
         guard let schemeString = url.scheme else {
             throw HTTPClientError.emptyScheme

--- a/Sources/AsyncHTTPClient/RequestValidation.swift
+++ b/Sources/AsyncHTTPClient/RequestValidation.swift
@@ -110,3 +110,20 @@ extension HTTPHeaders {
         }
     }
 }
+
+extension HTTPHeaders {
+    mutating func addHostIfNeeded(for url: DeconstructedURL) {
+        // if no host header was set, let's use the url host
+        guard !self.contains(name: "host"),
+              var host = url.connectionTarget.host
+        else {
+            return
+        }
+        // if the request uses a non-default port, we need to add it after the host
+        if let port = url.connectionTarget.port,
+           port != url.scheme.defaultPort {
+            host += ":\(port)"
+        }
+        self.add(name: "host", value: host)
+    }
+}


### PR DESCRIPTION
Before we can execute a `HTTPClientRequest` we need do a couple of validation and transformation steps which can fail. 
The result of the preparation is now encapsulated in a separate object called `HTTPClientRequest.Prepared`.
