### PR TITLE
Don’t call `didReceiveError` twice if deadline is exceeded and request is canceled afterwards

### DIFF
--- a/Tests/AsyncHTTPClientTests/RequestBagTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests+XCTest.swift
@@ -29,6 +29,7 @@ extension RequestBagTests {
             ("testTaskIsFailedIfWritingFails", testTaskIsFailedIfWritingFails),
             ("testCancelFailsTaskBeforeRequestIsSent", testCancelFailsTaskBeforeRequestIsSent),
             ("testDeadlineExceededFailsTaskEvenIfRaceBetweenCancelingSchedulerAndRequestStart", testDeadlineExceededFailsTaskEvenIfRaceBetweenCancelingSchedulerAndRequestStart),
+            ("testCancelHasNoEffectAfterDeadlineExceededFailsTask", testCancelHasNoEffectAfterDeadlineExceededFailsTask),
             ("testCancelFailsTaskAfterRequestIsSent", testCancelFailsTaskAfterRequestIsSent),
             ("testCancelFailsTaskWhenTaskIsQueued", testCancelFailsTaskWhenTaskIsQueued),
             ("testFailsTaskWhenTaskIsWaitingForMoreFromServer", testFailsTaskWhenTaskIsWaitingForMoreFromServer),


### PR DESCRIPTION
### Motivation
If the deadline is exceeded and the connection state machine fails the request with an error, we forgot to transition to the finished state in the `RequestBag`. A symptom of this is that a request could afterwards still be canceled from user code and it would trigger a second call to the delegates `didRecieveError` method.

### Modification
- transition to the finished state
- add a test which fails without the change above

### Result
`didReceiveError` can't be called twice