### PR TITLE
Allow `HTTPClientRequest` to be executed multiple times if `body` is an `AsyncSequence`

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -194,7 +194,7 @@ extension Transaction: HTTPExecutableRequest {
             break
 
         case .startStream(let allocator):
-            switch self.request.body?.mode {
+            switch self.request.body {
             case .asyncSequence(_, let next):
                 // it is safe to call this async here. it dispatches...
                 self.continueRequestBodyStream(allocator, next: next)

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests+XCTest.swift
@@ -44,6 +44,7 @@ extension AsyncAwaitEndToEndTests {
             ("testRedirectChangesHostHeader", testRedirectChangesHostHeader),
             ("testShutdown", testShutdown),
             ("testCancelingBodyDoesNotCrash", testCancelingBodyDoesNotCrash),
+            ("testAsyncSequenceReuse", testAsyncSequenceReuse),
         ]
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -489,11 +489,11 @@ private struct LengthMismatch: Error {
 }
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-extension Optional where Wrapped == HTTPClientRequest.Body {
+extension Optional where Wrapped == HTTPClientRequest.Prepared.Body {
     /// Accumulates all data from `self` into a single `ByteBuffer` and checks that the user specified length matches
     /// the length of the accumulated data.
     fileprivate func read() async throws -> ByteBuffer {
-        switch self?.mode {
+        switch self {
         case .none:
             return ByteBuffer()
         case .byteBuffer(let buffer):


### PR DESCRIPTION
### Motivation
`AsyncSequence.makeAsyncIterator()` was only called once during the creation of `HTTPClientRequest.Body` and would have been shared if an `HTTPClientRequest` is executed a second time. 

### Modification
- call `AsyncSequence.makeAsyncIterator()` for each invocation of `HTTPClient.execute`
- create a test which would previously fail

### Result
We no longer share the `AsyncIterator` between different request executions. If the given `AsyncSequence` actually supports multiple iterators, and therefore can be correctly used by multiple request executions, depends on the concrete type though. 