### PR TITLE
Reduce use of `HTTPClient.Configuration` in the Connection objects

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1Connection.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1Connection.swift
@@ -57,11 +57,11 @@ final class HTTP1Connection {
         channel: Channel,
         connectionID: HTTPConnectionPool.Connection.ID,
         delegate: HTTP1ConnectionDelegate,
-        configuration: HTTPClient.Configuration,
+        decompression: HTTPClient.Decompression,
         logger: Logger
     ) throws -> HTTP1Connection {
         let connection = HTTP1Connection(channel: channel, connectionID: connectionID, delegate: delegate)
-        try connection.start(configuration: configuration, logger: logger)
+        try connection.start(decompression: decompression, logger: logger)
         return connection
     }
 
@@ -101,7 +101,7 @@ final class HTTP1Connection {
         self.channel.write(request, promise: nil)
     }
 
-    private func start(configuration: HTTPClient.Configuration, logger: Logger) throws {
+    private func start(decompression: HTTPClient.Decompression, logger: Logger) throws {
         self.channel.eventLoop.assertInEventLoop()
 
         guard case .initialized = self.state else {
@@ -127,7 +127,7 @@ final class HTTP1Connection {
             try sync.addHandler(requestEncoder)
             try sync.addHandler(ByteToMessageHandler(responseDecoder))
 
-            if case .enabled(let limit) = configuration.decompression {
+            if case .enabled(let limit) = decompression {
                 let decompressHandler = NIOHTTPResponseDecompressor(limit: limit)
                 try sync.addHandler(decompressHandler)
             }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
@@ -119,10 +119,16 @@ final class HTTP2Connection {
         channel: Channel,
         connectionID: HTTPConnectionPool.Connection.ID,
         delegate: HTTP2ConnectionDelegate,
-        configuration: HTTPClient.Configuration,
+        decompression: HTTPClient.Decompression,
         logger: Logger
     ) -> EventLoopFuture<(HTTP2Connection, Int)> {
-        let connection = HTTP2Connection(channel: channel, connectionID: connectionID, decompression: configuration.decompression, delegate: delegate, logger: logger)
+        let connection = HTTP2Connection(
+            channel: channel,
+            connectionID: connectionID,
+            decompression: decompression,
+            delegate: delegate,
+            logger: logger
+        )
         return connection.start().map { maxStreams in (connection, maxStreams) }
     }
 

--- a/Tests/AsyncHTTPClientTests/EmbeddedChannel+HTTPConvenience.swift
+++ b/Tests/AsyncHTTPClientTests/EmbeddedChannel+HTTPConvenience.swift
@@ -77,7 +77,7 @@ extension EmbeddedChannel {
             channel: self,
             connectionID: 1,
             delegate: connectionDelegate,
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         )
 

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionTests.swift
@@ -35,7 +35,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: MockHTTP1ConnectionDelegate(),
-            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            decompression: .enabled(limit: .ratio(4)),
             logger: logger
         ))
 
@@ -58,7 +58,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: MockHTTP1ConnectionDelegate(),
-            configuration: .init(decompression: .disabled),
+            decompression: .disabled,
             logger: logger
         ))
 
@@ -82,7 +82,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: MockHTTP1ConnectionDelegate(),
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         ))
     }
@@ -106,7 +106,7 @@ class HTTP1ConnectionTests: XCTestCase {
                     channel: $0,
                     connectionID: 0,
                     delegate: delegate,
-                    configuration: .init(decompression: .disabled),
+                    decompression: .disabled,
                     logger: logger
                 )
             }
@@ -206,7 +206,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: XCTUnwrap(maybeChannel),
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         ) }.wait())
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection here") }
@@ -260,7 +260,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: XCTUnwrap(maybeChannel),
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         ) }.wait())
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection here") }
@@ -332,7 +332,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: XCTUnwrap(maybeChannel),
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         ) }.wait())
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection here") }
@@ -377,7 +377,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            decompression: .enabled(limit: .ratio(4)),
             logger: logger
         ))
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection at this point.") }
@@ -442,7 +442,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            decompression: .enabled(limit: .ratio(4)),
             logger: logger
         ))
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection at this point.") }
@@ -504,7 +504,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            decompression: .enabled(limit: .ratio(4)),
             logger: logger
         ))
 
@@ -539,7 +539,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(decompression: .enabled(limit: .ratio(4))),
+            decompression: .enabled(limit: .ratio(4)),
             logger: logger
         ))
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection at this point.") }
@@ -691,7 +691,7 @@ class HTTP1ConnectionTests: XCTestCase {
             channel: channel,
             connectionID: 0,
             delegate: connectionDelegate,
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         ) }.wait())
         guard let connection = maybeConnection else { return XCTFail("Expected to have a connection at this point") }

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -37,7 +37,7 @@ class HTTP2ConnectionTests: XCTestCase {
             channel: embedded,
             connectionID: 0,
             delegate: TestHTTP2ConnectionDelegate(),
-            configuration: .init(),
+            decompression: .disabled,
             logger: logger
         ).wait())
     }


### PR DESCRIPTION
### Motivation

If we introduce a new 2/3 tier design, we have a new configuration object next to `HTTPClient.Configuration`. To prepare the way, we should reduce the areas in which we rely on `HTTPClient.Configuration` directly.

### Changes

- Depend on only the decompression settings in `HTTP1Connection` and `HTTP2Connection`
- Remove dead/unused code