### PR TITLE
Fix compilation of tests for Swift 5.5.0/5.5.1

### DIFF
--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -410,8 +410,8 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testRedirectChangesHostHeader() {
-        #if compiler(>=5.5) && canImport(_Concurrency)
-        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }


### PR DESCRIPTION
`#if compiler` and `#available` probably didn't get correctly updated after some merge conflict.
Couldn't find any other reference for `compiler(>=5.5)` in the code base.