### PR TITLE
Handle ResponseAccumulator not being able to buffer large response in memory

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -367,8 +367,8 @@ public class ResponseAccumulator: HTTPClientResponseDelegate {
         case error(Error)
     }
 
-    struct ResponseTooBigError: Error, CustomStringConvertible {
-        var description: String {
+    public struct ResponseTooBigError: Error, CustomStringConvertible {
+        public var description: String {
             return "ResponseTooBigError: writing response part would exceed internal storage capacity."
         }
     }


### PR DESCRIPTION
## Motivation

If the response being buffered by the `ResponseAccumulator` is too large (larger than `UInt32.max`), a crash will occur.

## Modifications

* Check that the number of bytes being written won't cause the buffer to go over the limit. If it does, return a failed future from `didReceiveBodyPart(task:_:)`
* Created a new `ResponseTooBigError` to be used with the failed future.

## Result

Will now fail graciously if too big a response is buffered in memory via the `ResponseAccumulator`.