### PR TITLE
Use `swift-atomics` instead of `NIOAtomics`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,6 +27,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.10.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [
         .target(name: "CAsyncHTTPClient"),
@@ -46,6 +47,7 @@ let package = Package(
                 .product(name: "NIOSOCKS", package: "swift-nio-extras"),
                 .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Atomics", package: "swift-atomics"),
             ]
         ),
         .testTarget(
@@ -61,6 +63,7 @@ let package = Package(
                 .product(name: "NIOHTTP2", package: "swift-nio-http2"),
                 .product(name: "NIOSOCKS", package: "swift-nio-extras"),
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "Atomics", package: "swift-atomics"),
             ],
             resources: [
                 .copy("Resources/self_signed_cert.pem"),

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Atomics
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -165,14 +166,14 @@ extension HTTPConnectionPool.Connection.ID {
     static var globalGenerator = Generator()
 
     struct Generator {
-        private let atomic: NIOAtomic<Int>
+        private let atomic: ManagedAtomic<Int>
 
         init() {
-            self.atomic = .makeAtomic(value: 0)
+            self.atomic = .init(0)
         }
 
         func next() -> Int {
-            return self.atomic.add(1)
+            return self.atomic.loadThenWrappingIncrement(ordering: .relaxed)
         }
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 import AsyncHTTPClient
+import Atomics
 import Foundation
 import Logging
 import NIOConcurrencyHelpers

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 /* NOT @testable */ import AsyncHTTPClient // Tests that need @testable go into HTTPClientInternalTests.swift
+import Atomics
 #if canImport(Network)
 import Network
 #endif

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Atomics
 /* NOT @testable */ import AsyncHTTPClient // Tests that need @testable go into HTTPClientInternalTests.swift
 #if canImport(Network)
 import Network
@@ -1790,16 +1791,16 @@ class HTTPClientTests: XCTestCase {
             typealias InboundIn = HTTPServerRequestPart
             typealias OutboundOut = HTTPServerResponsePart
 
-            let requestNumber: NIOAtomic<Int>
-            let connectionNumber: NIOAtomic<Int>
+            let requestNumber: ManagedAtomic<Int>
+            let connectionNumber: ManagedAtomic<Int>
 
-            init(requestNumber: NIOAtomic<Int>, connectionNumber: NIOAtomic<Int>) {
+            init(requestNumber: ManagedAtomic<Int>, connectionNumber: ManagedAtomic<Int>) {
                 self.requestNumber = requestNumber
                 self.connectionNumber = connectionNumber
             }
 
             func channelActive(context: ChannelHandlerContext) {
-                _ = self.connectionNumber.add(1)
+                _ = self.connectionNumber.loadThenWrappingIncrement(ordering: .relaxed)
             }
 
             func channelRead(context: ChannelHandlerContext, data: NIOAny) {
@@ -1809,7 +1810,7 @@ class HTTPClientTests: XCTestCase {
                 case .head, .body:
                     ()
                 case .end:
-                    let last = self.requestNumber.add(1)
+                    let last = self.requestNumber.loadThenWrappingIncrement(ordering: .relaxed)
                     switch last {
                     case 0, 2:
                         context.write(self.wrapOutboundOut(.head(.init(version: .init(major: 1, minor: 1), status: .ok))),
@@ -1824,8 +1825,8 @@ class HTTPClientTests: XCTestCase {
             }
         }
 
-        let requestNumber = NIOAtomic<Int>.makeAtomic(value: 0)
-        let connectionNumber = NIOAtomic<Int>.makeAtomic(value: 0)
+        let requestNumber = ManagedAtomic(0)
+        let connectionNumber = ManagedAtomic(0)
         let sharedStateServerHandler = ServerThatAcceptsThenRejects(requestNumber: requestNumber,
                                                                     connectionNumber: connectionNumber)
         var maybeServer: Channel?
@@ -1854,19 +1855,19 @@ class HTTPClientTests: XCTestCase {
             XCTAssertNoThrow(try client.syncShutdown())
         }
 
-        XCTAssertEqual(0, sharedStateServerHandler.connectionNumber.load())
-        XCTAssertEqual(0, sharedStateServerHandler.requestNumber.load())
+        XCTAssertEqual(0, sharedStateServerHandler.connectionNumber.load(ordering: .relaxed))
+        XCTAssertEqual(0, sharedStateServerHandler.requestNumber.load(ordering: .relaxed))
         XCTAssertEqual(.ok, try client.get(url: url).wait().status)
-        XCTAssertEqual(1, sharedStateServerHandler.connectionNumber.load())
-        XCTAssertEqual(1, sharedStateServerHandler.requestNumber.load())
+        XCTAssertEqual(1, sharedStateServerHandler.connectionNumber.load(ordering: .relaxed))
+        XCTAssertEqual(1, sharedStateServerHandler.requestNumber.load(ordering: .relaxed))
         XCTAssertThrowsError(try client.get(url: url).wait().status) { error in
             XCTAssertEqual(.remoteConnectionClosed, error as? HTTPClientError)
         }
-        XCTAssertEqual(1, sharedStateServerHandler.connectionNumber.load())
-        XCTAssertEqual(2, sharedStateServerHandler.requestNumber.load())
+        XCTAssertEqual(1, sharedStateServerHandler.connectionNumber.load(ordering: .relaxed))
+        XCTAssertEqual(2, sharedStateServerHandler.requestNumber.load(ordering: .relaxed))
         XCTAssertEqual(.ok, try client.get(url: url).wait().status)
-        XCTAssertEqual(2, sharedStateServerHandler.connectionNumber.load())
-        XCTAssertEqual(3, sharedStateServerHandler.requestNumber.load())
+        XCTAssertEqual(2, sharedStateServerHandler.connectionNumber.load(ordering: .relaxed))
+        XCTAssertEqual(3, sharedStateServerHandler.requestNumber.load(ordering: .relaxed))
     }
 
     func testPoolClosesIdleConnections() {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+StateTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+StateTestUtils.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Atomics
 @testable import AsyncHTTPClient
+import Atomics
 import Dispatch
 import NIOConcurrencyHelpers
 import NIOCore

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+StateTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+StateTestUtils.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Atomics
 @testable import AsyncHTTPClient
 import Dispatch
 import NIOConcurrencyHelpers
@@ -21,14 +22,14 @@ import NIOEmbedded
 /// An `EventLoopGroup` of `EmbeddedEventLoop`s.
 final class EmbeddedEventLoopGroup: EventLoopGroup {
     private let loops: [EmbeddedEventLoop]
-    private let index = NIOAtomic<Int>.makeAtomic(value: 0)
+    private let index = ManagedAtomic(0)
 
     internal init(loops: Int) {
         self.loops = (0..<loops).map { _ in EmbeddedEventLoop() }
     }
 
     internal func next() -> EventLoop {
-        let index: Int = self.index.add(1)
+        let index: Int = self.index.loadThenWrappingIncrement(ordering: .relaxed)
         return self.loops[index % self.loops.count]
     }
 


### PR DESCRIPTION
`NIOAtomics` was deprecated in https://github.com/apple/swift-nio/pull/2204 in favor of `swift-atomics` https://github.com/apple/swift-atomics