### PR TITLE
Crash fix: HTTP2 can handle requests are cancelled

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2ClientRequestHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2ClientRequestHandler.swift
@@ -198,7 +198,7 @@ final class HTTP2ClientRequestHandler: ChannelDuplexHandler {
             self.request = nil
             self.runTimeoutAction(.clearIdleReadTimeoutTimer, context: context)
             // No matter the error reason, we must always make sure the h2 stream is closed. Only
-            // once the h2 stream is closed, it is released form the h2 multiplexer. The
+            // once the h2 stream is closed, it is released from the h2 multiplexer. The
             // HTTPRequestStateMachine may signal finalAction: .none in the error case (as this is
             // the right result for HTTP/1). In the h2 case we MUST always close.
             self.runFinalAction(.close, context: context)

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
@@ -108,16 +108,24 @@ struct HTTPRequestStateMachine {
     }
 
     mutating func startRequest(head: HTTPRequestHead, metadata: RequestFramingMetadata) -> Action {
-        guard case .initialized = self.state else {
-            preconditionFailure("`start()` must be called first, and exactly once. Invalid state: \(self.state)")
-        }
+        switch self.state {
+        case .initialized:
+            guard self.isChannelWritable else {
+                self.state = .waitForChannelToBecomeWritable(head, metadata)
+                return .wait
+            }
+            return self.startSendingRequest(head: head, metadata: metadata)
 
-        guard self.isChannelWritable else {
-            self.state = .waitForChannelToBecomeWritable(head, metadata)
+        case .failed:
+            // The request state machine is marked as failed before the request is started, if
+            // the request was cancelled before hitting the channel handler. Before `startRequest`
+            // is called on the state machine, `willExecuteRequest` is called on
+            // `HTTPExecutableRequest`, which might loopback to state machines cancel method.
             return .wait
-        }
 
-        return self.startSendingRequest(head: head, metadata: metadata)
+        case .running, .finished, .waitForChannelToBecomeWritable, .modifying:
+            preconditionFailure("`startRequest()` must be called first, and exactly once. Invalid state: \(self.state)")
+        }
     }
 
     mutating func writabilityChanged(writable: Bool) -> Action {
@@ -381,6 +389,10 @@ struct HTTPRequestStateMachine {
         case .initialized, .waitForChannelToBecomeWritable:
             let error = HTTPClientError.cancelled
             self.state = .failed(error)
+            // Okay, this has different semantics for HTTP/1 and HTTP/2. In HTTP/1 we don't want to
+            // close the connection, if we haven't send anything yet, to reuse the connection for
+            // another request. In HTTP/2 we must close the channel to ensure it is released from
+            // HTTP/2 multiplexer.
             return .failRequest(error, .none)
 
         case .running:

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPRequestStateMachine.swift
@@ -390,7 +390,7 @@ struct HTTPRequestStateMachine {
             let error = HTTPClientError.cancelled
             self.state = .failed(error)
             // Okay, this has different semantics for HTTP/1 and HTTP/2. In HTTP/1 we don't want to
-            // close the connection, if we haven't send anything yet, to reuse the connection for
+            // close the connection, if we haven't sent anything yet, to reuse the connection for
             // another request. In HTTP/2 we must close the channel to ensure it is released from
             // HTTP/2 multiplexer.
             return .failRequest(error, .none)

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientTests+XCTest.swift
@@ -34,6 +34,7 @@ extension HTTP2ClientTests {
             ("testUncleanShutdownCancelsExecutingAndQueuedTasks", testUncleanShutdownCancelsExecutingAndQueuedTasks),
             ("testCancelingRunningRequest", testCancelingRunningRequest),
             ("testReadTimeout", testReadTimeout),
+            ("testH2CanHandleRequestsThatHaveAlreadyHitTheDeadline", testH2CanHandleRequestsThatHaveAlreadyHitTheDeadline),
             ("testStressCancelingRunningRequestFromDifferentThreads", testStressCancelingRunningRequestFromDifferentThreads),
             ("testPlatformConnectErrorIsForwardedOnTimeout", testPlatformConnectErrorIsForwardedOnTimeout),
         ]


### PR DESCRIPTION
### Motivation

If a already cancelled request is scheduled on an existing HTTP/2 connection we currently run into a crash. This only happens if the request is scheduled on the same EventLoop as the HTTP/2 connection. 

### Changes

- Make the `HTTPRequestStateMachine` resilient to failures before request start.

### Result

- A crash less.