### PR TITLE
Use a local TCP server that doesn’t accept connections on macOS for `testConnectTimeout()`

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -650,7 +650,7 @@ class HTTPClientTests: XCTestCase {
         // The backlog behaviour on Linux can not be used to simulate a non-reachable server.
         // Linux sends a `SYN/ACK` back even if the `backlog` queue is full as it has two queues.
         // The second queue is not limit by `ChannelOptions.backlog` but by `/proc/sys/net/ipv4/tcp_max_syn_backlog`.
-        
+
         let serverChannel = try ServerBootstrap(group: self.serverGroup)
             .serverChannelOption(ChannelOptions.backlog, value: 1)
             .serverChannelOption(ChannelOptions.autoRead, value: false)
@@ -668,7 +668,7 @@ class HTTPClientTests: XCTestCase {
         }
         let url = "http://localhost:\(port)/get"
         #endif
-        
+
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                     configuration: .init(timeout: .init(connect: .milliseconds(100), read: .milliseconds(150))))
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -640,7 +640,35 @@ class HTTPClientTests: XCTestCase {
         }
     }
 
-    func testConnectTimeout() {
+    func testConnectTimeout() throws {
+        #if os(Linux)
+        // 198.51.100.254 is reserved for documentation only and therefore should not accept any TCP connection
+        let url = "http://198.51.100.254/get"
+        #else
+        // on macOS we can use the TCP backlog behaviour when the queue is full to simulate a non reachable server.
+        // this makes this test a bit more stable if `198.51.100.254` actually responds to connection attempt.
+        // The backlog behaviour on Linux can not be used to simulate a non-reachable server.
+        // Linux sends a `SYN/ACK` back even if the `backlog` queue is full as it has two queues.
+        // The second queue is not limit by `ChannelOptions.backlog` but by `/proc/sys/net/ipv4/tcp_max_syn_backlog`.
+        
+        let serverChannel = try ServerBootstrap(group: self.serverGroup)
+            .serverChannelOption(ChannelOptions.backlog, value: 1)
+            .serverChannelOption(ChannelOptions.autoRead, value: false)
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try serverChannel.close().wait())
+        }
+        let port = serverChannel.localAddress!.port!
+        let firstClientChannel = try ClientBootstrap(group: self.serverGroup)
+            .connect(host: "127.0.0.1", port: port)
+            .wait()
+        defer {
+            XCTAssertNoThrow(try firstClientChannel.close().wait())
+        }
+        let url = "http://localhost:\(port)/get"
+        #endif
+        
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                     configuration: .init(timeout: .init(connect: .milliseconds(100), read: .milliseconds(150))))
 
@@ -648,9 +676,8 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try httpClient.syncShutdown())
         }
 
-        // This must throw as 198.51.100.254 is reserved for documentation only
-        XCTAssertThrowsError(try httpClient.get(url: "http://198.51.100.254/get").wait()) {
-            XCTAssertEqual($0 as? HTTPClientError, .connectTimeout)
+        XCTAssertThrowsError(try httpClient.get(url: url).wait()) {
+            XCTAssertEqualTypeAndValue($0, HTTPClientError.connectTimeout)
         }
     }
 


### PR DESCRIPTION
We have observed some test failures on our CI where `198.51.100.254` accepts connection but it shouldn't.
Luckily, this happens only on macOS and we can workaround this by creating a local TCP server with a backlog of `1`.
This server will only send a `SYN/ACK` back to the first connection as it doesn't actually accept the connection. Further connection attempts will not see a `SYN/ACK`. We can use this behaviour to test a connection timeout on macOS.

The backlog behaviour on Linux can not be used to simulate a non-reachable server. Linux sends a `SYN/ACK` back even if the `backlog` queue is full as it has two queues. The second queue is not limit by `ChannelOptions.backlog` but by `/proc/sys/net/ipv4/tcp_max_syn_backlog`. We will therefore fallback to `198.51.100.254` on Linux.