### PR TITLE
Add async/await examples

### DIFF
--- a/Examples/GetHTML/GetHTML.swift
+++ b/Examples/GetHTML/GetHTML.swift
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2022 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// TODO: remove @testable after async/await API is public
+@testable import AsyncHTTPClient
+import NIOCore
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+@main
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+struct GetHTML {
+    static func main() async throws {
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        do {
+            let request = HTTPClientRequest(url: "https://apple.com")
+            let response = try await httpClient.execute(request, timeout: .seconds(30))
+            print("HTTP head", response)
+            let body = try await response.body.collect(upTo: 1024 * 1024) // 1 MB
+            print(String(buffer: body))
+        } catch {
+            print("request failed:", error)
+        }
+        // it is important to shutdown the httpClient after all requests are done, even if one failed
+        try await httpClient.shutdown()
+    }
+}
+
+#endif

--- a/Examples/GetHTML/GetHTML.swift
+++ b/Examples/GetHTML/GetHTML.swift
@@ -12,14 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: remove @testable after async/await API is public
-@testable import AsyncHTTPClient
+import AsyncHTTPClient
 import NIOCore
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @main
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct GetHTML {
     static func main() async throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
@@ -36,5 +32,3 @@ struct GetHTML {
         try await httpClient.shutdown()
     }
 }
-
-#endif

--- a/Examples/GetJSON/GetJSON.swift
+++ b/Examples/GetJSON/GetJSON.swift
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2022 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// TODO: remove @testable after async/await API is public
+@testable import AsyncHTTPClient
+import NIOCore
+import Foundation
+import NIOFoundationCompat
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+struct Comic: Codable {
+    var num: Int
+    var title: String
+    var day: String
+    var month: String
+    var year: String
+    var img: String
+    var alt: String
+    var news: String
+    var link: String
+    var transcript: String
+}
+
+@main
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+struct GetJSON {
+    static func main() async throws {
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        do {
+            let request = HTTPClientRequest(url: "https://xkcd.com/info.0.json")
+            let response = try await httpClient.execute(request, timeout: .seconds(30))
+            print("HTTP head", response)
+            let body = try await response.body.collect(upTo: 1024 * 1024) // 1 MB
+            let comic = try JSONDecoder().decode(Comic.self, from: body)
+            dump(comic)
+        } catch {
+            print("request failed:", error)
+        }
+        // it is important to shutdown the httpClient after all requests are done, even if one failed
+        try await httpClient.shutdown()
+    }
+}
+
+#endif

--- a/Examples/GetJSON/GetJSON.swift
+++ b/Examples/GetJSON/GetJSON.swift
@@ -14,8 +14,8 @@
 
 // TODO: remove @testable after async/await API is public
 @testable import AsyncHTTPClient
-import NIOCore
 import Foundation
+import NIOCore
 import NIOFoundationCompat
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Examples/GetJSON/GetJSON.swift
+++ b/Examples/GetJSON/GetJSON.swift
@@ -12,13 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: remove @testable after async/await API is public
-@testable import AsyncHTTPClient
+import AsyncHTTPClient
 import Foundation
 import NIOCore
 import NIOFoundationCompat
-
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 struct Comic: Codable {
     var num: Int
@@ -34,7 +31,6 @@ struct Comic: Codable {
 }
 
 @main
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct GetJSON {
     static func main() async throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
@@ -43,6 +39,8 @@ struct GetJSON {
             let response = try await httpClient.execute(request, timeout: .seconds(30))
             print("HTTP head", response)
             let body = try await response.body.collect(upTo: 1024 * 1024) // 1 MB
+            // we use an overload defined in `NIOFoundationCompat` for `decode(_:from:)` to
+            // efficiently decode from a `ByteBuffer`
             let comic = try JSONDecoder().decode(Comic.self, from: body)
             dump(comic)
         } catch {
@@ -52,5 +50,3 @@ struct GetJSON {
         try await httpClient.shutdown()
     }
 }
-
-#endif

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -1,0 +1,57 @@
+// swift-tools-version:5.5
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2018-2022 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import PackageDescription
+
+let package = Package(
+    name: "async-http-client-examples",
+    products: [
+        .executable(name: "GetHTML", targets: ["GetHTML"]),
+        .executable(name: "GetJSON", targets: ["GetJSON"]),
+        .executable(name: "StreamingByteCounter", targets: ["StreamingByteCounter"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", .branch("main")),
+        
+        // in real-world projects this would be
+        // .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0")
+        .package(name: "async-http-client", path: "../"),
+    ],
+    targets: [
+        // MARK: - Examples
+        .executableTarget(
+            name: "GetHTML",
+            dependencies: [
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "NIOCore", package: "swift-nio"),
+            ], path: "GetHTML"
+        ),
+        .executableTarget(
+            name: "GetJSON",
+            dependencies: [
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+            ], path: "GetJSON"
+        ),
+        .executableTarget(
+            name: "StreamingByteCounter",
+            dependencies: [
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "NIOCore", package: "swift-nio"),
+            ], path: "StreamingByteCounter"
+        ),
+    ]
+)

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -24,13 +24,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", .branch("main")),
-        
+
         // in real-world projects this would be
         // .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0")
         .package(name: "async-http-client", path: "../"),
     ],
     targets: [
         // MARK: - Examples
+
         .executableTarget(
             name: "GetHTML",
             dependencies: [

--- a/Examples/Package.swift
+++ b/Examples/Package.swift
@@ -17,6 +17,12 @@ import PackageDescription
 
 let package = Package(
     name: "async-http-client-examples",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .tvOS(.v13),
+        .watchOS(.v6),
+    ],
     products: [
         .executable(name: "GetHTML", targets: ["GetHTML"]),
         .executable(name: "GetJSON", targets: ["GetJSON"]),

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -9,3 +9,19 @@ swift run GetHTML
 ```
 To run other examples you can just replace `GetHTML` with the name of the example you want to run.
 
+## [GetHTML](./GetHTML/GetHTML.swift)
+
+This examples sends a HTTP GET request to `https://apple.com/` and first `await`s and `print`s the HTTP Response Head. 
+Afterwards it buffers the full response body in memory and prints the response as a `String`.    
+
+## [GetJSON](./GetJSON/GetJSON.swift)
+
+This examples sends a HTTP GET request to `https://xkcd.com/info.0.json` and first `await`s and `print`s the HTTP Response Head. 
+Afterwards it buffers the full response body in memory, decodes the buffer using a `JSONDecoder` and `dump`s the decoded response. 
+
+## [StreamingByteCounter](./StreamingByteCounter/StreamingByteCounter.swift)
+
+This examples sends a HTTP GET request to `https://apple.com/` and first `await`s and `print`s the HTTP Response Head. 
+Afterwards it asynchronously iterates over all body fragments, counts the received bytes and prints a progress indicator (if the server send a content-length header).
+At the end the total received bytes are printed.
+Note that we drop all received fragment and therefore do **not** buffer the whole response body in-memory.

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,0 +1,11 @@
+# Examples
+This folder includes a couple of Examples for `AsyncHTTPClient`. 
+You can run them by opening the `Package.swift` in this folder through Xcode.
+In Xcode you can then select the scheme for the example you want run e.g. `GetHTML`.
+
+You can also run the examples from the command line by executing the follow command in this folder:
+```
+swift run GetHTML
+```
+To run other examples you can just replace `GetHTML` with the name of the example you want to run.
+

--- a/Examples/StreamingByteCounter/StreamingByteCounter.swift
+++ b/Examples/StreamingByteCounter/StreamingByteCounter.swift
@@ -27,20 +27,20 @@ struct StreamingByteCounter {
             let request = HTTPClientRequest(url: "https://apple.com")
             let response = try await httpClient.execute(request, timeout: .seconds(30))
             print("HTTP head", response)
-            
+
             // if defined, the content-length headers announces the size of the body
             let expectedBytes = response.headers.first(name: "content-length").flatMap(Int.init)
-            
+
             var receivedBytes = 0
             // asynchronously iterates over all body fragments
             // this loop will automatically propagate backpressure correctly
             for try await buffer in response.body {
                 // For this example, we are just interested in the size of the fragment
                 receivedBytes += buffer.readableBytes
-                
+
                 if let expectedBytes = expectedBytes {
                     // if the body size is known, we calculate a progress indicator
-                    let progress = Double(receivedBytes)/Double(expectedBytes)
+                    let progress = Double(receivedBytes) / Double(expectedBytes)
                     print("progress: \(Int(progress * 100))%")
                 }
                 // in case backpressure is needed, all reads will be paused until returned future is resolved

--- a/Examples/StreamingByteCounter/StreamingByteCounter.swift
+++ b/Examples/StreamingByteCounter/StreamingByteCounter.swift
@@ -12,14 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO: remove @testable after async/await API is public
-@testable import AsyncHTTPClient
+import AsyncHTTPClient
 import NIOCore
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 @main
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 struct StreamingByteCounter {
     static func main() async throws {
         let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
@@ -53,5 +49,3 @@ struct StreamingByteCounter {
         try await httpClient.shutdown()
     }
 }
-
-#endif

--- a/Examples/StreamingByteCounter/StreamingByteCounter.swift
+++ b/Examples/StreamingByteCounter/StreamingByteCounter.swift
@@ -39,7 +39,6 @@ struct StreamingByteCounter {
                     let progress = Double(receivedBytes) / Double(expectedBytes)
                     print("progress: \(Int(progress * 100))%")
                 }
-                // in case backpressure is needed, all reads will be paused until returned future is resolved
             }
             print("did receive \(receivedBytes) bytes")
         } catch {

--- a/Examples/StreamingByteCounter/StreamingByteCounter.swift
+++ b/Examples/StreamingByteCounter/StreamingByteCounter.swift
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2022 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// TODO: remove @testable after async/await API is public
+@testable import AsyncHTTPClient
+import NIOCore
+
+#if compiler(>=5.5.2) && canImport(_Concurrency)
+
+@main
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+struct StreamingByteCounter {
+    static func main() async throws {
+        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        do {
+            let request = HTTPClientRequest(url: "https://apple.com")
+            let response = try await httpClient.execute(request, timeout: .seconds(30))
+            print("HTTP head", response)
+            
+            // if defined, the content-length headers announces the size of the body
+            let expectedBytes = response.headers.first(name: "content-length").flatMap(Int.init)
+            
+            var receivedBytes = 0
+            // asynchronously iterates over all body fragments
+            // this loop will automatically propagate backpressure correctly
+            for try await buffer in response.body {
+                // For this example, we are just interested in the size of the fragment
+                receivedBytes += buffer.readableBytes
+                
+                if let expectedBytes = expectedBytes {
+                    // if the body size is known, we calculate a progress indicator
+                    let progress = Double(receivedBytes)/Double(expectedBytes)
+                    print("progress: \(Int(progress * 100))%")
+                }
+                // in case backpressure is needed, all reads will be paused until returned future is resolved
+            }
+            print("did receive \(receivedBytes) bytes")
+        } catch {
+            print("request failed:", error)
+        }
+        // it is important to shutdown the httpClient after all requests are done, even if one failed
+        try await httpClient.shutdown()
+    }
+}
+
+#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
@@ -47,6 +47,13 @@ public struct HTTPClientResponse {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+extension HTTPClientResponse: CustomStringConvertible {
+    public var description: String {
+        return "HTTPClientResponse(version: \(self.version), status: \(self.status), headers: \(self.headers))"
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientResponse.Body: AsyncSequence {
     public typealias Element = AsyncIterator.Element
 

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
@@ -47,13 +47,6 @@ public struct HTTPClientResponse {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension HTTPClientResponse: CustomStringConvertible {
-    public var description: String {
-        return "HTTPClientResponse(version: \(self.version), status: \(self.status), headers: \(self.headers))"
-    }
-}
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientResponse.Body: AsyncSequence {
     public typealias Element = AsyncIterator.Element
 


### PR DESCRIPTION
This PR adds examples which make use of the new async/await APIs. Sadly, async/await is not supported in top level code [(but there is a pitch)](https://forums.swift.org/t/concurrency-in-top-level-code/55001). Just spinning up a task is not enough, we also need to wait for its completion. The new `@main` attribute already supports async/await and automatically waits for completion but we need to mark the target as an `executableTarget`. `executableTargets` were introduced in Swift 5.4 and we therefore need swift-tools-version 5.4. As we still support Swift 5.2 and Swift 5.3 we sadly need to create separate Package.swift files. 

Alternatively, we could also use a semaphore to wait until completion. But as this is an example, we should be a role model.

Note: this PR requires the newest unreleased version of `swift-nio`. We can only merge it after a new release of `swift-nio`.