### PR TITLE
Add `Hashable` conformance to `HTTPClient.Configuration.Proxy`

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient+Proxy.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+Proxy.swift
@@ -25,7 +25,7 @@ extension HTTPClient.Configuration {
     /// If a `TLSConfiguration` is used in conjunction with `HTTPClient.Configuration.Proxy`,
     /// TLS will be established _after_ successful proxy, between your client
     /// and the destination server.
-    public struct Proxy: NIOSendable {
+    public struct Proxy: NIOSendable, Hashable {
         enum ProxyType: Hashable {
             case http(HTTPClient.Authorization?)
             case socks


### PR DESCRIPTION
### Motivation

If we want to make progress on a 2/3-tier design, we need to take proxy settings into account for pool keying.

### Changes

- Make `HTTPClient.Configuration.Proxy` hashable