### PR TITLE
Report last connection error if request deadline is exceeded with async/await API

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -174,7 +174,9 @@ extension Transaction: HTTPExecutableRequest {
         switch action {
         case .cancel(let executor):
             executor.cancelRequest(self)
-
+        case .cancelAndFail(let executor, let continuation, with: let error):
+            executor.cancelRequest(self)
+            continuation.resume(throwing: error)
         case .none:
             break
         }
@@ -309,7 +311,8 @@ extension Transaction: HTTPExecutableRequest {
             scheduler?.cancelRequest(self)
             executor?.cancelRequest(self)
             bodyStreamContinuation?.resume(throwing: HTTPClientError.deadlineExceeded)
-
+        case .cancelSchedulerOnly(scheduler: let scheduler):
+            scheduler.cancelRequest(self)
         case .none:
             break
         }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -38,6 +38,7 @@ extension AsyncAwaitEndToEndTests {
             ("testCanceling", testCanceling),
             ("testDeadline", testDeadline),
             ("testImmediateDeadline", testImmediateDeadline),
+            ("testSelfSignedCertificateIsRejectedWithCorrectErrorIfRequestDeadlineIsExceeded", testSelfSignedCertificateIsRejectedWithCorrectErrorIfRequestDeadlineIsExceeded),
             ("testInvalidURL", testInvalidURL),
             ("testRedirectChangesHostHeader", testRedirectChangesHostHeader),
             ("testShutdown", testShutdown),

--- a/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests+XCTest.swift
@@ -28,7 +28,9 @@ extension Transaction_StateMachineTests {
             ("testRequestWasQueuedAfterWillExecuteRequestWasCalled", testRequestWasQueuedAfterWillExecuteRequestWasCalled),
             ("testRequestBodyStreamWasPaused", testRequestBodyStreamWasPaused),
             ("testQueuedRequestGetsRemovedWhenDeadlineExceeded", testQueuedRequestGetsRemovedWhenDeadlineExceeded),
+            ("testDeadlineExceededAndFullyFailedRequestCanBeCanceledWithNoEffect", testDeadlineExceededAndFullyFailedRequestCanBeCanceledWithNoEffect),
             ("testScheduledRequestGetsRemovedWhenDeadlineExceeded", testScheduledRequestGetsRemovedWhenDeadlineExceeded),
+            ("testDeadlineExceededRaceWithRequestWillExecute", testDeadlineExceededRaceWithRequestWillExecute),
             ("testRequestWithHeadReceivedGetNotCancelledWhenDeadlineExceeded", testRequestWithHeadReceivedGetNotCancelledWhenDeadlineExceeded),
         ]
     }

--- a/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests.swift
@@ -73,6 +73,7 @@ final class Transaction_StateMachineTests: XCTestCase {
     }
 
     func testQueuedRequestGetsRemovedWhenDeadlineExceeded() {
+        struct MyError: Error, Equatable {}
         #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
@@ -82,16 +83,62 @@ final class Transaction_StateMachineTests: XCTestCase {
 
                 state.requestWasQueued(queuer)
 
-                let failAction = state.deadlineExceeded()
-                guard case .cancel(let continuation, let scheduler, nil, nil) = failAction else {
+                let deadlineExceededAction = state.deadlineExceeded()
+                guard case .cancelSchedulerOnly(let scheduler) = deadlineExceededAction else {
+                    return XCTFail("Unexpected fail action: \(deadlineExceededAction)")
+                }
+                XCTAssertIdentical(scheduler as? MockTaskQueuer, queuer)
+
+                let failAction = state.fail(MyError())
+                guard case .failResponseHead(let continuation, let error, nil, nil, bodyStreamContinuation: nil) = failAction else {
                     return XCTFail("Unexpected fail action: \(failAction)")
                 }
                 XCTAssertIdentical(scheduler as? MockTaskQueuer, queuer)
 
-                continuation.resume(throwing: HTTPClientError.deadlineExceeded)
+                continuation.resume(throwing: error)
             }
 
-            await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround))
+            await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround)) {
+                XCTAssertEqualTypeAndValue($0, MyError())
+            }
+        }
+        #endif
+    }
+
+    func testDeadlineExceededAndFullyFailedRequestCanBeCanceledWithNoEffect() {
+        struct MyError: Error, Equatable {}
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        XCTAsyncTest {
+            func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
+                var state = Transaction.StateMachine(continuation)
+                let queuer = MockTaskQueuer()
+
+                state.requestWasQueued(queuer)
+
+                let deadlineExceededAction = state.deadlineExceeded()
+                guard case .cancelSchedulerOnly(let scheduler) = deadlineExceededAction else {
+                    return XCTFail("Unexpected fail action: \(deadlineExceededAction)")
+                }
+                XCTAssertIdentical(scheduler as? MockTaskQueuer, queuer)
+
+                let failAction = state.fail(MyError())
+                guard case .failResponseHead(let continuation, let error, nil, nil, bodyStreamContinuation: nil) = failAction else {
+                    return XCTFail("Unexpected fail action: \(failAction)")
+                }
+                XCTAssertIdentical(scheduler as? MockTaskQueuer, queuer)
+
+                let secondFailAction = state.fail(HTTPClientError.cancelled)
+                guard case .none = secondFailAction else {
+                    return XCTFail("Unexpected fail action: \(secondFailAction)")
+                }
+
+                continuation.resume(throwing: error)
+            }
+
+            await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround)) {
+                XCTAssertEqualTypeAndValue($0, MyError())
+            }
         }
         #endif
     }
@@ -119,6 +166,40 @@ final class Transaction_StateMachineTests: XCTestCase {
             }
 
             await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround))
+        }
+        #endif
+    }
+
+    func testDeadlineExceededRaceWithRequestWillExecute() {
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        let eventLoop = EmbeddedEventLoop()
+        XCTAsyncTest {
+            func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
+                var state = Transaction.StateMachine(continuation)
+                let expectedExecutor = MockRequestExecutor(eventLoop: eventLoop)
+                let queuer = MockTaskQueuer()
+
+                state.requestWasQueued(queuer)
+
+                let deadlineExceededAction = state.deadlineExceeded()
+                guard case .cancelSchedulerOnly(let scheduler) = deadlineExceededAction else {
+                    return XCTFail("Unexpected fail action: \(deadlineExceededAction)")
+                }
+                XCTAssertIdentical(scheduler as? MockTaskQueuer, queuer)
+
+                let failAction = state.willExecuteRequest(expectedExecutor)
+                guard case .cancelAndFail(let returnedExecutor, let continuation, with: let error) = failAction else {
+                    return XCTFail("Unexpected fail action: \(failAction)")
+                }
+                XCTAssertIdentical(returnedExecutor as? MockRequestExecutor, expectedExecutor)
+
+                continuation.resume(throwing: error)
+            }
+
+            await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround)) {
+                XCTAssertEqualTypeAndValue($0, HTTPClientError.deadlineExceeded)
+            }
         }
         #endif
     }


### PR DESCRIPTION
Port changes over from https://github.com/swift-server/async-http-client/pull/601 to the async/await API