### PR TITLE
Improve errors and testing using NIOTS

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -467,6 +467,16 @@ extension HTTPConnectionPool: HTTPConnectionRequester {
             $0.failedToCreateNewConnection(error, connectionID: connectionID)
         }
     }
+
+    func waitingForConnectivity(_ connectionID: HTTPConnectionPool.Connection.ID, error: Error) {
+        self.logger.debug("waiting for connectivity", metadata: [
+            "ahc-error": "\(error)",
+            "ahc-connection-id": "\(connectionID)",
+        ])
+        self.modifyStateAndRunActions {
+            $0.waitingForConnectivity(error, connectionID: connectionID)
+        }
+    }
 }
 
 extension HTTPConnectionPool: HTTP1ConnectionDelegate {

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1StateMachine.swift
@@ -241,6 +241,12 @@ extension HTTPConnectionPool {
             }
         }
 
+        mutating func waitingForConnectivity(_ error: Error, connectionID: Connection.ID) -> Action {
+            self.lastConnectFailure = error
+
+            return .init(request: .none, connection: .none)
+        }
+
         mutating func connectionCreationBackoffDone(_ connectionID: Connection.ID) -> Action {
             switch self.lifecycleState {
             case .running:

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP2StateMachine.swift
@@ -406,6 +406,11 @@ extension HTTPConnectionPool {
             return .init(request: .none, connection: .scheduleBackoffTimer(connectionID, backoff: backoff, on: eventLoop))
         }
 
+        mutating func waitingForConnectivity(_ error: Error, connectionID: Connection.ID) -> Action {
+            self.lastConnectFailure = error
+            return .init(request: .none, connection: .none)
+        }
+
         mutating func connectionCreationBackoffDone(_ connectionID: Connection.ID) -> Action {
             // The naming of `failConnection` is a little confusing here. All it does is moving the
             // connection state from `.backingOff` to `.closed` here. It also returns the

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+StateMachine.swift
@@ -211,6 +211,14 @@ extension HTTPConnectionPool {
             })
         }
 
+        mutating func waitingForConnectivity(_ error: Error, connectionID: Connection.ID) -> Action {
+            self.state.modify(http1: { http1 in
+                http1.waitingForConnectivity(error, connectionID: connectionID)
+            }, http2: { http2 in
+                http2.waitingForConnectivity(error, connectionID: connectionID)
+            })
+        }
+
         mutating func connectionCreationBackoffDone(_ connectionID: Connection.ID) -> Action {
             self.state.modify(http1: { http1 in
                 http1.connectionCreationBackoffDone(connectionID)

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -655,6 +655,10 @@ public class HTTPClient {
         /// is set to `.automatic` by default which will use HTTP/2 if run over https and the server supports it, otherwise HTTP/1
         public var httpVersion: HTTPVersion
 
+        /// Whether `HTTPClient` will let Network.framework sit in the `.waiting` state awaiting new network changes, or fail immediately. Defaults to `true`,
+        /// which is the recommended setting. Only set this to `false` when attempting to trigger a particular error path.
+        public var networkFrameworkWaitForConnectivity: Bool
+
         public init(
             tlsConfiguration: TLSConfiguration? = nil,
             redirectConfiguration: RedirectConfiguration? = nil,
@@ -671,6 +675,7 @@ public class HTTPClient {
             self.proxy = proxy
             self.decompression = decompression
             self.httpVersion = .automatic
+            self.networkFrameworkWaitForConnectivity = true
         }
 
         public init(tlsConfiguration: TLSConfiguration? = nil,

--- a/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
@@ -14,11 +14,11 @@
 
 #if canImport(Network)
 import Network
-#endif
 import NIOCore
 import NIOHTTP1
 import NIOTransportServices
 
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInboundHandler {
     typealias InboundIn = Any
     typealias InboundOut = Any
@@ -32,14 +32,10 @@ final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInbound
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        #if canImport(Network)
-        if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
-            if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity, let requester = self.requester {
-                requester.waitingForConnectivity(self.connectionID, error: HTTPClient.NWErrorHandler.translateError(waitingEvent.transientError))
-                self.requester = nil
-            }
+        if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity, let requester = self.requester {
+            requester.waitingForConnectivity(self.connectionID, error: HTTPClient.NWErrorHandler.translateError(waitingEvent.transientError))
+            self.requester = nil
         }
-        #endif
         context.fireUserInboundEventTriggered(event)
     }
 
@@ -47,3 +43,4 @@ final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInbound
         self.requester = nil
     }
 }
+#endif

--- a/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
@@ -23,7 +23,7 @@ final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInbound
     typealias InboundIn = Any
     typealias InboundOut = Any
 
-    private var requester: Requester?
+    private var requester: Requester
     private let connectionID: HTTPConnectionPool.Connection.ID
 
     init(requester: Requester, connectionID: HTTPConnectionPool.Connection.ID) {
@@ -32,15 +32,10 @@ final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInbound
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity, let requester = self.requester {
-            requester.waitingForConnectivity(self.connectionID, error: HTTPClient.NWErrorHandler.translateError(waitingEvent.transientError))
-            self.requester = nil
+        if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity{
+            self.requester.waitingForConnectivity(self.connectionID, error: HTTPClient.NWErrorHandler.translateError(waitingEvent.transientError))
         }
         context.fireUserInboundEventTriggered(event)
-    }
-
-    func handlerRemoved(context: ChannelHandlerContext) {
-        self.requester = nil
     }
 }
 #endif

--- a/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2022 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+import Network
+#endif
+import NIOCore
+import NIOHTTP1
+import NIOTransportServices
+
+final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInboundHandler {
+    typealias InboundIn = Any
+    typealias InboundOut = Any
+
+    private var requester: Requester?
+    private let connectionID: HTTPConnectionPool.Connection.ID
+
+    init(requester: Requester, connectionID: HTTPConnectionPool.Connection.ID) {
+        self.requester = requester
+        self.connectionID = connectionID
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        #if canImport(Network)
+        if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+            if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity, let requester = self.requester {
+                requester.waitingForConnectivity(self.connectionID, error: HTTPClient.NWErrorHandler.translateError(waitingEvent.transientError))
+                self.requester = nil
+            }
+        }
+        #endif
+        context.fireUserInboundEventTriggered(event)
+    }
+
+    func handlerRemoved(context: ChannelHandlerContext) {
+        self.requester = nil
+    }
+}

--- a/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/NWWaitingHandler.swift
@@ -32,7 +32,7 @@ final class NWWaitingHandler<Requester: HTTPConnectionRequester>: ChannelInbound
     }
 
     func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
-        if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity{
+        if let waitingEvent = event as? NIOTSNetworkEvents.WaitingForConnectivity {
             self.requester.waitingForConnectivity(self.connectionID, error: HTTPClient.NWErrorHandler.translateError(waitingEvent.transientError))
         }
         context.fireUserInboundEventTriggered(event)

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -405,6 +405,10 @@ extension TestConnectionCreator: HTTPConnectionRequester {
         }
         wrapper.fail(error)
     }
+
+    func waitingForConnectivity(_: HTTPConnectionPool.Connection.ID, error: Swift.Error) {
+        preconditionFailure("TODO")
+    }
 }
 
 class TestHTTP2ConnectionDelegate: HTTP2ConnectionDelegate {

--- a/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
@@ -90,8 +90,10 @@ class HTTPClientSOCKSTests: XCTestCase {
     }
 
     func testProxySOCKSBogusAddress() throws {
+        var config = HTTPClient.Configuration(proxy: .socksServer(host: "127.0.."))
+        config.networkFrameworkWaitForConnectivity = false
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(proxy: .socksServer(host: "127.0..")))
+                                     configuration: config)
 
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
@@ -102,8 +104,11 @@ class HTTPClientSOCKSTests: XCTestCase {
     // there is no socks server, so we should fail
     func testProxySOCKSFailureNoServer() throws {
         let localHTTPBin = HTTPBin()
+        var config = HTTPClient.Configuration(proxy: .socksServer(host: "localhost", port: localHTTPBin.port))
+        config.networkFrameworkWaitForConnectivity = false
+
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(proxy: .socksServer(host: "localhost", port: localHTTPBin.port)))
+                                     configuration: config)
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
             XCTAssertNoThrow(try localHTTPBin.shutdown())
@@ -113,8 +118,11 @@ class HTTPClientSOCKSTests: XCTestCase {
 
     // speak to a server that doesn't speak SOCKS
     func testProxySOCKSFailureInvalidServer() throws {
+        var config = HTTPClient.Configuration(proxy: .socksServer(host: "localhost"))
+        config.networkFrameworkWaitForConnectivity = false
+
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(proxy: .socksServer(host: "localhost")))
+                                     configuration: config)
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
         }
@@ -124,8 +132,11 @@ class HTTPClientSOCKSTests: XCTestCase {
     // test a handshake failure with a misbehaving server
     func testProxySOCKSMisbehavingServer() throws {
         let socksBin = try MockSOCKSServer(expectedURL: "/socks/test", expectedResponse: "it works!", misbehave: true)
+        var config = HTTPClient.Configuration(proxy: .socksServer(host: "localhost", port: socksBin.port))
+        config.networkFrameworkWaitForConnectivity = false
+
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
-                                     configuration: .init(proxy: .socksServer(host: "localhost", port: socksBin.port)))
+                                     configuration: config)
 
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -429,7 +429,9 @@ class HTTPClientInternalTests: XCTestCase {
         let el2 = elg.next()
 
         let httpBin = HTTPBin(.refuse)
-        let client = HTTPClient(eventLoopGroupProvider: .shared(elg))
+        var config = HTTPClient.Configuration()
+        config.networkFrameworkWaitForConnectivity = false
+        let client = HTTPClient(eventLoopGroupProvider: .shared(elg), configuration: config)
 
         defer {
             XCTAssertNoThrow(try client.syncShutdown())

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests+XCTest.swift
@@ -27,6 +27,7 @@ extension HTTPClientNIOTSTests {
         return [
             ("testCorrectEventLoopGroup", testCorrectEventLoopGroup),
             ("testTLSFailError", testTLSFailError),
+            ("testConnectionFailsFastError", testConnectionFailsFastError),
             ("testConnectionFailError", testConnectionFailError),
             ("testTLSVersionError", testTLSVersionError),
             ("testTrustRootCertificateLoadFail", testTrustRootCertificateLoadFail),

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -81,6 +81,7 @@ class HTTPClientNIOTSTests: XCTestCase {
 
     func testConnectionFailsFastError() {
         guard isTestingNIOTS() else { return }
+        #if canImport(Network)
         let httpBin = HTTPBin(.http1_1(ssl: false))
         var config = HTTPClient.Configuration()
         config.networkFrameworkWaitForConnectivity = false
@@ -98,6 +99,7 @@ class HTTPClientNIOTSTests: XCTestCase {
         XCTAssertThrowsError(try httpClient.get(url: "http://localhost:\(port)/get").wait()) {
             XCTAssertTrue($0 is NWError)
         }
+        #endif
     }
 
     func testConnectionFailError() {

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -22,7 +22,6 @@ import NIOPosix
 import NIOSSL
 import NIOTransportServices
 import XCTest
-import NIOEmbedded
 
 class HTTPClientNIOTSTests: XCTestCase {
     var clientGroup: EventLoopGroup!

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -54,7 +54,10 @@ class HTTPClientNIOTSTests: XCTestCase {
         guard isTestingNIOTS() else { return }
 
         let httpBin = HTTPBin(.http1_1(ssl: true))
-        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup))
+        var config = HTTPClient.Configuration()
+        config.networkFrameworkWaitForConnectivity = false
+        let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
+                                    configuration: config)
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
             XCTAssertNoThrow(try httpBin.shutdown())
@@ -77,7 +80,7 @@ class HTTPClientNIOTSTests: XCTestCase {
 
     func testConnectionFailError() {
         guard isTestingNIOTS() else { return }
-        let httpBin = HTTPBin(.http1_1(ssl: true))
+        let httpBin = HTTPBin(.http1_1(ssl: false))
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                     configuration: .init(timeout: .init(connect: .milliseconds(100),
                                                                         read: .milliseconds(100))))
@@ -89,7 +92,7 @@ class HTTPClientNIOTSTests: XCTestCase {
         let port = httpBin.port
         XCTAssertNoThrow(try httpBin.shutdown())
 
-        XCTAssertThrowsError(try httpClient.get(url: "https://localhost:\(port)/get").wait()) {
+        XCTAssertThrowsError(try httpClient.get(url: "http://localhost:\(port)/get").wait()) {
             XCTAssertEqual($0 as? HTTPClientError, .connectTimeout)
         }
     }
@@ -102,9 +105,12 @@ class HTTPClientNIOTSTests: XCTestCase {
         tlsConfig.certificateVerification = .none
         tlsConfig.minimumTLSVersion = .tlsv11
         tlsConfig.maximumTLSVersion = .tlsv1
+
+        var clientConfig = HTTPClient.Configuration(tlsConfiguration: tlsConfig)
+        clientConfig.networkFrameworkWaitForConnectivity = false
         let httpClient = HTTPClient(
             eventLoopGroupProvider: .shared(self.clientGroup),
-            configuration: .init(tlsConfiguration: tlsConfig)
+            configuration: clientConfig
         )
         defer {
             XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2763,8 +2763,8 @@ class HTTPClientTests: XCTestCase {
         if isTestingNIOTS() {
             // If we are using Network.framework, we set the connect timeout down very low here
             // because on NIOTS a failing TLS handshake manifests as a connect timeout.
-            // Note that we do this here to prove that we correctly manifest the underlying error: DO NOT
-            // CHANGE THIS TO DISABLE WAITING FOR CONNECTIVITY.
+            // Note that we do this here to prove that we correctly manifest the underlying error: 
+            // DO NOT CHANGE THIS TO DISABLE WAITING FOR CONNECTIVITY.
             timeout.connect = .milliseconds(100)
         }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -2763,7 +2763,7 @@ class HTTPClientTests: XCTestCase {
         if isTestingNIOTS() {
             // If we are using Network.framework, we set the connect timeout down very low here
             // because on NIOTS a failing TLS handshake manifests as a connect timeout.
-            // Note that we do this here to prove that we correctly manifest the underlying error: 
+            // Note that we do this here to prove that we correctly manifest the underlying error:
             // DO NOT CHANGE THIS TO DISABLE WAITING FOR CONNECTIVITY.
             timeout.connect = .milliseconds(100)
         }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+FactoryTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+FactoryTests.swift
@@ -46,6 +46,7 @@ class HTTPConnectionPool_FactoryTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try factory.makeChannel(
+            requester: ExplodingRequester(),
             connectionID: 1,
             deadline: .now() - .seconds(1),
             eventLoop: group.next(),
@@ -81,6 +82,7 @@ class HTTPConnectionPool_FactoryTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try factory.makeChannel(
+            requester: ExplodingRequester(),
             connectionID: 1,
             deadline: .now() + .seconds(1),
             eventLoop: group.next(),
@@ -116,6 +118,7 @@ class HTTPConnectionPool_FactoryTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try factory.makeChannel(
+            requester: ExplodingRequester(),
             connectionID: 1,
             deadline: .now() + .seconds(1),
             eventLoop: group.next(),
@@ -153,6 +156,7 @@ class HTTPConnectionPool_FactoryTests: XCTestCase {
         )
 
         XCTAssertThrowsError(try factory.makeChannel(
+            requester: ExplodingRequester(),
             connectionID: 1,
             deadline: .now() + .seconds(1),
             eventLoop: group.next(),
@@ -169,5 +173,24 @@ class NeverrespondServerHandler: ChannelInboundHandler {
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         // do nothing
+    }
+}
+
+/// A `HTTPConnectionRequester` that will fail a test if any of its methods are ever called.
+final class ExplodingRequester: HTTPConnectionRequester {
+    func http1ConnectionCreated(_: HTTP1Connection) {
+        XCTFail("http1ConnectionCreated called unexpectedly")
+    }
+
+    func http2ConnectionCreated(_: HTTP2Connection, maximumStreams: Int) {
+        XCTFail("http2ConnectionCreated called unexpectedly")
+    }
+
+    func failedToCreateHTTPConnection(_: HTTPConnectionPool.Connection.ID, error: Error) {
+        XCTFail("failedToCreateHTTPConnection called unexpectedly")
+    }
+
+    func waitingForConnectivity(_: HTTPConnectionPool.Connection.ID, error: Error) {
+        XCTFail("waitingForConnectivity called unexpectedly")
     }
 }


### PR DESCRIPTION
Motivation

Currently error reporting with NIO Transport Services is often sub-par.
This occurs because the Network.framework connections may enter the
waiting state until the network connectivity state changes. We were not
watching for the user event that contains the error in that state, so if
we timed out in that state we'd just give a generic timeout error,
instead of telling the user anything more detailed.

Additionally, several of our tests assume that failure will be fast, but
in NIO Transport Services we will enter that .waiting state. This is
reasonable, as changed network connections may make a connection that
was not succeeding suddenly viable. However, it's inconvenient for
testing, where we're mostly interested in confirming that the error path
works as expected.

Modifications

- Add an observer of the WaitingForConnectivity event that records it
  into our state machine for later reporting.
- Add support for disabling waiting for connectivity for testing
  purposes.
- Add annotations to several tests to stop them waiting for
  connectivity.

Results

Faster tests, better coverage, better errors for our users.