### PR TITLE
Add `Hashable` conformance to `HTTPClient.Configuration.HTTPVersion`

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -985,7 +985,7 @@ extension HTTPClient.Configuration {
         }
     }
 
-    public struct HTTPVersion: NIOSendable {
+    public struct HTTPVersion: NIOSendable, Hashable {
         internal enum Configuration {
             case http1Only
             case automatic


### PR DESCRIPTION
### Motivation

If we want to make progress on a 2/3-tier design, we need to take the http version settings into account for pool keying.

### Changes

- Make `HTTPClient.Configuration.HTTPVersion` hashable