### PR TITLE
Tollerate more data after request body is cancelled

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -431,11 +431,11 @@ extension Transaction {
 
             case .executing(_, _, .buffering(_, _, next: .endOfFile)):
                 preconditionFailure("If we have received an eof before, why did we get another body part?")
-                
+
             case .executing(_, _, .buffering(_, _, next: .error)):
                 // we might still get pending buffers if the user has canceled the request
                 return .none
-                
+
             case .executing(let context, let requestState, .buffering(let streamID, var currentBuffer, next: .askExecutorForMore)):
                 if currentBuffer.isEmpty {
                     currentBuffer = buffer
@@ -444,7 +444,7 @@ extension Transaction {
                 }
                 self.state = .executing(context, requestState, .buffering(streamID, currentBuffer, next: .askExecutorForMore))
                 return .none
-            
+
             case .executing(let executor, let requestState, .waitingForResponseIterator(var currentBuffer, next: let next)):
                 guard case .askExecutorForMore = next else {
                     preconditionFailure("If we have received an error or eof before, why did we get another body part? Next: \(next)")

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -429,19 +429,22 @@ extension Transaction {
             case .executing(_, _, .waitingForResponseHead):
                 preconditionFailure("If we receive a response body, we must have received a head before")
 
-            case .executing(let context, let requestState, .buffering(let streamID, var currentBuffer, next: let next)):
-                guard case .askExecutorForMore = next else {
-                    preconditionFailure("If we have received an error or eof before, why did we get another body part? Next: \(next)")
-                }
-
+            case .executing(_, _, .buffering(_, _, next: .endOfFile)):
+                preconditionFailure("If we have received an eof before, why did we get another body part?")
+                
+            case .executing(_, _, .buffering(_, _, next: .error)):
+                // we might still get pending buffers if the user has canceled the request
+                return .none
+                
+            case .executing(let context, let requestState, .buffering(let streamID, var currentBuffer, next: .askExecutorForMore)):
                 if currentBuffer.isEmpty {
                     currentBuffer = buffer
                 } else {
                     currentBuffer.append(contentsOf: buffer)
                 }
-                self.state = .executing(context, requestState, .buffering(streamID, currentBuffer, next: next))
+                self.state = .executing(context, requestState, .buffering(streamID, currentBuffer, next: .askExecutorForMore))
                 return .none
-
+            
             case .executing(let executor, let requestState, .waitingForResponseIterator(var currentBuffer, next: let next)):
                 guard case .askExecutorForMore = next else {
                     preconditionFailure("If we have received an error or eof before, why did we get another body part? Next: \(next)")
@@ -690,10 +693,11 @@ extension Transaction {
             case .finished:
                 // the request failed or was cancelled before, we can ignore all events
                 return .none
-
+            case .executing(_, _, .buffering(_, _, next: .error)):
+                // we might still get pending buffers if the user has canceled the request
+                return .none
             case .executing(_, _, .waitingForResponseIterator(_, next: .error)),
                  .executing(_, _, .waitingForResponseIterator(_, next: .endOfFile)),
-                 .executing(_, _, .buffering(_, _, next: .error)),
                  .executing(_, _, .buffering(_, _, next: .endOfFile)),
                  .executing(_, _, .finished(_, _)):
                 preconditionFailure("Already received an eof or error before. Must not receive further events. Invalid state: \(self.state)")

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -43,6 +43,7 @@ extension AsyncAwaitEndToEndTests {
             ("testInvalidURL", testInvalidURL),
             ("testRedirectChangesHostHeader", testRedirectChangesHostHeader),
             ("testShutdown", testShutdown),
+            ("testCancelingBodyDoesNotCrash", testCancelingBodyDoesNotCrash),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -610,9 +610,3 @@ extension AsyncSequence where Element == ByteBuffer {
     }
 }
 #endif
-
-extension NIOTooManyBytesError: Equatable {
-    public static func == (lhs: NIOTooManyBytesError, rhs: NIOTooManyBytesError) -> Bool {
-        true
-    }
-}

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -578,7 +578,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         }
         #endif
     }
-    
+
     /// Regression test for https://github.com/swift-server/async-http-client/issues/612
     func testCancelingBodyDoesNotCrash() {
         #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -588,10 +588,10 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
             let bin = HTTPBin(.http2(compress: true))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
-            
+
             let request = HTTPClientRequest(url: "https://127.0.0.1:\(bin.port)/mega-chunked")
             let response = try await client.execute(request, deadline: .now() + .seconds(1))
-            
+
             await XCTAssertThrowsError(try await response.body.collect(upTo: 100)) { error in
                 XCTAssert(error is NIOTooManyBytesError)
             }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -579,30 +579,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         #endif
     }
     
-    func test() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
-        XCTAsyncTest {
-            let client = HTTPClient(eventLoopGroupProvider: .createNew)
-            
-            defer { XCTAssertNoThrow(try client.syncShutdown()) }
-            
-            var request = HTTPClientRequest(url: "http://api.weather.gov/zones/forecast/AKZ026/forecast")
-            request.headers.add(name: "User-Agent", value: "Swift HTTPClient")
-            let response = try await client.execute(request, deadline: .now() + .seconds(10))
-            
-            let maxBodySize = 1024 * 1024
-        
-            await XCTAssertThrowsError(try await response.body.collect(upTo: maxBodySize)) { error in
-                XCTAssert(error is NIOTooManyBytesError)
-            }
-            
-            // we need to wait a bit to receive more packets before we shutdown the HTTPClient
-            try await Task.sleep(nanoseconds: UInt64(TimeAmount.milliseconds(100).nanoseconds))
-        }
-        #endif
-    }
-    
     /// Regression test for https://github.com/swift-server/async-http-client/issues/612
     func testCancelingBodyDoesNotCrash() {
         #if compiler(>=5.5.2) && canImport(_Concurrency)

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -619,9 +619,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             await XCTAssertThrowsError(try await response.body.collect(upTo: 100)) { error in
                 XCTAssert(error is NIOTooManyBytesError)
             }
-            
-            // we need to wait a bit to receive more packets before we shutdown the HTTPClient
-            try await Task.sleep(nanoseconds: UInt64(TimeAmount.milliseconds(100).nanoseconds))
         }
         #endif
     }

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -590,7 +590,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             defer { XCTAssertNoThrow(try bin.shutdown()) }
 
             let request = HTTPClientRequest(url: "https://127.0.0.1:\(bin.port)/mega-chunked")
-            let response = try await client.execute(request, deadline: .now() + .seconds(1))
+            let response = try await client.execute(request, deadline: .now() + .seconds(10))
 
             await XCTAssertThrowsError(try await response.body.collect(upTo: 100)) { error in
                 XCTAssert(error is NIOTooManyBytesError)

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -578,6 +578,53 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         }
         #endif
     }
+    
+    func test() {
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        XCTAsyncTest {
+            let client = HTTPClient(eventLoopGroupProvider: .createNew)
+            
+            defer { XCTAssertNoThrow(try client.syncShutdown()) }
+            
+            var request = HTTPClientRequest(url: "http://api.weather.gov/zones/forecast/AKZ026/forecast")
+            request.headers.add(name: "User-Agent", value: "Swift HTTPClient")
+            let response = try await client.execute(request, deadline: .now() + .seconds(10))
+            
+            let maxBodySize = 1024 * 1024
+        
+            await XCTAssertThrowsError(try await response.body.collect(upTo: maxBodySize)) { error in
+                XCTAssert(error is NIOTooManyBytesError)
+            }
+            
+            // we need to wait a bit to receive more packets before we shutdown the HTTPClient
+            try await Task.sleep(nanoseconds: UInt64(TimeAmount.milliseconds(100).nanoseconds))
+        }
+        #endif
+    }
+    
+    /// Regression test for https://github.com/swift-server/async-http-client/issues/612
+    func testCancelingBodyDoesNotCrash() {
+        #if compiler(>=5.5.2) && canImport(_Concurrency)
+        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
+        XCTAsyncTest {
+            let client = makeDefaultHTTPClient()
+            defer { XCTAssertNoThrow(try client.syncShutdown()) }
+            let bin = HTTPBin(.http2(compress: true))
+            defer { XCTAssertNoThrow(try bin.shutdown()) }
+            
+            let request = HTTPClientRequest(url: "https://127.0.0.1:\(bin.port)/mega-chunked")
+            let response = try await client.execute(request, deadline: .now() + .seconds(1))
+            
+            await XCTAssertThrowsError(try await response.body.collect(upTo: 100)) { error in
+                XCTAssert(error is NIOTooManyBytesError)
+            }
+            
+            // we need to wait a bit to receive more packets before we shutdown the HTTPClient
+            try await Task.sleep(nanoseconds: UInt64(TimeAmount.milliseconds(100).nanoseconds))
+        }
+        #endif
+    }
 }
 
 #if compiler(>=5.5.2) && canImport(_Concurrency)
@@ -590,3 +637,9 @@ extension AsyncSequence where Element == ByteBuffer {
     }
 }
 #endif
+
+extension NIOTooManyBytesError: Equatable {
+    public static func == (lhs: NIOTooManyBytesError, rhs: NIOTooManyBytesError) -> Bool {
+        true
+    }
+}


### PR DESCRIPTION
We might still get pending buffers if the user has canceled the request because they might already be enqueued to be delivered. We therefore need to tolerate buffers after we are in the error state.

Fixes https://github.com/swift-server/async-http-client/issues/612