### PR TITLE
Replace Lock with NIOLock

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.41.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.42.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.22.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.13.0"),

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -29,7 +29,7 @@ final class Transaction: @unchecked Sendable {
     let preferredEventLoop: EventLoop
     let requestOptions: RequestOptions
 
-    private let stateLock = Lock()
+    private let stateLock = NIOLock()
     private var state: StateMachine
 
     init(

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Manager.swift
@@ -35,7 +35,7 @@ extension HTTPConnectionPool {
 
         private var state: State = .active
         private var _pools: [Key: HTTPConnectionPool] = [:]
-        private let lock = Lock()
+        private let lock = NIOLock()
 
         private let sslContextCache = SSLContextCache()
 

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -22,7 +22,7 @@ protocol HTTPConnectionPoolDelegate {
 }
 
 final class HTTPConnectionPool {
-    private let stateLock = Lock()
+    private let stateLock = NIOLock()
     private var _state: StateMachine
     /// The connection idle timeout timers. Protected by the stateLock
     private var _idleTimer = [Connection.ID: Scheduled<Void>]()

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -75,10 +75,10 @@ public class HTTPClient {
 
     /// Shared thread pool used for file IO. It is lazily created on first access of ``Task/fileIOThreadPool``.
     private var fileIOThreadPool: NIOThreadPool?
-    private let fileIOThreadPoolLock = Lock()
+    private let fileIOThreadPoolLock = NIOLock()
 
     private var state: State
-    private let stateLock = Lock()
+    private let stateLock = NIOLock()
 
     internal static let loggingDisabled = Logger(label: "AHC-do-not-log", factory: { _ in SwiftLogNoOpLogHandler() })
 
@@ -169,7 +169,7 @@ public class HTTPClient {
             Current eventLoop: \(eventLoop)
             """)
         }
-        let errorStorageLock = Lock()
+        let errorStorageLock = NIOLock()
         let errorStorage: UnsafeMutableTransferBox<Error?> = .init(nil)
         let continuation = DispatchWorkItem {}
         self.shutdown(requiresCleanClose: requiresCleanClose, queue: DispatchQueue(label: "async-http-client.shutdown")) { error in
@@ -256,7 +256,7 @@ public class HTTPClient {
     }
 
     private func shutdownFileIOThreadPool(queue: DispatchQueue, _ callback: @escaping ShutdownCallback) {
-        self.fileIOThreadPoolLock.withLockVoid {
+        self.fileIOThreadPoolLock.withLock {
             guard let fileIOThreadPool = fileIOThreadPool else {
                 callback(nil)
                 return

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -657,7 +657,7 @@ extension HTTPClient {
 
         private var _isCancelled: Bool = false
         private var _taskDelegate: HTTPClientTaskDelegate?
-        private let lock = Lock()
+        private let lock = NIOLock()
         private let makeOrGetFileIOThreadPool: () -> NIOThreadPool
 
         /// The shared thread pool of a ``HTTPClient`` used for file IO. It is lazily created on first access.

--- a/Sources/AsyncHTTPClient/SSLContextCache.swift
+++ b/Sources/AsyncHTTPClient/SSLContextCache.swift
@@ -19,7 +19,7 @@ import NIOCore
 import NIOSSL
 
 final class SSLContextCache {
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var sslContextCache = LRUCache<BestEffortHashableTLSConfiguration, NIOSSLContext>()
     private let offloadQueue = DispatchQueue(label: "io.github.swift-server.AsyncHTTPClient.SSLContextCache")
 }

--- a/Tests/AsyncHTTPClientTests/AsyncTestHelpers.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncTestHelpers.swift
@@ -45,7 +45,7 @@ final class AsyncSequenceWriter<Element>: AsyncSequence, @unchecked Sendable {
     }
 
     private var _state = State.buffering(.init(), nil)
-    private let lock = Lock()
+    private let lock = NIOLock()
 
     public var hasDemand: Bool {
         self.lock.withLock {

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
@@ -595,12 +595,12 @@ class HTTP1ConnectionTests: XCTestCase {
             var _reads = 0
             var _channel: Channel?
 
-            let lock: Lock
+            let lock: NIOLock
             let backpressurePromise: EventLoopPromise<Void>
             let messageReceived: EventLoopPromise<Void>
 
             init(eventLoop: EventLoop) {
-                self.lock = Lock()
+                self.lock = NIOLock()
                 self.backpressurePromise = eventLoop.makePromise()
                 self.messageReceived = eventLoop.makePromise()
             }
@@ -612,7 +612,7 @@ class HTTP1ConnectionTests: XCTestCase {
             }
 
             func willExecuteOnChannel(_ channel: Channel) {
-                self.lock.withLockVoid {
+                self.lock.withLock {
                     self._channel = channel
                 }
             }
@@ -623,7 +623,7 @@ class HTTP1ConnectionTests: XCTestCase {
 
             func didReceiveBodyPart(task: HTTPClient.Task<Response>, _ buffer: ByteBuffer) -> EventLoopFuture<Void> {
                 // We count a number of reads received.
-                self.lock.withLockVoid {
+                self.lock.withLock {
                     self._reads += 1
                 }
                 // We need to notify the test when first byte of the message is arrived.
@@ -805,7 +805,7 @@ class AfterRequestCloseConnectionChannelHandler: ChannelInboundHandler {
 }
 
 class MockConnectionDelegate: HTTP1ConnectionDelegate {
-    private var lock = Lock()
+    private var lock = NIOLock()
 
     private var _hitConnectionReleased = 0
     private var _hitConnectionClosed = 0
@@ -821,13 +821,13 @@ class MockConnectionDelegate: HTTP1ConnectionDelegate {
     init() {}
 
     func http1ConnectionReleased(_: HTTP1Connection) {
-        self.lock.withLockVoid {
+        self.lock.withLock {
             self._hitConnectionReleased += 1
         }
     }
 
     func http1ConnectionClosed(_: HTTP1Connection) {
-        self.lock.withLockVoid {
+        self.lock.withLock {
             self._hitConnectionClosed += 1
         }
     }

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -235,7 +235,7 @@ class TestConnectionCreator {
     }
 
     private var state: State = .idle
-    private let lock = Lock()
+    private let lock = NIOLock()
 
     init() {}
 
@@ -428,7 +428,7 @@ class TestHTTP2ConnectionDelegate: HTTP2ConnectionDelegate {
         self.lock.withLock { self._maxStreamSetting }
     }
 
-    private let lock = Lock()
+    private let lock = NIOLock()
     private var _hitStreamClosed: Int = 0
     private var _hitGoAwayReceived: Int = 0
     private var _hitConnectionClosed: Int = 0
@@ -439,19 +439,19 @@ class TestHTTP2ConnectionDelegate: HTTP2ConnectionDelegate {
     func http2Connection(_: HTTP2Connection, newMaxStreamSetting: Int) {}
 
     func http2ConnectionStreamClosed(_: HTTP2Connection, availableStreams: Int) {
-        self.lock.withLockVoid {
+        self.lock.withLock {
             self._hitStreamClosed += 1
         }
     }
 
     func http2ConnectionGoAwayReceived(_: HTTP2Connection) {
-        self.lock.withLockVoid {
+        self.lock.withLock {
             self._hitGoAwayReceived += 1
         }
     }
 
     func http2ConnectionClosed(_: HTTP2Connection) {
-        self.lock.withLockVoid {
+        self.lock.withLock {
             self._hitConnectionClosed += 1
         }
     }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -1118,7 +1118,7 @@ struct CollectEverythingLogHandler: LogHandler {
             var metadata: [String: String]
         }
 
-        var lock = Lock()
+        var lock = NIOLock()
         var logs: [Entry] = []
 
         var allEntries: [Entry] {


### PR DESCRIPTION
SwiftNIO 2.42.0 has deprecated Lock and replaced it with a new NIOLock. This commit removes all uses of Lock and replaces them with NIOLock. Further now we must require SwiftNIO 2.42.0