### PR TITLE
Fix flaky test: testConnectionClosesAfterTheRequestWithoutHavingSentAnCloseHeader

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
@@ -320,6 +320,7 @@ class HTTP1ConnectionTests: XCTestCase {
         defer { XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully()) }
 
         let httpBin = HTTPBin(handlerFactory: { _ in AfterRequestCloseConnectionChannelHandler() })
+        defer { XCTAssertNoThrow(try httpBin.shutdown()) }
 
         var maybeChannel: Channel?
 
@@ -362,7 +363,6 @@ class HTTP1ConnectionTests: XCTestCase {
 
         XCTAssertNoThrow(try XCTUnwrap(maybeChannel).closeFuture.wait())
         XCTAssertEqual(connectionDelegate.hitConnectionClosed, 1)
-        XCTAssertEqual(httpBin.activeConnections, 0)
     }
 
     func testConnectionIsClosedAfterSwitchingProtocols() {


### PR DESCRIPTION
### Motivation

Currently that test is flaky because of an assertion, we do that doesn't add any value to the test itself.

### Changes

- Remove unneeded/sometimes failing assertion
- Shutdown the server

### Result

Should fix #468.