### PR TITLE
Replace `NIOSendable` with `Sendable`

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/RequestBodyLength.swift
@@ -16,7 +16,7 @@ import NIOCore
 
 /// - Note: use `HTTPClientRequest.Body.Length` if you want to expose `RequestBodyLength` publicly
 @usableFromInline
-internal enum RequestBodyLength: Hashable, NIOSendable {
+internal enum RequestBodyLength: Hashable, Sendable {
     /// size of the request body is not known before starting the request
     case unknown
     /// size of the request body is fixed and exactly `count` bytes

--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -23,7 +23,7 @@ import NIOCore
 
 extension HTTPClient {
     /// A representation of an HTTP cookie.
-    public struct Cookie: NIOSendable {
+    public struct Cookie: Sendable {
         /// The name of the cookie.
         public var name: String
         /// The cookie's string value.

--- a/Sources/AsyncHTTPClient/HTTPClient+Proxy.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+Proxy.swift
@@ -25,7 +25,7 @@ extension HTTPClient.Configuration {
     /// If a `TLSConfiguration` is used in conjunction with `HTTPClient.Configuration.Proxy`,
     /// TLS will be established _after_ successful proxy, between your client
     /// and the destination server.
-    public struct Proxy: NIOSendable, Hashable {
+    public struct Proxy: Sendable, Hashable {
         enum ProxyType: Hashable {
             case http(HTTPClient.Authorization?)
             case socks

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -875,7 +875,7 @@ public class HTTPClient {
     }
 
     /// Specifies decompression settings.
-    public enum Decompression: NIOSendable {
+    public enum Decompression: Sendable {
         /// Decompression is disabled.
         case disabled
         /// Decompression is enabled.
@@ -911,7 +911,7 @@ extension HTTPClient: @unchecked Sendable {}
 
 extension HTTPClient.Configuration {
     /// Timeout configuration.
-    public struct Timeout: NIOSendable {
+    public struct Timeout: Sendable {
         /// Specifies connect timeout. If no connect timeout is given, a default 30 seconds timeout will applied.
         public var connect: TimeAmount?
         /// Specifies read timeout.
@@ -934,7 +934,7 @@ extension HTTPClient.Configuration {
     }
 
     /// Specifies redirect processing settings.
-    public struct RedirectConfiguration: NIOSendable {
+    public struct RedirectConfiguration: Sendable {
         enum Mode {
             /// Redirects are not followed.
             case disallow
@@ -966,7 +966,7 @@ extension HTTPClient.Configuration {
     }
 
     /// Connection pool configuration.
-    public struct ConnectionPool: Hashable, NIOSendable {
+    public struct ConnectionPool: Hashable, Sendable {
         /// Specifies amount of time connections are kept idle in the pool. After this time has passed without a new
         /// request the connections are closed.
         public var idleTimeout: TimeAmount
@@ -995,7 +995,7 @@ extension HTTPClient.Configuration {
         }
     }
 
-    public struct HTTPVersion: NIOSendable, Hashable {
+    public struct HTTPVersion: Sendable, Hashable {
         internal enum Configuration {
             case http1Only
             case automatic

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -311,7 +311,7 @@ extension HTTPClient {
     }
 
     /// HTTP authentication.
-    public struct Authorization: Hashable, NIOSendable {
+    public struct Authorization: Hashable, Sendable {
         private enum Scheme: Hashable {
             case Basic(String)
             case Bearer(String)


### PR DESCRIPTION
We now require Swift 5.5.2 which includes `Sendable` so we no longer require the `NIOSendable` workaround.
`NIOSendable` is just a `typealias` of `Sendable` so this is a non source breaking change.
This allows `swift-nio` to eventually deprecate `NIOSendable`.