### PR TITLE
SSLProtocol tls* deprecations

### DIFF
--- a/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
@@ -39,6 +39,10 @@ extension TLSVersion {
 
 extension TLSVersion {
     /// return as SSL protocol
+    @available(macOS, deprecated: 10.15, message: "legacy functionality")
+    @available(iOS, deprecated: 13.0, message: "legacy functionality")
+    @available(tvOS, deprecated: 13.0, message: "legacy functionality")
+    @available(watchOS, deprecated: 6.0, message: "legacy functionality")
     var sslProtocol: SSLProtocol {
         switch self {
         case .tlsv1:


### PR DESCRIPTION
Motivation:

SSLProtocol's tlsProtocol* members are deprecated but we need them in compatibility code (breaks SemVer otherwise).

Modification:

Annotate the legacy function as such.

Result:

Fewer warnings.