### PR TITLE
Accurately apply the connect timeout in async code

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -134,7 +134,7 @@ extension HTTPClient {
                     request: request,
                     requestOptions: .init(idleReadTimeout: nil),
                     logger: logger,
-                    connectionDeadline: deadline,
+                    connectionDeadline: .now() + (self.configuration.timeout.connectionCreationTimeout),
                     preferredEventLoop: eventLoop,
                     responseContinuation: continuation
                 )

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -604,7 +604,7 @@ public class HTTPClient {
                 eventLoopPreference: eventLoopPreference,
                 task: task,
                 redirectHandler: redirectHandler,
-                connectionDeadline: .now() + (self.configuration.timeout.connect ?? .seconds(10)),
+                connectionDeadline: .now() + (self.configuration.timeout.connectionCreationTimeout),
                 requestOptions: .fromClientConfiguration(self.configuration),
                 delegate: delegate
             )

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -38,6 +38,7 @@ extension AsyncAwaitEndToEndTests {
             ("testCanceling", testCanceling),
             ("testDeadline", testDeadline),
             ("testImmediateDeadline", testImmediateDeadline),
+            ("testConnectTimeout", testConnectTimeout),
             ("testSelfSignedCertificateIsRejectedWithCorrectErrorIfRequestDeadlineIsExceeded", testSelfSignedCertificateIsRejectedWithCorrectErrorIfRequestDeadlineIsExceeded),
             ("testInvalidURL", testInvalidURL),
             ("testRedirectChangesHostHeader", testRedirectChangesHostHeader),


### PR DESCRIPTION
Motivation

We should apply the connect timeout to the complete set of connection
attempts, rather than the request deadline. This allows users
fine-grained control over how long we attempt to connect for. This is
also the behaviour of our old-school interface.

Modifications

- Changed the connect deadline calculation for async/await to match that
  of the future-based code.
- Added a connect timeout test.

Result

Connect timeouts are properly handled