### PR TITLE
async/await execute

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -51,6 +51,8 @@ extension HTTPClient {
     ) async throws -> HTTPClientResponse {
         var currentRequest = request
         var currentRedirectState = redirectState
+
+        // this loop is there to follow potential redirects
         while true {
             let preparedRequest = try HTTPClientRequest.Prepared(currentRequest)
             let response = try await executeCancellable(preparedRequest, deadline: deadline, logger: logger)

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -49,7 +49,7 @@ extension HTTPClient {
         redirectState: RedirectState?
     ) async throws -> HTTPClientResponse {
         let preparedRequest = try HTTPClientRequest.Prepared(request)
-        let response = try await execute(request, deadline: deadline, logger: logger)
+        let response = try await executeWithoutFollowingRedirects(preparedRequest, deadline: deadline, logger: logger)
         guard
             preparedRequest.body.canBeConsumedMultipleTimes,
             let redirectState = redirectState,

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -107,7 +107,8 @@ extension HTTPClient {
                     preferredEventLoop: self.eventLoopGroup.next(),
                     responseContinuation: continuation
                 )
-
+                
+                // `HTTPClient.Task` conflicts with Swift Concurrency Task and `Swift.Task` doesn't work
                 _Concurrency.Task {
                     await cancelHandler.registerTransaction(transaction)
                 }
@@ -115,6 +116,7 @@ extension HTTPClient {
                 self.poolManager.executeRequest(transaction)
             }
         }, onCancel: {
+            // `HTTPClient.Task` conflicts with Swift Concurrency Task and `Swift.Task` doesn't work
             _Concurrency.Task {
                 await cancelHandler.cancel()
             }

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -50,7 +50,7 @@ extension HTTPClient {
         redirectState: RedirectState?
     ) async throws -> HTTPClientResponse {
         let preparedRequest = try HTTPClientRequest.Prepared(request)
-        let response = try await executeWithoutFollowingRedirects(preparedRequest, deadline: deadline, logger: logger)
+        let response = try await executeCancellable(preparedRequest, deadline: deadline, logger: logger)
 
         if !preparedRequest.body.canBeConsumedMultipleTimes,
            let redirectState = redirectState,
@@ -90,7 +90,7 @@ extension HTTPClient {
         )
     }
 
-    private func executeWithoutFollowingRedirects(
+    private func executeCancellable(
         _ request: HTTPClientRequest.Prepared,
         deadline: NIODeadline,
         logger: Logger

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -116,7 +116,7 @@ extension HTTPClient {
 
 /// There is currently no good way to asynchronously cancel an object that is initiated inside the `body` closure of `with*Continuation`.
 /// As a workaround we use `TransactionCancelHandler` which will take care of the race between instantiation of `Transaction`
-/// in the `body` closure and cancelation from the `onCancel` closure  of `with*Continuation`.
+/// in the `body` closure and cancelation from the `onCancel` closure  of `withTaskCancellationHandler`.
 @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
 private actor TransactionCancelHandler {
     private enum State {

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2021 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+import struct Foundation.URL
+import Logging
+import NIOCore
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HTTPClient {
+    /// Execute arbitrary HTTP requests.
+    ///
+    /// - Parameters:
+    ///   - request: HTTP request to execute.
+    ///   - deadline: Point in time by which the request must complete.
+    ///   - logger: The logger to use for this request.
+    /// - Returns: The response to the request. Note that the `body` of the response may not yet have been fully received.
+    func execute(
+        _ request: HTTPClientRequest,
+        deadline: NIODeadline,
+        logger: Logger
+    ) async throws -> HTTPClientResponse {
+        try await self.executeAndFollowRedirectsIfNeeded(
+            request,
+            deadline: deadline,
+            logger: logger,
+            redirectState: RedirectState(self.configuration.redirectConfiguration.mode, initialURL: request.url)
+        )
+    }
+}
+
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HTTPClient {
+    private func executeAndFollowRedirectsIfNeeded(
+        _ request: HTTPClientRequest,
+        deadline: NIODeadline,
+        logger: Logger,
+        redirectState: RedirectState?
+    ) async throws -> HTTPClientResponse {
+        let preparedRequest = try HTTPClientRequest.Prepared(request)
+        let response = try await execute(request, deadline: deadline, logger: logger)
+        guard
+            preparedRequest.body.canBeConsumedMultipleTimes,
+            let redirectState = redirectState,
+            let redirectURL = response.headers.extractRedirectTarget(
+                status: response.status,
+                originalURL: preparedRequest.url,
+                originalScheme: preparedRequest.poolKey.scheme
+            )
+        else {
+            return response
+        }
+
+        return try await self.followRedirect(
+            redirectURL: redirectURL,
+            redirectState: redirectState,
+            request: preparedRequest,
+            response: response,
+            deadline: deadline,
+            logger: logger
+        )
+    }
+
+    private func followRedirect(
+        redirectURL: URL,
+        redirectState: RedirectState,
+        request: HTTPClientRequest.Prepared,
+        response: HTTPClientResponse,
+        deadline: NIODeadline,
+        logger: Logger
+    ) async throws -> HTTPClientResponse {
+        var redirectState = redirectState
+        try redirectState.redirect(to: redirectURL.absoluteString)
+        let (method, headers, body) = transformRequestForRedirect(
+            from: request.url,
+            method: request.head.method,
+            headers: request.head.headers,
+            body: request.body,
+            to: redirectURL,
+            status: response.status
+        )
+        var newRequest = HTTPClientRequest(url: redirectURL.absoluteString)
+        newRequest.method = method
+        newRequest.headers = headers
+        newRequest.body = body
+        return try await self.executeAndFollowRedirectsIfNeeded(
+            newRequest,
+            deadline: deadline,
+            logger: logger,
+            redirectState: redirectState
+        )
+    }
+
+    private func executeWithoutFollowingRedirects(
+        _ request: HTTPClientRequest.Prepared,
+        deadline: NIODeadline,
+        logger: Logger
+    ) async throws -> HTTPClientResponse {
+        /// There is currently no good way to asynchronously cancel an object that is initiated inside the `body` closure of `with*Continuation`.
+        /// As a workaround we use `TransactionCancelHandler` which will take care of the race between instantiation of `Transaction`
+        /// in the `body` closure and cancelation from the `onCancel` closure  of `with*Continuation`.
+        actor TransactionCancelHandler {
+            private enum State {
+                case initialised
+                case register(Transaction)
+                case cancelled
+            }
+
+            private var state: State = .initialised
+
+            init() {}
+
+            func registerTransaction(_ transaction: Transaction) {
+                switch self.state {
+                case .initialised:
+                    self.state = .register(transaction)
+                case .cancelled:
+                    transaction.cancel()
+                case .register:
+                    preconditionFailure("transaction already set")
+                }
+            }
+
+            func cancel() {
+                switch self.state {
+                case .register(let bag):
+                    self.state = .cancelled
+                    bag.cancel()
+                case .cancelled:
+                    break
+                case .initialised:
+                    self.state = .cancelled
+                }
+            }
+        }
+
+        let cancelHandler = TransactionCancelHandler()
+
+        return try await withTaskCancellationHandler(operation: { () async throws -> HTTPClientResponse in
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<HTTPClientResponse, Swift.Error>) -> Void in
+                let transaction = Transaction(
+                    request: request,
+                    requestOptions: .init(idleReadTimeout: nil),
+                    logger: logger,
+                    connectionDeadline: deadline,
+                    preferredEventLoop: self.eventLoopGroup.next(),
+                    responseContinuation: continuation
+                )
+
+                _Concurrency.Task {
+                    await cancelHandler.registerTransaction(transaction)
+                }
+
+                self.poolManager.executeRequest(transaction)
+            }
+        }, onCancel: {
+            _Concurrency.Task {
+                await cancelHandler.cancel()
+            }
+        })
+    }
+}
+
+#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -74,4 +74,23 @@ extension RequestBodyLength {
     }
 }
 
+@available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+extension HTTPClientRequest.Prepared {
+    func followingRedirect(to redirectURL: URL, status: HTTPResponseStatus) -> HTTPClientRequest {
+        let (method, headers, body) = transformRequestForRedirect(
+            from: self.url,
+            method: self.head.method,
+            headers: self.head.headers,
+            body: self.body,
+            to: redirectURL,
+            status: status
+        )
+        var newRequest = HTTPClientRequest(url: redirectURL.absoluteString)
+        newRequest.method = method
+        newRequest.headers = headers
+        newRequest.body = body
+        return newRequest
+    }
+}
+
 #endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
@@ -57,7 +57,7 @@ extension HTTPClientRequest.Body {
 
     @inlinable
     static func bytes<Bytes: Sequence>(
-        length: Int? = nil,
+        length: Int?,
         _ bytes: Bytes
     ) -> Self where Bytes.Element == UInt8 {
         self.init(.sequence(length: length, canBeConsumedMultipleTimes: false) { allocator in
@@ -72,7 +72,7 @@ extension HTTPClientRequest.Body {
 
     @inlinable
     static func bytes<Bytes: Collection>(
-        length: Int? = nil,
+        length: Int?,
         _ bytes: Bytes
     ) -> Self where Bytes.Element == UInt8 {
         self.init(.sequence(length: length, canBeConsumedMultipleTimes: true) { allocator in
@@ -101,7 +101,7 @@ extension HTTPClientRequest.Body {
 
     @inlinable
     static func stream<SequenceOfBytes: AsyncSequence>(
-        length: Int? = nil,
+        length: Int?,
         _ sequenceOfBytes: SequenceOfBytes
     ) -> Self where SequenceOfBytes.Element == ByteBuffer {
         var iterator = sequenceOfBytes.makeAsyncIterator()
@@ -113,11 +113,11 @@ extension HTTPClientRequest.Body {
 
     @inlinable
     static func stream<Bytes: AsyncSequence>(
-        length: Int? = nil,
+        length: Int?,
         _ bytes: Bytes
     ) -> Self where Bytes.Element == UInt8 {
         var iterator = bytes.makeAsyncIterator()
-        let body = self.init(.asyncSequence(length: nil) { allocator -> ByteBuffer? in
+        let body = self.init(.asyncSequence(length: length) { allocator -> ByteBuffer? in
             var buffer = allocator.buffer(capacity: 1024) // TODO: Magic number
             while buffer.writableBytes > 0, let byte = try await iterator.next() {
                 buffer.writeInteger(byte)

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -203,7 +203,7 @@ extension Transaction: HTTPExecutableRequest {
             case .none:
                 break
 
-            case .sequence(_, let create):
+            case .sequence(_, _, let create):
                 let byteBuffer = create(allocator)
                 self.writeOnceAndOneTimeOnly(byteBuffer: byteBuffer)
             }

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -411,7 +411,7 @@ class HTTPClientRequestTests: XCTestCase {
                 .asAsyncSequence()
                 .map { ByteBuffer($0) }
 
-            request.body = .stream(asyncSequence)
+            request.body = .stream(length: nil, asyncSequence)
             var preparedRequest: PreparedRequest?
             XCTAssertNoThrow(preparedRequest = try PreparedRequest(request))
             guard let preparedRequest = preparedRequest else { return }

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -498,7 +498,7 @@ extension Optional where Wrapped == HTTPClientRequest.Body {
             return ByteBuffer()
         case .byteBuffer(let buffer):
             return buffer
-        case .sequence(let announcedLength, let generate):
+        case .sequence(let announcedLength, _, let generate):
             let buffer = generate(ByteBufferAllocator())
             if let announcedLength = announcedLength,
                announcedLength != buffer.readableBytes {

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -189,7 +189,7 @@ final class TransactionTests: XCTestCase {
 
             var request = HTTPClientRequest(url: "https://localhost/")
             request.method = .POST
-            request.body = .stream(streamWriter)
+            request.body = .stream(length: nil, streamWriter)
 
             var maybePreparedRequest: PreparedRequest?
             XCTAssertNoThrow(maybePreparedRequest = try PreparedRequest(request))
@@ -318,7 +318,7 @@ final class TransactionTests: XCTestCase {
 
             var request = HTTPClientRequest(url: "https://localhost/")
             request.method = .POST
-            request.body = .bytes("Hello world!".utf8)
+            request.body = .bytes(length: nil, "Hello world!".utf8)
             var maybePreparedRequest: PreparedRequest?
             XCTAssertNoThrow(maybePreparedRequest = try PreparedRequest(request))
             guard let preparedRequest = maybePreparedRequest else {


### PR DESCRIPTION
This is the last missing piece to actually execute a `HTTPClientRequest` and await a `HTTPClientResponse`.
It brings everything together but first preparing the `HTTPClientRequest` and then executing the `Transaction` using the `HTTPConnectionPool.Manager`. We optional follow redirects if the configurations allows it and the `HTTPClientRequest.Body` can be consumed multiple times.