### PR TITLE
Fix crash when receiving 2xx response before stream is complete.

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
@@ -267,6 +267,9 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
                 writePromise.futureResult.whenComplete { result in
                     switch result {
                     case .success:
+                        // If our final action was `sendRequestEnd`, that means we've already received
+                        // the complete response. As a result, once we've uploaded all the body parts
+                        // we need to tell the pool that the connection is idle.
                         self.connection.taskCompleted()
                         oldRequest.succeedRequest(buffer)
                     case .failure(let error):

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
@@ -267,6 +267,7 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
                 writePromise.futureResult.whenComplete { result in
                     switch result {
                     case .success:
+                        self.connection.taskCompleted()
                         oldRequest.succeedRequest(buffer)
                     case .failure(let error):
                         oldRequest.fail(error)

--- a/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
@@ -347,10 +347,14 @@ extension RequestBag.StateMachine {
             self.state = .executing(executor, requestState, .buffering(currentBuffer, next: next))
             return .none
         case .executing(let executor, let requestState, .waitingForRemote):
-            var buffer = buffer
-            let first = buffer.removeFirst()
-            self.state = .executing(executor, requestState, .buffering(buffer, next: .askExecutorForMore))
-            return .forwardResponsePart(first)
+            if buffer.count > 0 {
+                var buffer = buffer
+                let first = buffer.removeFirst()
+                self.state = .executing(executor, requestState, .buffering(buffer, next: .askExecutorForMore))
+                return .forwardResponsePart(first)
+            } else {
+                return .none
+            }
         case .redirected(let executor, var receivedBytes, let head, let redirectURL):
             let partsLength = buffer.reduce(into: 0) { $0 += $1.readableBytes }
             receivedBytes += partsLength

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -1253,7 +1253,7 @@ class HTTPEchoHandler: ChannelInboundHandler {
     }
 }
 
-class HTTP200DelayedHandler: ChannelInboundHandler {
+final class HTTP200DelayedHandler: ChannelInboundHandler {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -129,6 +129,7 @@ extension HTTPClientTests {
             ("testSSLHandshakeErrorPropagationDelayedClose", testSSLHandshakeErrorPropagationDelayedClose),
             ("testWeCloseConnectionsWhenConnectionCloseSetByServer", testWeCloseConnectionsWhenConnectionCloseSetByServer),
             ("testBiDirectionalStreaming", testBiDirectionalStreaming),
+            ("testBiDirectionalStreamingEarly200", testBiDirectionalStreamingEarly200),
             ("testSynchronousHandshakeErrorReporting", testSynchronousHandshakeErrorReporting),
             ("testFileDownloadChunked", testFileDownloadChunked),
             ("testCloseWhileBackpressureIsExertedIsFine", testCloseWhileBackpressureIsExertedIsFine),


### PR DESCRIPTION
Motivation

It's totally acceptable for a HTTP server to respond before a request
upload has completed. If the response is an error, we should abort the
upload (and we do), but if the response is a 2xx we should probably just
finish the upload.

In this case it turns out we'll actually hit a crash when we attempt to
deliver an empty body message. This is no good!

Once that bug was fixed it revealed another: while we'd attempted to
account for this case, we hadn't tested it, and so it turns out that
shutdown would hang. As a result, I've also cleaned that up.

Modifications

- Tolerate empty circular buffers of bytes when streaming an upload.
- Notify the connection that the task is complete when we're done.

Result

Fewer crashes and hangs.
Resolves #562