### PR TITLE
Respect deadline on new HTTPClient.execute for async/await 

### DIFF
--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -37,7 +37,7 @@ extension AsyncAwaitEndToEndTests {
             ("testPostWithFragmentedAsyncSequenceOfLargeByteBuffers", testPostWithFragmentedAsyncSequenceOfLargeByteBuffers),
             ("testCanceling", testCanceling),
             ("testDeadline", testDeadline),
-            ("testConnectTimeout", testConnectTimeout),
+            ("testImmediateDeadline", testImmediateDeadline),
             ("testInvalidURL", testInvalidURL),
         ]
     }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -37,6 +37,7 @@ extension AsyncAwaitEndToEndTests {
             ("testPostWithFragmentedAsyncSequenceOfLargeByteBuffers", testPostWithFragmentedAsyncSequenceOfLargeByteBuffers),
             ("testCanceling", testCanceling),
             ("testDeadline", testDeadline),
+            ("testConnectTimeout", testConnectTimeout),
             ("testInvalidURL", testInvalidURL),
         ]
     }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -346,7 +346,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testDeadline() throws {
-        try XCTSkipIf(true, "deadline is currently not correctly implemented. We only use it to timeout connection establishment. will be fixed in a follow up PR")
         #if compiler(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
@@ -358,11 +357,35 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             let request = HTTPClientRequest(url: "https://localhost:\(bin.port)/wait")
 
             let task = Task<HTTPClientResponse, Error> { [request] in
-                try await client.execute(request, deadline: .now() + .seconds(1), logger: logger)
+                try await client.execute(request, deadline: .now() + .milliseconds(100), logger: logger)
             }
             await XCTAssertThrowsError(try await task.value) {
-                XCTAssertEqual($0 as? HTTPClientError, HTTPClientError.readTimeout)
+                XCTAssertEqual($0 as? HTTPClientError, HTTPClientError.deadlineExceeded)
             }
+        }
+        #endif
+    }
+
+    func testImmediateDeadline() throws {
+        // does not work on nether Linux nor Darwin
+        try XCTSkipIf(true, "test times out because of a swift concurrency bug: https://bugs.swift.org/browse/SR-15592")
+        #if compiler(>=5.5) && canImport(_Concurrency)
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        XCTAsyncTest(timeout: 5) {
+            let bin = HTTPBin(.http2(compress: false))
+            defer { XCTAssertNoThrow(try bin.shutdown()) }
+            let client = makeDefaultHTTPClient()
+            defer { XCTAssertNoThrow(try client.syncShutdown()) }
+            let logger = Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
+            let request = HTTPClientRequest(url: "https://localhost:\(bin.port)/wait")
+
+            let task = Task<HTTPClientResponse, Error> { [request] in
+                try await client.execute(request, deadline: .now(), logger: logger)
+            }
+            await XCTAssertThrowsError(try await task.value) {
+                XCTAssertEqual($0 as? HTTPClientError, HTTPClientError.deadlineExceeded)
+            }
+            print("done")
         }
         #endif
     }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -318,18 +318,16 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         #endif
     }
 
-    func testCanceling() throws {
-        #if os(Linux)
-        #else
-        try XCTSkipIf(true, "test times out because of a swift concurrency bug on macOS: https://bugs.swift.org/browse/SR-15592")
-        #endif
+    func testCanceling() {
         #if compiler(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
+            let bin = HTTPBin()
+            defer { XCTAssertNoThrow(try bin.shutdown()) }
             let client = makeDefaultHTTPClient()
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
             let logger = Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
-            var request = HTTPClientRequest(url: "https://localhost:45678/offline")
+            var request = HTTPClientRequest(url: "http://localhost:\(bin.port)/offline")
             request.method = .POST
             let streamWriter = AsyncSequenceWriter<ByteBuffer>()
             request.body = .stream(length: nil, streamWriter)
@@ -345,7 +343,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         #endif
     }
 
-    func testDeadline() throws {
+    func testDeadline() {
         #if compiler(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
@@ -366,18 +364,16 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         #endif
     }
 
-    func testImmediateDeadline() throws {
-        // does not work on nether Linux nor Darwin
-        try XCTSkipIf(true, "test times out because of a swift concurrency bug: https://bugs.swift.org/browse/SR-15592")
+    func testImmediateDeadline() {
         #if compiler(>=5.5) && canImport(_Concurrency)
         guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
-            let bin = HTTPBin(.http2(compress: false))
+            let bin = HTTPBin()
             defer { XCTAssertNoThrow(try bin.shutdown()) }
             let client = makeDefaultHTTPClient()
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
             let logger = Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
-            let request = HTTPClientRequest(url: "https://localhost:\(bin.port)/wait")
+            let request = HTTPClientRequest(url: "http://localhost:\(bin.port)/wait")
 
             let task = Task<HTTPClientResponse, Error> { [request] in
                 try await client.execute(request, deadline: .now(), logger: logger)
@@ -409,7 +405,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
 
 #if compiler(>=5.5) && canImport(_Concurrency)
 extension AsyncSequence where Element == ByteBuffer {
-    func collect() async throws -> ByteBuffer {
+    func collect() async rethrows -> ByteBuffer {
         try await self.reduce(into: ByteBuffer()) { accumulatingBuffer, nextBuffer in
             var nextBuffer = nextBuffer
             accumulatingBuffer.writeBuffer(&nextBuffer)

--- a/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests+XCTest.swift
@@ -27,6 +27,9 @@ extension Transaction_StateMachineTests {
         return [
             ("testRequestWasQueuedAfterWillExecuteRequestWasCalled", testRequestWasQueuedAfterWillExecuteRequestWasCalled),
             ("testRequestBodyStreamWasPaused", testRequestBodyStreamWasPaused),
+            ("testQueuedRequestGetsRemovedWhenDeadlineExceeded", testQueuedRequestGetsRemovedWhenDeadlineExceeded),
+            ("testScheduledRequestGetsRemovedWhenDeadlineExceeded", testScheduledRequestGetsRemovedWhenDeadlineExceeded),
+            ("testRequestWithHeadReceivedGetNotCancelledWhenDeadlineExceeded", testRequestWithHeadReceivedGetNotCancelledWhenDeadlineExceeded),
         ]
     }
 }


### PR DESCRIPTION
We forgot to schedule a timeout timer for the user defined deadline and just use it as a connection timeout.