### PR TITLE
Refactor redirect logic to be reusable for async/await

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -519,7 +519,7 @@ public class HTTPClient {
             deadline: deadline,
             logger: originalLogger,
             redirectState: RedirectState(
-                self.configuration.redirectConfiguration.configuration,
+                self.configuration.redirectConfiguration.mode,
                 initialURL: request.url.absoluteString
             )
         )
@@ -835,21 +835,21 @@ extension HTTPClient.Configuration {
 
     /// Specifies redirect processing settings.
     public struct RedirectConfiguration {
-        enum Configuration {
+        enum Mode {
             /// Redirects are not followed.
             case disallow
             /// Redirects are followed with a specified limit.
             case follow(max: Int, allowCycles: Bool)
         }
 
-        var configuration: Configuration
+        var mode: Mode
 
         init() {
-            self.configuration = .follow(max: 5, allowCycles: false)
+            self.mode = .follow(max: 5, allowCycles: false)
         }
 
-        init(configuration: Configuration) {
-            self.configuration = configuration
+        init(configuration: Mode) {
+            self.mode = configuration
         }
 
         /// Redirects are not followed.

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -512,7 +512,7 @@ public class HTTPClient {
         deadline: NIODeadline? = nil,
         logger originalLogger: Logger?
     ) -> Task<Delegate.Response> {
-        _execute(
+        self._execute(
             request: request,
             delegate: delegate,
             eventLoop: eventLoopPreference,
@@ -524,7 +524,7 @@ public class HTTPClient {
             )
         )
     }
-    
+
     /// Execute arbitrary HTTP request and handle response processing using provided delegate.
     ///
     /// - parameters:
@@ -541,7 +541,6 @@ public class HTTPClient {
         logger originalLogger: Logger?,
         redirectState: RedirectState?
     ) -> Task<Delegate.Response> {
-        
         let logger = (originalLogger ?? HTTPClient.loggingDisabled).attachingRequestInformation(request, requestID: globalRequestID.add(1))
         let taskEL: EventLoop
         switch eventLoopPreference.preference {

--- a/Sources/AsyncHTTPClient/RedirectState.swift
+++ b/Sources/AsyncHTTPClient/RedirectState.swift
@@ -1,0 +1,140 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import struct Foundation.URL
+import NIOHTTP1
+
+struct RedirectState {
+    /// number of redirects we are allowed to follow.
+    private var count: Int
+
+    /// All visited URLs.
+    private var visited: [String]
+    
+    /// if true, `redirect(to:)` will throw an error if a cycle is detected.
+    private let allowCycles: Bool
+}
+
+extension RedirectState {
+    /// Creates a `RedirectState` from a configuration.
+    /// Returns nil if the user disallowed redirects,
+    /// otherwise an instance of `RedirectState` which respects the user defined settings.
+    init?(
+        _ configuration: HTTPClient.Configuration.RedirectConfiguration.Configuration,
+        initialURL: String
+    ) {
+        switch configuration {
+        case .disallow:
+            return nil
+        case .follow(let maxRedirects, let allowCycles):
+            self.init(count: maxRedirects, visited: [initialURL], allowCycles: allowCycles)
+        }
+    }
+}
+
+extension RedirectState {
+    /// Call this method when you are about to do a redirect to the given `redirectURL`.
+    /// This method records that URL into `self`.
+    /// - Parameter redirectURL: the new URL to redirect the request to
+    /// - Throws: if it reaches the redirect limit or detects a redirect cycle if and `allowCycles` is false
+    mutating func redirect(to redirectURL: String) throws {
+        guard self.count > 0 else {
+            throw HTTPClientError.redirectLimitReached
+        }
+
+        if !allowCycles && self.visited.contains(redirectURL) == true {
+            throw HTTPClientError.redirectCycleDetected
+        }
+
+        self.count -= 1
+        self.visited.append(redirectURL)
+    }
+}
+
+extension HTTPHeaders {
+    /// Tries to extract a redirect URL from the `location` header if the `status` indicates it should do so.
+    /// It also validates that we can redirect to the scheme of the extracted redirect URL from the `originalScheme`.
+    /// - Parameters:
+    ///   - status: response status of the request
+    ///   - originalURL: url of the previous request
+    ///   - originalScheme: scheme of the previous request
+    /// - Returns: redirect URL to follow
+    func extractRedirectTarget(
+        status: HTTPResponseStatus,
+        originalURL: URL,
+        originalScheme: Scheme
+    ) -> URL? {
+        switch status {
+        case .movedPermanently, .found, .seeOther, .notModified, .useProxy, .temporaryRedirect, .permanentRedirect:
+            break
+        default:
+            return nil
+        }
+
+        guard let location = self.first(name: "Location") else {
+            return nil
+        }
+
+        guard let url = URL(string: location, relativeTo: originalURL) else {
+            return nil
+        }
+
+        guard originalScheme.supportsRedirects(to: url.scheme) else {
+            return nil
+        }
+
+        if url.isFileURL {
+            return nil
+        }
+
+        return url.absoluteURL
+    }
+}
+
+/// Transforms the original `requestMethod`, `requestHeaders` and `requestBody` to be ready to be send out as a new request to the `redirectURL`.
+/// - Returns: New `HTTPMethod`, `HTTPHeaders` and `Body` to be send as a new request to `redirectURL`
+func transformRequestForRedirect<Body>(
+    from originalURL: URL,
+    method requestMethod: HTTPMethod,
+    headers requestHeaders: HTTPHeaders,
+    body requestBody: Body?,
+    to redirectURL: URL,
+    status responseStatus: HTTPResponseStatus
+) -> (HTTPMethod, HTTPHeaders, Body?) {
+    var convertToGet = false
+    if responseStatus == .seeOther, requestMethod != .HEAD {
+        convertToGet = true
+    } else if responseStatus == .movedPermanently || responseStatus == .found, requestMethod == .POST {
+        convertToGet = true
+    }
+
+    var method = requestMethod
+    var headers = requestHeaders
+    var body = requestBody
+
+    if convertToGet {
+        method = .GET
+        body = nil
+        headers.remove(name: "Content-Length")
+        headers.remove(name: "Content-Type")
+    }
+
+    if !originalURL.hasTheSameOrigin(as: redirectURL) {
+        headers.remove(name: "Origin")
+        headers.remove(name: "Cookie")
+        headers.remove(name: "Authorization")
+        headers.remove(name: "Proxy-Authorization")
+    }
+    return (method, headers, body)
+}

--- a/Sources/AsyncHTTPClient/RedirectState.swift
+++ b/Sources/AsyncHTTPClient/RedirectState.swift
@@ -15,6 +15,8 @@
 import struct Foundation.URL
 import NIOHTTP1
 
+typealias RedirectMode = HTTPClient.Configuration.RedirectConfiguration.Mode
+
 struct RedirectState {
     /// number of redirects we are allowed to follow.
     private var limit: Int
@@ -31,7 +33,7 @@ extension RedirectState {
     /// Returns nil if the user disallowed redirects,
     /// otherwise an instance of `RedirectState` which respects the user defined settings.
     init?(
-        _ configuration: HTTPClient.Configuration.RedirectConfiguration.Mode,
+        _ configuration: RedirectMode,
         initialURL: String
     ) {
         switch configuration {

--- a/Sources/AsyncHTTPClient/RedirectState.swift
+++ b/Sources/AsyncHTTPClient/RedirectState.swift
@@ -112,11 +112,13 @@ func transformRequestForRedirect<Body>(
     to redirectURL: URL,
     status responseStatus: HTTPResponseStatus
 ) -> (HTTPMethod, HTTPHeaders, Body?) {
-    var convertToGet = false
+    let convertToGet: Bool
     if responseStatus == .seeOther, requestMethod != .HEAD {
         convertToGet = true
     } else if responseStatus == .movedPermanently || responseStatus == .found, requestMethod == .POST {
         convertToGet = true
+    } else {
+        convertToGet = false
     }
 
     var method = requestMethod

--- a/Sources/AsyncHTTPClient/RedirectState.swift
+++ b/Sources/AsyncHTTPClient/RedirectState.swift
@@ -21,7 +21,7 @@ struct RedirectState {
 
     /// All visited URLs.
     private var visited: [String]
-    
+
     /// if true, `redirect(to:)` will throw an error if a cycle is detected.
     private let allowCycles: Bool
 }

--- a/Sources/AsyncHTTPClient/RedirectState.swift
+++ b/Sources/AsyncHTTPClient/RedirectState.swift
@@ -31,7 +31,7 @@ extension RedirectState {
     /// Returns nil if the user disallowed redirects,
     /// otherwise an instance of `RedirectState` which respects the user defined settings.
     init?(
-        _ configuration: HTTPClient.Configuration.RedirectConfiguration.Configuration,
+        _ configuration: HTTPClient.Configuration.RedirectConfiguration.Mode,
         initialURL: String
     ) {
         switch configuration {

--- a/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
@@ -268,7 +268,10 @@ extension RequestBag.StateMachine {
                 preconditionFailure("If we receive a response, we must not have received something else before")
             }
 
-            if let redirectURL = self.redirectHandler?.redirectTarget(status: head.status, headers: head.headers) {
+            if let redirectURL = self.redirectHandler?.redirectTarget(
+                status: head.status,
+                responseHeaders: head.headers
+            ) {
                 self.state = .redirected(head, redirectURL)
                 return false
             } else {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -67,6 +67,7 @@ extension HTTPClientTests {
             ("testDecompressionLimit", testDecompressionLimit),
             ("testLoopDetectionRedirectLimit", testLoopDetectionRedirectLimit),
             ("testCountRedirectLimit", testCountRedirectLimit),
+            ("testRedirectToTheInitialURLDoesThrowOnFirstRedirect", testRedirectToTheInitialURLDoesThrowOnFirstRedirect),
             ("testMultipleConcurrentRequests", testMultipleConcurrentRequests),
             ("testWorksWith500Error", testWorksWith500Error),
             ("testWorksWithHTTP10Response", testWorksWithHTTP10Response),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -110,6 +110,7 @@ extension HTTPClientTests {
             ("testWeHandleUsReceivingACloseHeaderCorrectly", testWeHandleUsReceivingACloseHeaderCorrectly),
             ("testWeHandleUsSendingACloseHeaderAmongstOtherConnectionHeadersCorrectly", testWeHandleUsSendingACloseHeaderAmongstOtherConnectionHeadersCorrectly),
             ("testWeHandleUsReceivingACloseHeaderAmongstOtherConnectionHeadersCorrectly", testWeHandleUsReceivingACloseHeaderAmongstOtherConnectionHeadersCorrectly),
+            ("testLoggingCorrectlyAttachesRequestInformationEvenAfterDuringRedirect", testLoggingCorrectlyAttachesRequestInformationEvenAfterDuringRedirect),
             ("testLoggingCorrectlyAttachesRequestInformation", testLoggingCorrectlyAttachesRequestInformation),
             ("testNothingIsLoggedAtInfoOrHigher", testNothingIsLoggedAtInfoOrHigher),
             ("testAllMethodsLog", testAllMethodsLog),

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -882,11 +882,11 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try localHTTPBin.shutdown())
         }
 
-        XCTAssertThrowsError(try localClient.get(url: "https://localhost:\(localHTTPBin.port)/redirect/infinite1").timeout(after: .seconds(10)).wait(), "Should fail with redirect limit") { error in
+        XCTAssertThrowsError(try localClient.get(url: "https://localhost:\(localHTTPBin.port)/redirect/infinite1").timeout(after: .seconds(10)).wait()) { error in
             XCTAssertEqual(error as? HTTPClientError, HTTPClientError.redirectLimitReached)
         }
     }
-    
+
     func testRedirectToTheInitialURLDoesThrowOnFirstRedirect() throws {
         let localHTTPBin = HTTPBin(.http1_1(ssl: true))
         defer { XCTAssertNoThrow(try localHTTPBin.shutdown()) }
@@ -898,8 +898,7 @@ class HTTPClientTests: XCTestCase {
             )
         )
         defer { XCTAssertNoThrow(try localClient.syncShutdown()) }
-        
-        
+
         var maybeRequest: HTTPClient.Request?
         XCTAssertNoThrow(maybeRequest = try HTTPClient.Request(
             url: "https://localhost:\(localHTTPBin.port)/redirect/target",
@@ -909,10 +908,9 @@ class HTTPClientTests: XCTestCase {
             ]
         ))
         guard let request = maybeRequest else { return }
-        
+
         XCTAssertThrowsError(
-            try localClient.execute(request: request).timeout(after: .seconds(10)).wait(),
-            "Should fail with redirect limit"
+            try localClient.execute(request: request).timeout(after: .seconds(10)).wait()
         ) { error in
             XCTAssertEqual(error as? HTTPClientError, HTTPClientError.redirectCycleDetected)
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -882,8 +882,39 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try localHTTPBin.shutdown())
         }
 
-        XCTAssertThrowsError(try localClient.get(url: "https://localhost:\(localHTTPBin.port)/redirect/infinite1").wait(), "Should fail with redirect limit") { error in
+        XCTAssertThrowsError(try localClient.get(url: "https://localhost:\(localHTTPBin.port)/redirect/infinite1").timeout(after: .seconds(10)).wait(), "Should fail with redirect limit") { error in
             XCTAssertEqual(error as? HTTPClientError, HTTPClientError.redirectLimitReached)
+        }
+    }
+    
+    func testRedirectToTheInitialURLDoesThrowOnFirstRedirect() throws {
+        let localHTTPBin = HTTPBin(.http1_1(ssl: true))
+        defer { XCTAssertNoThrow(try localHTTPBin.shutdown()) }
+        let localClient = HTTPClient(
+            eventLoopGroupProvider: .shared(self.clientGroup),
+            configuration: .init(
+                certificateVerification: .none,
+                redirectConfiguration: .follow(max: 1, allowCycles: false)
+            )
+        )
+        defer { XCTAssertNoThrow(try localClient.syncShutdown()) }
+        
+        
+        var maybeRequest: HTTPClient.Request?
+        XCTAssertNoThrow(maybeRequest = try HTTPClient.Request(
+            url: "https://localhost:\(localHTTPBin.port)/redirect/target",
+            method: .GET,
+            headers: [
+                "X-Target-Redirect-URL": "/redirect/target",
+            ]
+        ))
+        guard let request = maybeRequest else { return }
+        
+        XCTAssertThrowsError(
+            try localClient.execute(request: request).timeout(after: .seconds(10)).wait(),
+            "Should fail with redirect limit"
+        ) { error in
+            XCTAssertEqual(error as? HTTPClientError, HTTPClientError.redirectCycleDetected)
         }
     }
 


### PR DESCRIPTION
### Motivation
We want to reuse the current redirect logic, which was mainly located inside the `RedirectHandler`, for the upcoming async/await implementation.

### Changes
- move `HTTPClient.Request.RedirectState` to the top level and a separate file
- refactor redirect logic from `RedirectHandler` into methods on `HTTPHeaders` and methods on `RedirectState`
- use the refactored methods in `RedirectHandler`