### PR TITLE
Use NIOCore.System.coreCount for the fileIO thread pool

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -269,7 +269,7 @@ public class HTTPClient {
     private func makeOrGetFileIOThreadPool() -> NIOThreadPool {
         self.fileIOThreadPoolLock.withLock {
             guard let fileIOThreadPool = fileIOThreadPool else {
-                let fileIOThreadPool = NIOThreadPool(numberOfThreads: ProcessInfo.processInfo.processorCount)
+                let fileIOThreadPool = NIOThreadPool(numberOfThreads: System.coreCount)
                 fileIOThreadPool.start()
                 self.fileIOThreadPool = fileIOThreadPool
                 return fileIOThreadPool


### PR DESCRIPTION
`ProcessInfo` is a Foundation API, so this broke the Foundationless build