### PR TITLE
Update to 1.11.4 which fixes retain cycle bug

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.1"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.10.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
     ],
     targets: [


### PR DESCRIPTION
 * Update the minimum version to the one that fixes retain/release bug https://github.com/apple/swift-nio-transport-services/pull/138