### PR TITLE
Make Task.logger accessible to delegate implementations outside of Package

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -697,9 +697,10 @@ extension HTTPClient {
     public final class Task<Response> {
         /// The `EventLoop` the delegate will be executed on.
         public let eventLoop: EventLoop
+        /// The `Logger` used by the `Task` for logging.
+        public let logger: Logger // We are okay to store the logger here because a Task is for only one request.
 
         let promise: EventLoopPromise<Response>
-        let logger: Logger // We are okay to store the logger here because a Task is for only one request.
 
         var isCancelled: Bool {
             self.lock.withLock { self._isCancelled }


### PR DESCRIPTION
### Motivation:

This change was proposed in issue [#389](https://github.com/swift-server/async-http-client/issues/389).

Users writing their own `HttpClientResponseDelegate` implementation
might want to emit log messages to the `task`'s `logger`.

### Modifications:

Changed the access level of `Task`'s `logger` property from `internal`
to `public`.

### Result:

Users can access the `logger` property of a `Task` outside of the
`async-http-client` Package.