### PR TITLE
Remove the last remaining NIOAtomic

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import Atomics
+import Foundation
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import Atomics
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -36,7 +37,7 @@ extension Logger {
     }
 }
 
-let globalRequestID = NIOAtomic<Int>.makeAtomic(value: 0)
+let globalRequestID = ManagedAtomic(0)
 
 /// HTTPClient class provides API for request execution.
 ///
@@ -541,7 +542,7 @@ public class HTTPClient {
         logger originalLogger: Logger?,
         redirectState: RedirectState?
     ) -> Task<Delegate.Response> {
-        let logger = (originalLogger ?? HTTPClient.loggingDisabled).attachingRequestInformation(request, requestID: globalRequestID.add(1))
+        let logger = (originalLogger ?? HTTPClient.loggingDisabled).attachingRequestInformation(request, requestID: globalRequestID.wrappingIncrementThenLoad(ordering: .relaxed))
         let taskEL: EventLoop
         switch eventLoopPreference.preference {
         case .indifferent:


### PR DESCRIPTION
Motivation

Warnings aren't great, and NIOAtomic is deprecated.

Modifications

Replace the last use of NIOAtomic with ManagedAtomic.

Result

Fewer warnings
Fixes #606