### PR TITLE
Fix race between connection close and scheduling new request

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests+XCTest.swift
@@ -42,6 +42,7 @@ extension HTTP1ConnectionStateMachineTests {
             ("testConnectionIsClosedIfErrorHappensWhileInRequest", testConnectionIsClosedIfErrorHappensWhileInRequest),
             ("testConnectionIsClosedAfterSwitchingProtocols", testConnectionIsClosedAfterSwitchingProtocols),
             ("testWeDontCrashAfterEarlyHintsAndConnectionClose", testWeDontCrashAfterEarlyHintsAndConnectionClose),
+            ("testWeDontCrashInRaceBetweenSchedulingNewRequestAndConnectionClose", testWeDontCrashInRaceBetweenSchedulingNewRequestAndConnectionClose),
         ]
     }
 }


### PR DESCRIPTION
### Motivation

We may have a race condition between scheduling a request on an http/1.1 connection and the connection being closed.

### Changes

- Fail request that is scheduled on a closed connection

### Result

We don't crash anymore.
