### PR TITLE
Add `async` shutdown method to `HTTPClient`

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+shutdown.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+shutdown.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2022 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+extension HTTPClient {
+    /// Shuts down the client and `EventLoopGroup` if it was created by the client.
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+    func shutdown() async throws {
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            self.shutdown { error in
+                switch error {
+                case .none:
+                    continuation.resume()
+                case .some(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -40,6 +40,7 @@ extension AsyncAwaitEndToEndTests {
             ("testImmediateDeadline", testImmediateDeadline),
             ("testInvalidURL", testInvalidURL),
             ("testRedirectChangesHostHeader", testRedirectChangesHostHeader),
+            ("testShutdown", testShutdown),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -437,6 +437,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         }
         #endif
     }
+
     func testShutdown() {
         #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -437,6 +437,18 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         }
         #endif
     }
+    func testShutdown() {
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        XCTAsyncTest {
+            let client = makeDefaultHTTPClient()
+            try await client.shutdown()
+            await XCTAssertThrowsError(try await client.shutdown()) { error in
+                XCTAssertEqualTypeAndValue(error, HTTPClientError.alreadyShutdown)
+            }
+        }
+        #endif
+    }
 }
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -3,7 +3,7 @@
 ##
 ## This source file is part of the AsyncHTTPClient open source project
 ##
-## Copyright (c) 2018-2019 Apple Inc. and the AsyncHTTPClient project authors
+## Copyright (c) 2018-2022 Apple Inc. and the AsyncHTTPClient project authors
 ## Licensed under Apache License v2.0
 ##
 ## See LICENSE.txt for license information
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][0-9]-20[12][0-9]/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/'
+    sed -e 's/20[12][0-9]-20[12][0-9]/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/' -e 's/2022/YEARS/'
 }
 
 printf "=> Checking linux tests... "


### PR DESCRIPTION
Allows to shutdown a `HTTPClient` in an async context without blocking or using the callback version of shutdown.