### PR TITLE
Print invalid state, if hitting precondition

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ConnectionStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ConnectionStateMachine.swift
@@ -159,7 +159,7 @@ struct HTTP1ConnectionStateMachine {
         metadata: RequestFramingMetadata
     ) -> Action {
         guard case .idle = self.state else {
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
 
         var requestStateMachine = HTTPRequestStateMachine(isChannelWritable: self.isChannelWritable)
@@ -173,7 +173,7 @@ struct HTTP1ConnectionStateMachine {
 
     mutating func requestStreamPartReceived(_ part: IOData) -> Action {
         guard case .inRequest(var requestStateMachine, let close) = self.state else {
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
 
         return self.avoidingStateMachineCoW { state -> Action in
@@ -185,7 +185,7 @@ struct HTTP1ConnectionStateMachine {
 
     mutating func requestStreamFinished() -> Action {
         guard case .inRequest(var requestStateMachine, let close) = self.state else {
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
 
         return self.avoidingStateMachineCoW { state -> Action in
@@ -198,7 +198,7 @@ struct HTTP1ConnectionStateMachine {
     mutating func requestCancelled(closeConnection: Bool) -> Action {
         switch self.state {
         case .initialized:
-            preconditionFailure("This event must only happen, if the connection is leased. During startup this is impossible")
+            preconditionFailure("This event must only happen, if the connection is leased. During startup this is impossible. Invalid state: \(self.state)")
 
         case .idle:
             if closeConnection {
@@ -250,7 +250,7 @@ struct HTTP1ConnectionStateMachine {
     mutating func channelRead(_ part: HTTPClientResponsePart) -> Action {
         switch self.state {
         case .initialized, .idle:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
 
         case .inRequest(var requestStateMachine, var close):
             return self.avoidingStateMachineCoW { state -> Action in
@@ -369,7 +369,7 @@ extension HTTP1ConnectionStateMachine.State {
             return .forwardResponseBodyParts(parts)
         case .succeedRequest(let finalAction, let finalParts):
             guard case .inRequest(_, close: let close) = self else {
-                preconditionFailure("Invalid state")
+                preconditionFailure("Invalid state: \(self)")
             }
 
             let newFinalAction: HTTP1ConnectionStateMachine.Action.FinalStreamAction
@@ -388,7 +388,7 @@ extension HTTP1ConnectionStateMachine.State {
         case .failRequest(let error, let finalAction):
             switch self {
             case .initialized:
-                preconditionFailure("Invalid state")
+                preconditionFailure("Invalid state: \(self)")
             case .idle:
                 preconditionFailure("How can we fail a task, if we are idle")
             case .inRequest(_, close: let close):
@@ -433,7 +433,7 @@ extension HTTP1ConnectionStateMachine: CustomStringConvertible {
         case .closed:
             return ".closed"
         case .modifying:
-            preconditionFailure(".modifying")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 }

--- a/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
@@ -127,10 +127,10 @@ extension RequestBag.StateMachine {
             return .none
 
         case .finished:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
 
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -158,7 +158,7 @@ extension RequestBag.StateMachine {
             // the request is already finished nothing further to do
             break
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -205,7 +205,7 @@ extension RequestBag.StateMachine {
         case .finished(error: .none):
             return .failFuture(HTTPClientError.requestStreamCancelled)
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -251,7 +251,7 @@ extension RequestBag.StateMachine {
         case .finished(error: _):
             return .none
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -285,7 +285,7 @@ extension RequestBag.StateMachine {
         case .finished(error: .none):
             preconditionFailure("How can the request be finished without error, before receiving response head?")
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -322,7 +322,7 @@ extension RequestBag.StateMachine {
         case .finished(error: .none):
             preconditionFailure("How can the request be finished without error, before receiving response head?")
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -374,7 +374,7 @@ extension RequestBag.StateMachine {
         case .finished(error: .none):
             preconditionFailure("How can the request be finished without error, before receiving response head?")
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 
@@ -398,7 +398,7 @@ extension RequestBag.StateMachine {
     private mutating func failWithConsumptionError(_ error: Error) -> ConsumeAction {
         switch self.state {
         case .initialized, .queued:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         case .executing(_, _, .initialized):
             preconditionFailure("Invalid state: Must have received response head, before this method is called for the first time")
 
@@ -521,7 +521,7 @@ extension RequestBag.StateMachine {
             // this might happen, if the stream consumer has failed... let's just drop the data
             return .none
         case .modifying:
-            preconditionFailure("Invalid state")
+            preconditionFailure("Invalid state: \(self.state)")
         }
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -352,7 +352,7 @@ extension TestConnectionCreator: HTTPConnectionRequester {
                 return .fail(promise, Error.wantedHTTP2ConnectionButGotHTTP1)
 
             case .idle:
-                preconditionFailure("Invalid state")
+                preconditionFailure("Invalid state: \(self.state)")
             }
         }
         wrapper.complete()
@@ -369,7 +369,7 @@ extension TestConnectionCreator: HTTPConnectionRequester {
                 return .succeed(promise, connection)
 
             case .idle:
-                preconditionFailure("Invalid state")
+                preconditionFailure("Invalid state: \(self.state)")
             }
         }
         wrapper.complete()
@@ -400,7 +400,7 @@ extension TestConnectionCreator: HTTPConnectionRequester {
                 return .type2(promise)
 
             case .idle:
-                preconditionFailure("Invalid state")
+                preconditionFailure("Invalid state: \(self.state)")
             }
         }
         wrapper.fail(error)


### PR DESCRIPTION
If we hit a `precondition` because of an invalid state, we should print the state to make debugging easier.