### PR TITLE
MockRequestExecutor calls `requestHeadSent`

### DIFF
--- a/Tests/AsyncHTTPClientTests/Mocks/MockRequestExecutor.swift
+++ b/Tests/AsyncHTTPClientTests/Mocks/MockRequestExecutor.swift
@@ -88,6 +88,7 @@ final class MockRequestExecutor {
         precondition(self.request == nil)
         self.request = request
         request.willExecuteRequest(self)
+        request.requestHeadSent()
     }
 
     func receiveRequestBody(deadline: NIODeadline = .now() + .seconds(60), _ verify: (ByteBuffer) throws -> Void) throws {
@@ -166,7 +167,7 @@ final class MockRequestExecutor {
         }
     }
 
-    func resetResponseStreamDemandSignal0() {
+    private func resetResponseStreamDemandSignal0() {
         self._signaledDemandForResponseBody = false
     }
 }

--- a/Tests/AsyncHTTPClientTests/RequestBagTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests.swift
@@ -76,11 +76,10 @@ final class RequestBagTests: XCTestCase {
             eventLoop: embeddedEventLoop
         )
 
-        executor.runRequest(bag)
-
         XCTAssertEqual(delegate.hitDidSendRequestHead, 0)
-        bag.requestHeadSent()
+        executor.runRequest(bag)
         XCTAssertEqual(delegate.hitDidSendRequestHead, 1)
+
         streamIsAllowedToWrite = true
         bag.resumeRequestBodyStream()
         streamIsAllowedToWrite = false
@@ -180,10 +179,8 @@ final class RequestBagTests: XCTestCase {
 
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
 
-        bag.willExecuteRequest(executor)
-
         XCTAssertEqual(delegate.hitDidSendRequestHead, 0)
-        bag.requestHeadSent()
+        executor.runRequest(bag)
         XCTAssertEqual(delegate.hitDidSendRequestHead, 1)
         XCTAssertEqual(delegate.hitDidSendRequestPart, 0)
         bag.resumeRequestBodyStream()
@@ -256,12 +253,11 @@ final class RequestBagTests: XCTestCase {
 
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
 
-        bag.willExecuteRequest(executor)
         XCTAssertFalse(executor.isCancelled)
 
         XCTAssertEqual(delegate.hitDidSendRequestHead, 0)
         XCTAssertEqual(delegate.hitDidSendRequest, 0)
-        bag.requestHeadSent()
+        executor.runRequest(bag)
         XCTAssertEqual(delegate.hitDidSendRequestHead, 1)
         XCTAssertEqual(delegate.hitDidSendRequest, 1)
 
@@ -330,8 +326,7 @@ final class RequestBagTests: XCTestCase {
         guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
 
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
-        bag.willExecuteRequest(executor)
-        bag.requestHeadSent()
+        executor.runRequest(bag)
         bag.receiveResponseHead(.init(version: .http1_1, status: .ok))
         XCTAssertEqual(executor.isCancelled, false)
         bag.fail(HTTPClientError.readTimeout)
@@ -387,11 +382,10 @@ final class RequestBagTests: XCTestCase {
         guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
 
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
-        bag.willExecuteRequest(executor)
 
         XCTAssertEqual(delegate.hitDidSendRequestHead, 0)
         XCTAssertEqual(delegate.hitDidSendRequest, 0)
-        bag.requestHeadSent()
+        executor.runRequest(bag)
         XCTAssertEqual(delegate.hitDidSendRequestHead, 1)
         XCTAssertEqual(delegate.hitDidSendRequest, 0)
 
@@ -432,8 +426,7 @@ final class RequestBagTests: XCTestCase {
         guard let bag = maybeRequestBag else { return XCTFail("Expected to be able to create a request bag.") }
 
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
-        bag.willExecuteRequest(executor)
-        bag.requestHeadSent()
+        executor.runRequest(bag)
         bag.receiveResponseHead(.init(version: .http1_1, status: .ok))
         XCTAssertFalse(executor.signalledDemandForResponseBody)
         XCTAssertNoThrow(try XCTUnwrap(delegate.backpressurePromise).succeed(()))


### PR DESCRIPTION
### Motivation

Our actual HTTPRequestExecutors send out a HTTPRequest as soon as they see it and they call `willExecuteRequest` and `requestHeadSent` in very fast succession on the HTTPExecutableRequest. We should have the same behavior in tests.

### Changes

- Call `requestHeadSent` from `MockRequestExecutor.runRequest`
- Tests that use `MockRequestExecutor` call `runRequest` on it first

### Result

Cleaner, more life like tests