### PR TITLE
Add missing @available anotations

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -549,6 +549,7 @@ extension Collection {
     }
 }
 
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 struct AsyncSequenceFromSyncSequence<Wrapped: Sequence>: AsyncSequence {
     typealias Element = Wrapped.Element
     struct AsyncIterator: AsyncIteratorProtocol {
@@ -565,6 +566,7 @@ struct AsyncSequenceFromSyncSequence<Wrapped: Sequence>: AsyncSequence {
     }
 }
 
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 extension Sequence {
     /// Turns `self` into an `AsyncSequence` by wending each element of `self` asynchronously.
     func asAsyncSequence() -> AsyncSequenceFromSyncSequence<Self> {

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -76,6 +76,7 @@ internal func XCTAssertThrowsError<T>(
     }
 }
 
+@available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
     file: StaticString = #file,


### PR DESCRIPTION
Otherwise it fails to compile with Xcode 13.1.
Xcode 13.2 seems fine without but this is probably a regression in the swift compiler because the @available anotations are actally needed.