### PR TITLE
Update README.md for async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ do {
         
         if let expectedBytes = expectedBytes {
             // if the body size is known, we calculate a progress indicator
-            let progress = Double(receivedBytes)/Double(expectedBytes)
+            let progress = Double(receivedBytes) / Double(expectedBytes)
             print("progress: \(Int(progress * 100))%")
         }
     }


### PR DESCRIPTION
We want to highlight the new async/await API in the README. 
- add new examples for async/await but keeps old examples for SwiftNIOs `EventLoopFuture`s
- change URL used in examples from swift.org to apple.com because swift.org doesn't respect that we don't support compression by default which results in gibberish output if examples are run by users.
- increase recommended Xcode Version to 13.2 and Swift Version to 5.5.2
- increase recommend AsyncHTTPClient version to `1.9.0`