### PR TITLE
Call `didSendRequestPart` at the right time

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
@@ -185,11 +185,11 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
         case .sendRequestHead(let head, startBody: let startBody):
             self.sendRequestHead(head, startBody: startBody, context: context)
 
-        case .sendBodyPart(let part):
-            context.writeAndFlush(self.wrapOutboundOut(.body(part)), promise: nil)
+        case .sendBodyPart(let part, let writePromise):
+            context.writeAndFlush(self.wrapOutboundOut(.body(part)), promise: writePromise)
 
-        case .sendRequestEnd:
-            context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+        case .sendRequestEnd(let writePromise):
+            context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: writePromise)
 
             if let timeoutAction = self.idleReadTimeoutStateMachine?.requestEndSent() {
                 self.runTimeoutAction(timeoutAction, context: context)
@@ -260,15 +260,24 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
             switch finalAction {
             case .close:
                 context.close(promise: nil)
-            case .sendRequestEnd:
-                context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+                oldRequest.succeedRequest(buffer)
+            case .sendRequestEnd(let writePromise):
+                let writePromise = writePromise ?? context.eventLoop.makePromise(of: Void.self)
+                // We need to defer succeeding the old request to avoid ordering issues
+                writePromise.futureResult.whenComplete { result in
+                    switch result {
+                    case .success:
+                        oldRequest.succeedRequest(buffer)
+                    case .failure(let error):
+                        oldRequest.fail(error)
+                    }
+                }
+
+                context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: writePromise)
             case .informConnectionIsIdle:
                 self.connection.taskCompleted()
-            case .none:
-                break
+                oldRequest.succeedRequest(buffer)
             }
-
-            oldRequest.succeedRequest(buffer)
 
         case .failRequest(let error, let finalAction):
             // see comment in the `succeedRequest` case.
@@ -277,17 +286,26 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
             self.runTimeoutAction(.clearIdleReadTimeoutTimer, context: context)
 
             switch finalAction {
-            case .close:
+            case .close(let writePromise):
                 context.close(promise: nil)
-            case .sendRequestEnd:
-                context.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
-            case .informConnectionIsIdle:
+                writePromise?.fail(error)
+                oldRequest.fail(error)
+
+            case .informConnectionIsIdle(let writePromise):
                 self.connection.taskCompleted()
+                writePromise?.fail(error)
+                oldRequest.fail(error)
+
+            case .failWritePromise(let writePromise):
+                writePromise?.fail(error)
+                oldRequest.fail(error)
+
             case .none:
-                break
+                oldRequest.fail(error)
             }
 
-            oldRequest.fail(error)
+        case .failSendBodyPart(let error, let writePromise), .failSendStreamFinished(let error, let writePromise):
+            writePromise?.fail(error)
         }
     }
 
@@ -355,27 +373,28 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
 
     // MARK: Private HTTPRequestExecutor
 
-    private func writeRequestBodyPart0(_ data: IOData, request: HTTPExecutableRequest) {
+    private func writeRequestBodyPart0(_ data: IOData, request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         guard self.request === request, let context = self.channelContext else {
             // Because the HTTPExecutableRequest may run in a different thread to our eventLoop,
             // calls from the HTTPExecutableRequest to our ChannelHandler may arrive here after
             // the request has been popped by the state machine or the ChannelHandler has been
             // removed from the Channel pipeline. This is a normal threading issue, noone has
             // screwed up.
+            promise?.fail(HTTPClientError.requestStreamCancelled)
             return
         }
 
-        let action = self.state.requestStreamPartReceived(data)
+        let action = self.state.requestStreamPartReceived(data, promise: promise)
         self.run(action, context: context)
     }
 
-    private func finishRequestBodyStream0(_ request: HTTPExecutableRequest) {
+    private func finishRequestBodyStream0(_ request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         guard self.request === request, let context = self.channelContext else {
             // See code comment in `writeRequestBodyPart0`
             return
         }
 
-        let action = self.state.requestStreamFinished()
+        let action = self.state.requestStreamFinished(promise: promise)
         self.run(action, context: context)
     }
 
@@ -405,22 +424,22 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
 }
 
 extension HTTP1ClientChannelHandler: HTTPRequestExecutor {
-    func writeRequestBodyPart(_ data: IOData, request: HTTPExecutableRequest) {
+    func writeRequestBodyPart(_ data: IOData, request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         if self.eventLoop.inEventLoop {
-            self.writeRequestBodyPart0(data, request: request)
+            self.writeRequestBodyPart0(data, request: request, promise: promise)
         } else {
             self.eventLoop.execute {
-                self.writeRequestBodyPart0(data, request: request)
+                self.writeRequestBodyPart0(data, request: request, promise: promise)
             }
         }
     }
 
-    func finishRequestBodyStream(_ request: HTTPExecutableRequest) {
+    func finishRequestBodyStream(_ request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         if self.eventLoop.inEventLoop {
-            self.finishRequestBodyStream0(request)
+            self.finishRequestBodyStream0(request, promise: promise)
         } else {
             self.eventLoop.execute {
-                self.finishRequestBodyStream0(request)
+                self.finishRequestBodyStream0(request, promise: promise)
             }
         }
     }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
@@ -291,9 +291,8 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
                 writePromise?.fail(error)
                 oldRequest.fail(error)
 
-            case .informConnectionIsIdle(let writePromise):
+            case .informConnectionIsIdle:
                 self.connection.taskCompleted()
-                writePromise?.fail(error)
                 oldRequest.fail(error)
 
             case .failWritePromise(let writePromise):
@@ -391,6 +390,7 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
     private func finishRequestBodyStream0(_ request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         guard self.request === request, let context = self.channelContext else {
             // See code comment in `writeRequestBodyPart0`
+            promise?.fail(HTTPClientError.requestStreamCancelled)
             return
         }
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ConnectionStateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ConnectionStateMachine.swift
@@ -28,21 +28,39 @@ struct HTTP1ConnectionStateMachine {
 
     enum Action {
         /// A action to execute, when we consider a request "done".
-        enum FinalStreamAction {
+        enum FinalSuccessfulStreamAction {
             /// Close the connection
             case close
             /// If the server has replied, with a status of 200...300 before all data was sent, a request is considered succeeded,
             /// as soon as we wrote the request end onto the wire.
-            case sendRequestEnd
+            ///
+            /// The promise is an optional write promise.
+            case sendRequestEnd(EventLoopPromise<Void>?)
             /// Inform an observer that the connection has become idle
             case informConnectionIsIdle
+        }
+
+        /// A action to execute, when we consider a request "done".
+        enum FinalFailedStreamAction {
+            /// Close the connection
+            ///
+            /// The promise is an optional write promise.
+            case close(EventLoopPromise<Void>?)
+            /// Inform an observer that the connection has become idle
+            ///
+            /// The promise is an optional write promise.
+            case informConnectionIsIdle(EventLoopPromise<Void>?)
+            /// Fail the write promise
+            case failWritePromise(EventLoopPromise<Void>?)
             /// Do nothing.
             case none
         }
 
         case sendRequestHead(HTTPRequestHead, startBody: Bool)
-        case sendBodyPart(IOData)
-        case sendRequestEnd
+        case sendBodyPart(IOData, EventLoopPromise<Void>?)
+        case sendRequestEnd(EventLoopPromise<Void>?)
+        case failSendBodyPart(Error, EventLoopPromise<Void>?)
+        case failSendStreamFinished(Error, EventLoopPromise<Void>?)
 
         case pauseRequestBodyStream
         case resumeRequestBodyStream
@@ -50,8 +68,8 @@ struct HTTP1ConnectionStateMachine {
         case forwardResponseHead(HTTPResponseHead, pauseRequestBodyStream: Bool)
         case forwardResponseBodyParts(CircularBuffer<ByteBuffer>)
 
-        case failRequest(Error, FinalStreamAction)
-        case succeedRequest(FinalStreamAction, CircularBuffer<ByteBuffer>)
+        case failRequest(Error, FinalFailedStreamAction)
+        case succeedRequest(FinalSuccessfulStreamAction, CircularBuffer<ByteBuffer>)
 
         case read
         case close
@@ -173,7 +191,7 @@ struct HTTP1ConnectionStateMachine {
             // as closed.
             //
             // TODO: AHC should support a fast rescheduling mechanism here.
-            return .failRequest(HTTPClientError.remoteConnectionClosed, .none)
+            return .failRequest(HTTPClientError.remoteConnectionClosed, .failWritePromise(nil))
 
         case .idle:
             var requestStateMachine = HTTPRequestStateMachine(isChannelWritable: self.isChannelWritable)
@@ -189,25 +207,25 @@ struct HTTP1ConnectionStateMachine {
         }
     }
 
-    mutating func requestStreamPartReceived(_ part: IOData) -> Action {
+    mutating func requestStreamPartReceived(_ part: IOData, promise: EventLoopPromise<Void>?) -> Action {
         guard case .inRequest(var requestStateMachine, let close) = self.state else {
             preconditionFailure("Invalid state: \(self.state)")
         }
 
         return self.avoidingStateMachineCoW { state -> Action in
-            let action = requestStateMachine.requestStreamPartReceived(part)
+            let action = requestStateMachine.requestStreamPartReceived(part, promise: promise)
             state = .inRequest(requestStateMachine, close: close)
             return state.modify(with: action)
         }
     }
 
-    mutating func requestStreamFinished() -> Action {
+    mutating func requestStreamFinished(promise: EventLoopPromise<Void>?) -> Action {
         guard case .inRequest(var requestStateMachine, let close) = self.state else {
             preconditionFailure("Invalid state: \(self.state)")
         }
 
         return self.avoidingStateMachineCoW { state -> Action in
-            let action = requestStateMachine.requestStreamFinished()
+            let action = requestStateMachine.requestStreamFinished(promise: promise)
             state = .inRequest(requestStateMachine, close: close)
             return state.modify(with: action)
         }
@@ -377,10 +395,10 @@ extension HTTP1ConnectionStateMachine.State {
             return .pauseRequestBodyStream
         case .resumeRequestBodyStream:
             return .resumeRequestBodyStream
-        case .sendBodyPart(let part):
-            return .sendBodyPart(part)
-        case .sendRequestEnd:
-            return .sendRequestEnd
+        case .sendBodyPart(let part, let writePromise):
+            return .sendBodyPart(part, writePromise)
+        case .sendRequestEnd(let writePromise):
+            return .sendRequestEnd(writePromise)
         case .forwardResponseHead(let head, let pauseRequestBodyStream):
             return .forwardResponseHead(head, pauseRequestBodyStream: pauseRequestBodyStream)
         case .forwardResponseBodyParts(let parts):
@@ -390,13 +408,13 @@ extension HTTP1ConnectionStateMachine.State {
                 preconditionFailure("Invalid state: \(self)")
             }
 
-            let newFinalAction: HTTP1ConnectionStateMachine.Action.FinalStreamAction
+            let newFinalAction: HTTP1ConnectionStateMachine.Action.FinalSuccessfulStreamAction
             switch finalAction {
             case .close:
                 self = .closing
                 newFinalAction = .close
-            case .sendRequestEnd:
-                newFinalAction = .sendRequestEnd
+            case .sendRequestEnd(let writePromise):
+                newFinalAction = .sendRequestEnd(writePromise)
             case .none:
                 self = .idle
                 newFinalAction = close ? .close : .informConnectionIsIdle
@@ -404,27 +422,43 @@ extension HTTP1ConnectionStateMachine.State {
             return .succeedRequest(newFinalAction, finalParts)
 
         case .failRequest(let error, let finalAction):
-            switch self {
-            case .initialized:
+            switch (self, finalAction) {
+            case (.initialized, _):
                 preconditionFailure("Invalid state: \(self)")
-            case .idle:
-                preconditionFailure("How can we fail a task, if we are idle")
-            case .inRequest(_, close: let close):
-                if close || finalAction == .close {
-                    self = .closing
-                    return .failRequest(error, .close)
-                } else {
-                    self = .idle
-                    return .failRequest(error, .informConnectionIsIdle)
-                }
 
-            case .closing:
+            case (.idle, _):
+                preconditionFailure("How can we fail a task, if we are idle")
+
+            // If we are either in .inRequest(_, close: true) or the final action is .close
+            // we have to fail the request with .close()
+            case (.inRequest(_, let close), .none) where close:
+                self = .closing
+                return .failRequest(error, .close(nil))
+
+            case (.inRequest(_, _), .close(let writePromise)):
+                self = .closing
+                return .failRequest(error, .close(writePromise))
+
+            // otherwise we fail with .informConnectionIsIdle
+            case (.inRequest(_, _), .none):
+                self = .idle
+                return .failRequest(error, .informConnectionIsIdle(nil))
+
+            case (.closing, .close(let writePromise)):
+                return .failRequest(error, .failWritePromise(writePromise))
+
+            case (.closing, .none):
                 return .failRequest(error, .none)
-            case .closed:
+
+            case (.closed, .close(let writePromise)):
+                // this state can be reached, if the connection was unexpectedly closed by remote
+                return .failRequest(error, .failWritePromise(writePromise))
+
+            case (.closed, .none):
                 // this state can be reached, if the connection was unexpectedly closed by remote
                 return .failRequest(error, .none)
 
-            case .modifying:
+            case (.modifying, _):
                 preconditionFailure("Invalid state: \(self)")
             }
 
@@ -433,6 +467,12 @@ extension HTTP1ConnectionStateMachine.State {
 
         case .wait:
             return .wait
+
+        case .failSendBodyPart(let error, let writePromise):
+            return .failSendBodyPart(error, writePromise)
+
+        case .failSendStreamFinished(let error, let writePromise):
+            return .failSendStreamFinished(error, writePromise)
         }
     }
 }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPExecutableRequest.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPExecutableRequest.swift
@@ -180,12 +180,12 @@ protocol HTTPRequestExecutor {
     /// Writes a body part into the channel pipeline
     ///
     /// This method may be **called on any thread**. The executor needs to ensure thread safety.
-    func writeRequestBodyPart(_: IOData, request: HTTPExecutableRequest)
+    func writeRequestBodyPart(_: IOData, request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?)
 
     /// Signals that the request body stream has finished
     ///
     /// This method may be **called on any thread**. The executor needs to ensure thread safety.
-    func finishRequestBodyStream(_ task: HTTPExecutableRequest)
+    func finishRequestBodyStream(_ task: HTTPExecutableRequest, promise: EventLoopPromise<Void>?)
 
     /// Signals that more bytes from response body stream can be consumed.
     ///

--- a/Sources/AsyncHTTPClient/RequestBag.swift
+++ b/Sources/AsyncHTTPClient/RequestBag.swift
@@ -154,8 +154,11 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
             return self.task.eventLoop.makeFailedFuture(error)
 
         case .write(let part, let writer, let future):
-            writer.writeRequestBodyPart(part, request: self)
-            self.delegate.didSendRequestPart(task: self.task, part)
+            let promise = self.task.eventLoop.makePromise(of: Void.self)
+            promise.futureResult.whenSuccess {
+                self.delegate.didSendRequestPart(task: self.task, part)
+            }
+            writer.writeRequestBodyPart(part, request: self, promise: promise)
             return future
         }
     }
@@ -168,11 +171,12 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
         switch action {
         case .none:
             break
-        case .forwardStreamFinished(let writer, let promise):
-            writer.finishRequestBodyStream(self)
-            promise?.succeed(())
-
-            self.delegate.didSendRequest(task: self.task)
+        case .forwardStreamFinished(let writer, let writerPromise):
+            let promise = writerPromise ?? self.task.eventLoop.makePromise(of: Void.self)
+            promise.futureResult.whenSuccess {
+                self.delegate.didSendRequest(task: self.task)
+            }
+            writer.finishRequestBodyStream(self, promise: promise)
 
         case .forwardStreamFailureAndFailTask(let writer, let error, let promise):
             writer.cancelRequest(self)

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
@@ -32,22 +32,22 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         let part1 = IOData.byteBuffer(ByteBuffer(bytes: [1]))
         let part2 = IOData.byteBuffer(ByteBuffer(bytes: [2]))
         let part3 = IOData.byteBuffer(ByteBuffer(bytes: [3]))
-        XCTAssertEqual(state.requestStreamPartReceived(part0), .sendBodyPart(part0))
-        XCTAssertEqual(state.requestStreamPartReceived(part1), .sendBodyPart(part1))
+        XCTAssertEqual(state.requestStreamPartReceived(part0, promise: nil), .sendBodyPart(part0, nil))
+        XCTAssertEqual(state.requestStreamPartReceived(part1, promise: nil), .sendBodyPart(part1, nil))
 
         // oh the channel reports... we should slow down producing...
         XCTAssertEqual(state.writabilityChanged(writable: false), .pauseRequestBodyStream)
 
         // but we issued a .produceMoreRequestBodyData before... Thus, we must accept more produced
         // data
-        XCTAssertEqual(state.requestStreamPartReceived(part2), .sendBodyPart(part2))
+        XCTAssertEqual(state.requestStreamPartReceived(part2, promise: nil), .sendBodyPart(part2, nil))
         // however when we have put the data on the channel, we should not issue further
         // .produceMoreRequestBodyData events
 
         // once we receive a writable event again, we can allow the producer to produce more data
         XCTAssertEqual(state.writabilityChanged(writable: true), .resumeRequestBodyStream)
-        XCTAssertEqual(state.requestStreamPartReceived(part3), .sendBodyPart(part3))
-        XCTAssertEqual(state.requestStreamFinished(), .sendRequestEnd)
+        XCTAssertEqual(state.requestStreamPartReceived(part3, promise: nil), .sendBodyPart(part3, nil))
+        XCTAssertEqual(state.requestStreamFinished(promise: nil), .sendRequestEnd(nil))
 
         let responseHead = HTTPResponseHead(version: .http1_1, status: .ok)
         XCTAssertEqual(state.channelRead(.head(responseHead)), .forwardResponseHead(responseHead, pauseRequestBodyStream: false))
@@ -186,9 +186,9 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
 
         let part0 = IOData.byteBuffer(ByteBuffer(bytes: [0]))
         let part1 = IOData.byteBuffer(ByteBuffer(bytes: [1]))
-        XCTAssertEqual(state.requestStreamPartReceived(part0), .sendBodyPart(part0))
-        XCTAssertEqual(state.requestStreamPartReceived(part1), .sendBodyPart(part1))
-        XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .close))
+        XCTAssertEqual(state.requestStreamPartReceived(part0, promise: nil), .sendBodyPart(part0, nil))
+        XCTAssertEqual(state.requestStreamPartReceived(part1, promise: nil), .sendBodyPart(part1, nil))
+        XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .close(nil)))
     }
 
     func testCancelRequestIsIgnoredWhenConnectionIsIdle() {
@@ -226,7 +226,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         let requestHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/", headers: ["content-length": "4"])
         let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(4))
         XCTAssertEqual(state.runNewRequest(head: requestHead, metadata: metadata), .wait)
-        XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .informConnectionIsIdle))
+        XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .informConnectionIsIdle(nil)))
     }
 
     func testConnectionIsClosedIfErrorHappensWhileInRequest() {
@@ -241,7 +241,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         XCTAssertEqual(state.channelRead(.body(ByteBuffer(string: "Hello world!\n"))), .wait)
         XCTAssertEqual(state.channelRead(.body(ByteBuffer(string: "Foo Bar!\n"))), .wait)
         let decompressionError = NIOHTTPDecompression.DecompressionError.limit
-        XCTAssertEqual(state.errorHappened(decompressionError), .failRequest(decompressionError, .close))
+        XCTAssertEqual(state.errorHappened(decompressionError), .failRequest(decompressionError, .close(nil)))
     }
 
     func testConnectionIsClosedAfterSwitchingProtocols() {
@@ -276,7 +276,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
         let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
-        guard case .failRequest(let error, .none) = newRequestAction else {
+        guard case .failRequest(let error, .failWritePromise) = newRequestAction else {
             return XCTFail("Unexpected test case")
         }
         XCTAssertEqual(error as? HTTPClientError, .remoteConnectionClosed)
@@ -295,8 +295,8 @@ extension HTTP1ConnectionStateMachine.Action: Equatable {
         case (.sendRequestHead(let lhsHead, let lhsStartBody), .sendRequestHead(let rhsHead, let rhsStartBody)):
             return lhsHead == rhsHead && lhsStartBody == rhsStartBody
 
-        case (.sendBodyPart(let lhsData), .sendBodyPart(let rhsData)):
-            return lhsData == rhsData
+        case (.sendBodyPart(let lhsData, let lhsPromise), .sendBodyPart(let rhsData, let rhsPromise)):
+            return lhsData == rhsData && lhsPromise?.futureResult == rhsPromise?.futureResult
 
         case (.sendRequestEnd, .sendRequestEnd):
             return true
@@ -327,6 +327,38 @@ extension HTTP1ConnectionStateMachine.Action: Equatable {
         case (.wait, .wait):
             return true
 
+        default:
+            return false
+        }
+    }
+}
+
+extension HTTP1ConnectionStateMachine.Action.FinalSuccessfulStreamAction: Equatable {
+    public static func == (lhs: HTTP1ConnectionStateMachine.Action.FinalSuccessfulStreamAction, rhs: HTTP1ConnectionStateMachine.Action.FinalSuccessfulStreamAction) -> Bool {
+        switch (lhs, rhs) {
+        case (.close, .close):
+            return true
+        case (sendRequestEnd(let lhsPromise), sendRequestEnd(let rhsPromise)):
+            return lhsPromise?.futureResult == rhsPromise?.futureResult
+        case (informConnectionIsIdle, informConnectionIsIdle):
+            return true
+        default:
+            return false
+        }
+    }
+}
+
+extension HTTP1ConnectionStateMachine.Action.FinalFailedStreamAction: Equatable {
+    public static func == (lhs: HTTP1ConnectionStateMachine.Action.FinalFailedStreamAction, rhs: HTTP1ConnectionStateMachine.Action.FinalFailedStreamAction) -> Bool {
+        switch (lhs, rhs) {
+        case (.close(let lhsPromise), .close(let rhsPromise)):
+            return lhsPromise?.futureResult == rhsPromise?.futureResult
+        case (informConnectionIsIdle(let lhsPromise), informConnectionIsIdle(let rhsPromise)):
+            return lhsPromise?.futureResult == rhsPromise?.futureResult
+        case (.failWritePromise(let lhsPromise), .failWritePromise(let rhsPromise)):
+            return lhsPromise?.futureResult == rhsPromise?.futureResult
+        case (.none, .none):
+            return true
         default:
             return false
         }

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
@@ -226,7 +226,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         let requestHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/", headers: ["content-length": "4"])
         let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(4))
         XCTAssertEqual(state.runNewRequest(head: requestHead, metadata: metadata), .wait)
-        XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .informConnectionIsIdle(nil)))
+        XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .informConnectionIsIdle))
     }
 
     func testConnectionIsClosedIfErrorHappensWhileInRequest() {
@@ -353,8 +353,8 @@ extension HTTP1ConnectionStateMachine.Action.FinalFailedStreamAction: Equatable 
         switch (lhs, rhs) {
         case (.close(let lhsPromise), .close(let rhsPromise)):
             return lhsPromise?.futureResult == rhsPromise?.futureResult
-        case (informConnectionIsIdle(let lhsPromise), informConnectionIsIdle(let rhsPromise)):
-            return lhsPromise?.futureResult == rhsPromise?.futureResult
+        case (.informConnectionIsIdle, .informConnectionIsIdle):
+            return true
         case (.failWritePromise(let lhsPromise), .failWritePromise(let rhsPromise)):
             return lhsPromise?.futureResult == rhsPromise?.futureResult
         case (.none, .none):

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
@@ -276,7 +276,7 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         let requestHead = HTTPRequestHead(version: .http1_1, method: .GET, uri: "/")
         let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(0))
         let newRequestAction = state.runNewRequest(head: requestHead, metadata: metadata)
-        guard case .failRequest(let error, .failWritePromise) = newRequestAction else {
+        guard case .failRequest(let error, .none) = newRequestAction else {
             return XCTFail("Unexpected test case")
         }
         XCTAssertEqual(error as? HTTPClientError, .remoteConnectionClosed)

--- a/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests+XCTest.swift
@@ -30,6 +30,7 @@ extension HTTPRequestStateMachineTests {
             ("testPOSTContentLengthIsTooLong", testPOSTContentLengthIsTooLong),
             ("testPOSTContentLengthIsTooShort", testPOSTContentLengthIsTooShort),
             ("testRequestBodyStreamIsCancelledIfServerRespondsWith301", testRequestBodyStreamIsCancelledIfServerRespondsWith301),
+            ("testStreamPartReceived_whenCancelled", testStreamPartReceived_whenCancelled),
             ("testRequestBodyStreamIsCancelledIfServerRespondsWith301WhileWriteBackpressure", testRequestBodyStreamIsCancelledIfServerRespondsWith301WhileWriteBackpressure),
             ("testRequestBodyStreamIsContinuedIfServerRespondsWith200", testRequestBodyStreamIsContinuedIfServerRespondsWith200),
             ("testRequestBodyStreamIsContinuedIfServerSendHeadWithStatus200", testRequestBodyStreamIsContinuedIfServerSendHeadWithStatus200),

--- a/Tests/AsyncHTTPClientTests/Mocks/MockRequestExecutor.swift
+++ b/Tests/AsyncHTTPClientTests/Mocks/MockRequestExecutor.swift
@@ -184,12 +184,14 @@ extension MockRequestExecutor: HTTPRequestExecutor {
     // this should always be called twice. When we receive the first call, the next call to produce
     // data is already scheduled. If we call pause here, once, after the second call new subsequent
     // calls should not be scheduled.
-    func writeRequestBodyPart(_ part: IOData, request: HTTPExecutableRequest) {
+    func writeRequestBodyPart(_ part: IOData, request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         self.writeNextRequestPart(.body(part), request: request)
+        promise?.succeed(())
     }
 
-    func finishRequestBodyStream(_ request: HTTPExecutableRequest) {
+    func finishRequestBodyStream(_ request: HTTPExecutableRequest, promise: EventLoopPromise<Void>?) {
         self.writeNextRequestPart(.endOfStream, request: request)
+        promise?.succeed(())
     }
 
     private func writeNextRequestPart(_ part: RequestParts, request: HTTPExecutableRequest) {


### PR DESCRIPTION
# Motivation
Right now, we call `didSendRequestPart` after passing the write to the executor. However, this does not mean that the write hit the socket. To implement proper backpressure using the delegate, we should only call this method once the write was successful.

# Modification
Pass a promise to the actual channel write and only call the delegate once that promise succeeds.

# Result
The delegate method `didSendRequestPart` is only called after the write was successful.