### PR TITLE
Support transparent decompression with HTTP/2

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -539,6 +539,9 @@ internal final class HTTPBin<RequestHandler: ChannelInboundHandler> where
                                 let sync = channel.pipeline.syncOperations
 
                                 try sync.addHandler(HTTP2FramePayloadToHTTP1ServerCodec())
+                                if self.mode.compress {
+                                    try sync.addHandler(HTTPResponseCompressor())
+                                }
                                 try sync.addHandler(self.handlerFactory(connectionID))
 
                                 return channel.eventLoop.makeSucceededVoidFuture()

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -66,6 +66,7 @@ extension HTTPClientTests {
             ("testUploadStreaming", testUploadStreaming),
             ("testEventLoopArgument", testEventLoopArgument),
             ("testDecompression", testDecompression),
+            ("testDecompressionHTTP2", testDecompressionHTTP2),
             ("testDecompressionLimit", testDecompressionLimit),
             ("testLoopDetectionRedirectLimit", testLoopDetectionRedirectLimit),
             ("testCountRedirectLimit", testCountRedirectLimit),


### PR DESCRIPTION
Fixes https://github.com/swift-server/async-http-client/issues/537