### PR TITLE
Fix flaky `HTTPClientTests.testResponseDelayGet()` test

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -19,5 +19,6 @@
 --disable redundantReturn
 --disable preferKeyPath
 --disable sortedSwitchCases
+--disable numberFormatting
 
 # rules

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1218,7 +1218,7 @@ class HTTPClientTests: XCTestCase {
                                          body: nil)
         let start = NIODeadline.now()
         let response = try self.defaultClient.execute(request: req).wait()
-        XCTAssertGreaterThanOrEqual(.now() - start, .milliseconds(1_900 /* 1.9 seconds */))
+        XCTAssertGreaterThanOrEqual(.now() - start, .milliseconds(1_900 /* 1.9 seconds */ ))
         XCTAssertEqual(response.status, .ok)
     }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1216,9 +1216,9 @@ class HTTPClientTests: XCTestCase {
                                          method: .GET,
                                          headers: ["X-internal-delay": "2000"],
                                          body: nil)
-        let start = Date()
-        let response = try! self.defaultClient.execute(request: req).wait()
-        XCTAssertGreaterThan(Date().timeIntervalSince(start), 2)
+        let start = NIODeadline.now()
+        let response = try self.defaultClient.execute(request: req).wait()
+        XCTAssertGreaterThanOrEqual(.now() - start, .milliseconds(1_900 /* 1.9 seconds */))
         XCTAssertEqual(response.status, .ok)
     }
 


### PR DESCRIPTION
# Motivation 
We observed a test failure on our CI:
```
/async-http-client/Tests/AsyncHTTPClientTests/HTTPClientTests.swift: error: HTTPClientTests.testResponseDelayGet : XCTAssertGreaterThan failed: ("1.9851820468902588") is not greater than ("2.0") -
Test Case 'HTTPClientTests.testResponseDelayGet' failed (1.989 seconds)
```

# Modification
I could not reproduce the failure myself but giving this a bit more leeway does not hurt. To measure the time difference, we now use `NIODeadline` which internally uses nanoseconds since boot to measure the time instead of `Date`. `Date` uses the system time which may change during execution due to time sync with a time server and is therefore not best suited to measure elapsed time.

# Result
Immune to system time sync and slightly higher tolerance agains inaccurate timer implementations.
