### PR TITLE
Remove `#if compiler(>=5.5)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,11 +329,11 @@ Please have a look at [SECURITY.md](SECURITY.md) for AsyncHTTPClient's security 
 
 ## Supported Versions
 
-The most recent versions of AsyncHTTPClient support Swift 5.5 and newer. The minimum Swift version supported by AsyncHTTPClient releases are detailed below:
+The most recent versions of AsyncHTTPClient support Swift 5.5.2 and newer. The minimum Swift version supported by AsyncHTTPClient releases are detailed below:
 
 AsyncHTTPClient     | Minimum Swift Version
 --------------------|----------------------
 `1.0.0 ..< 1.5.0`   | 5.0
 `1.5.0 ..< 1.10.0`  | 5.2
 `1.10.0 ..< 1.13.0` | 5.4
-`1.13.0 ...`        | 5.5
+`1.13.0 ...`        | 5.5.2

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 import struct Foundation.URL
 import Logging
 import NIOCore
@@ -215,5 +214,3 @@ private actor TransactionCancelHandler {
         }
     }
 }
-
-#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+shutdown.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+shutdown.swift
@@ -14,8 +14,6 @@
 
 import NIOCore
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
-
 extension HTTPClient {
     /// Shuts down the client and `EventLoopGroup` if it was created by the client.
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
@@ -33,4 +31,3 @@ extension HTTPClient {
     }
 }
 
-#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+shutdown.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+shutdown.swift
@@ -30,4 +30,3 @@ extension HTTPClient {
         }
     }
 }
-

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 import struct Foundation.URL
 import NIOCore
 import NIOHTTP1
@@ -122,5 +121,3 @@ extension HTTPClientRequest {
         return newRequest
     }
 }
-
-#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 import NIOCore
 import NIOHTTP1
 
@@ -424,5 +423,3 @@ extension HTTPClientRequest.Body {
         internal var storage: RequestBodyLength
     }
 }
-
-#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 import NIOCore
 import NIOHTTP1
 
@@ -154,5 +153,3 @@ extension HTTPClientResponse.Body {
         .stream(CollectionOfOne(byteBuffer).async)
     }
 }
-
-#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+
 import Logging
 import NIOCore
 import NIOHTTP1
@@ -765,5 +765,3 @@ extension Transaction {
         }
     }
 }
-
-#endif

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -362,4 +361,3 @@ extension Transaction {
         self.performFailAction(action)
     }
 }
-#endif

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -904,10 +904,8 @@ extension HTTPClient.EventLoopGroupProvider: Sendable {}
 extension HTTPClient.EventLoopPreference: Sendable {}
 #endif
 
-#if swift(>=5.5) && canImport(_Concurrency)
 // HTTPClient is thread-safe because its shared mutable state is protected through a lock
 extension HTTPClient: @unchecked Sendable {}
-#endif
 
 extension HTTPClient.Configuration {
     /// Timeout configuration.

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -779,9 +779,7 @@ extension HTTPClient {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension HTTPClient.Task: @unchecked Sendable {}
-#endif
 
 internal struct TaskCancelEvent {}
 

--- a/Sources/AsyncHTTPClient/SSLContextCache.swift
+++ b/Sources/AsyncHTTPClient/SSLContextCache.swift
@@ -56,6 +56,4 @@ extension SSLContextCache {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension SSLContextCache: @unchecked Sendable {}
-#endif

--- a/Sources/AsyncHTTPClient/UnsafeTransfer.swift
+++ b/Sources/AsyncHTTPClient/UnsafeTransfer.swift
@@ -26,6 +26,4 @@ final class UnsafeMutableTransferBox<Wrapped> {
     }
 }
 
-#if swift(>=5.5) && canImport(_Concurrency)
 extension UnsafeMutableTransferBox: @unchecked Sendable {}
-#endif

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -56,7 +56,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testSimpleGet() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
@@ -75,11 +74,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.version, .http2)
         }
-        #endif
     }
 
     func testSimplePost() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
@@ -98,11 +95,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.version, .http2)
         }
-        #endif
     }
 
     func testPostWithByteBuffer() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -123,11 +118,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 
     func testPostWithSequenceOfUInt8() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -148,11 +141,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 
     func testPostWithCollectionOfUInt8() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -173,11 +164,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 
     func testPostWithRandomAccessCollectionOfUInt8() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -198,11 +187,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 
     func testPostWithAsyncSequenceOfByteBuffers() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -227,11 +214,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 
     func testPostWithAsyncSequenceOfUInt8() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -252,11 +237,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 
     func testPostWithFragmentedAsyncSequenceOfByteBuffers() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -294,11 +277,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(lastResult, nil)
         }
-        #endif
     }
 
     func testPostWithFragmentedAsyncSequenceOfLargeByteBuffers() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -337,11 +318,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(lastResult, nil)
         }
-        #endif
     }
 
     func testCanceling() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false))
@@ -362,11 +341,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertEqual(error as? HTTPClientError, .cancelled)
             }
         }
-        #endif
     }
 
     func testDeadline() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false))
@@ -387,11 +364,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertTrue([.deadlineExceeded, .connectTimeout].contains(error))
             }
         }
-        #endif
     }
 
     func testImmediateDeadline() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false))
@@ -412,11 +387,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertTrue([.deadlineExceeded, .connectTimeout].contains(error), "unexpected error \(error)")
             }
         }
-        #endif
     }
 
     func testConnectTimeout() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 60) {
             #if os(Linux)
@@ -471,11 +444,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertLessThan(duration, .seconds(1))
             }
         }
-        #endif
     }
 
     func testSelfSignedCertificateIsRejectedWithCorrectErrorIfRequestDeadlineIsExceeded() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             /// key + cert was created with the follwing command:
@@ -519,11 +490,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 #endif
             }
         }
-        #endif
     }
 
     func testInvalidURL() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let client = makeDefaultHTTPClient()
@@ -535,11 +504,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertEqual($0 as? HTTPClientError, .invalidURL)
             }
         }
-        #endif
     }
 
     func testRedirectChangesHostHeader() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
@@ -564,11 +531,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             XCTAssertEqual(response.version, .http2)
             XCTAssertEqual(requestInfo.data, "localhost:\(bin.port)")
         }
-        #endif
     }
 
     func testShutdown() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let client = makeDefaultHTTPClient()
@@ -577,12 +542,10 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertEqualTypeAndValue(error, HTTPClientError.alreadyShutdown)
             }
         }
-        #endif
     }
 
     /// Regression test for https://github.com/swift-server/async-http-client/issues/612
     func testCancelingBodyDoesNotCrash() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let client = makeDefaultHTTPClient()
@@ -597,11 +560,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssert(error is NIOTooManyBytesError)
             }
         }
-        #endif
     }
 
     func testAsyncSequenceReuse() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
@@ -635,11 +596,9 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             ) else { return }
             XCTAssertEqual(body, ByteBuffer(string: "1234"))
         }
-        #endif
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 extension AsyncSequence where Element == ByteBuffer {
     func collect() async rethrows -> ByteBuffer {
         try await self.reduce(into: ByteBuffer()) { accumulatingBuffer, nextBuffer in
@@ -690,5 +649,3 @@ extension AnySendableCollection: Collection {
         self.wrapped[position]
     }
 }
-
-#endif

--- a/Tests/AsyncHTTPClientTests/AsyncTestHelpers.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncTestHelpers.swift
@@ -12,7 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 import NIOConcurrencyHelpers
 import NIOCore
 
@@ -192,4 +191,3 @@ final class AsyncSequenceWriter<Element>: AsyncSequence, @unchecked Sendable {
         }
     }
 }
-#endif

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -17,16 +17,13 @@ import NIOCore
 import XCTest
 
 class HTTPClientRequestTests: XCTestCase {
-    #if compiler(>=5.5.2) && canImport(_Concurrency)
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     private typealias Request = HTTPClientRequest
 
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     private typealias PreparedRequest = HTTPClientRequest.Prepared
-    #endif
 
     func testCustomHeadersAreRespected() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "https://example.com/get")
@@ -58,11 +55,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testUnixScheme() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "unix://%2Fexample%2Ffolder.sock/some_path")
@@ -89,11 +84,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testHTTPUnixScheme() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http+unix://%2Fexample%2Ffolder.sock/some_path")
@@ -120,11 +113,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testHTTPSUnixScheme() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "https+unix://%2Fexample%2Ffolder.sock/some_path")
@@ -151,11 +142,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testGetWithoutBody() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let request = Request(url: "https://example.com/get")
@@ -181,11 +170,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testPostWithoutBody() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -216,11 +203,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testPostWithEmptyByteBuffer() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -252,11 +237,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, ByteBuffer())
         }
-        #endif
     }
 
     func testPostWithByteBuffer() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -287,11 +270,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
-        #endif
     }
 
     func testPostWithSequenceOfUnknownLength() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -323,11 +304,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
-        #endif
     }
 
     func testPostWithSequenceWithFixedLength() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -360,11 +339,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
-        #endif
     }
 
     func testPostWithRandomAccessCollection() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -396,11 +373,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
-        #endif
     }
 
     func testPostWithAsyncSequenceOfUnknownLength() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -437,11 +412,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
-        #endif
     }
 
     func testPostWithAsyncSequenceWithKnownLength() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
@@ -478,11 +451,9 @@ class HTTPClientRequestTests: XCTestCase {
             guard let buffer = await XCTAssertNoThrowWithResult(try await preparedRequest.body.read()) else { return }
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
-        #endif
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 private struct LengthMismatch: Error {
     var announcedLength: Int
     var actualLength: Int
@@ -550,5 +521,3 @@ extension Collection {
         .init(wrapped: self, maxChunkSize: maxChunkSize)
     }
 }
-
-#endif

--- a/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests.swift
@@ -20,7 +20,6 @@ import XCTest
 
 final class Transaction_StateMachineTests: XCTestCase {
     func testRequestWasQueuedAfterWillExecuteRequestWasCalled() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
@@ -46,11 +45,9 @@ final class Transaction_StateMachineTests: XCTestCase {
 
             await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround))
         }
-        #endif
     }
 
     func testRequestBodyStreamWasPaused() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
@@ -69,12 +66,10 @@ final class Transaction_StateMachineTests: XCTestCase {
 
             await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround))
         }
-        #endif
     }
 
     func testQueuedRequestGetsRemovedWhenDeadlineExceeded() {
         struct MyError: Error, Equatable {}
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
@@ -102,12 +97,10 @@ final class Transaction_StateMachineTests: XCTestCase {
                 XCTAssertEqualTypeAndValue($0, MyError())
             }
         }
-        #endif
     }
 
     func testDeadlineExceededAndFullyFailedRequestCanBeCanceledWithNoEffect() {
         struct MyError: Error, Equatable {}
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
@@ -140,11 +133,9 @@ final class Transaction_StateMachineTests: XCTestCase {
                 XCTAssertEqualTypeAndValue($0, MyError())
             }
         }
-        #endif
     }
 
     func testScheduledRequestGetsRemovedWhenDeadlineExceeded() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
@@ -167,11 +158,9 @@ final class Transaction_StateMachineTests: XCTestCase {
 
             await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround))
         }
-        #endif
     }
 
     func testDeadlineExceededRaceWithRequestWillExecute() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
@@ -201,11 +190,9 @@ final class Transaction_StateMachineTests: XCTestCase {
                 XCTAssertEqualTypeAndValue($0, HTTPClientError.deadlineExceeded)
             }
         }
-        #endif
     }
 
     func testRequestWithHeadReceivedGetNotCancelledWhenDeadlineExceeded() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
@@ -231,11 +218,9 @@ final class Transaction_StateMachineTests: XCTestCase {
 
             await XCTAssertThrowsError(try await withCheckedThrowingContinuation(workaround))
         }
-        #endif
     }
 }
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Transaction.StateMachine.StartExecutionAction: Equatable {
     public static func == (lhs: Self, rhs: Self) -> Bool {
@@ -286,4 +271,3 @@ extension Transaction.StateMachine.NextWriteAction: Equatable {
         }
     }
 }
-#endif

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -545,7 +545,7 @@ actor SharedIterator<Wrapped: AsyncSequence> where Wrapped.Element: Sendable {
 
 /// non fail-able promise that only supports one observer
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-fileprivate actor Promise<Value> {
+private actor Promise<Value> {
     private enum State {
         case initialised
         case fulfilled(Value)

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -21,14 +21,11 @@ import NIOHTTP1
 import NIOPosix
 import XCTest
 
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 typealias PreparedRequest = HTTPClientRequest.Prepared
-#endif
 
 final class TransactionTests: XCTestCase {
     func testCancelAsyncRequest() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -60,11 +57,9 @@ final class TransactionTests: XCTestCase {
             }
             XCTAssertEqual(queuer.hitCancelCount, 1)
         }
-        #endif
     }
 
     func testResponseStreamingWorks() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -123,11 +118,9 @@ final class TransactionTests: XCTestCase {
             let result = try await part
             XCTAssertNil(result)
         }
-        #endif
     }
 
     func testIgnoringResponseBodyWorks() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -174,11 +167,9 @@ final class TransactionTests: XCTestCase {
             transaction.receiveResponseBodyParts([ByteBuffer(string: "foo bar")])
             transaction.succeedRequest(nil)
         }
-        #endif
     }
 
     func testWriteBackpressureWorks() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -248,11 +239,9 @@ final class TransactionTests: XCTestCase {
             let result = try await part
             XCTAssertNil(result)
         }
-        #endif
     }
 
     func testSimpleGetRequest() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -306,11 +295,9 @@ final class TransactionTests: XCTestCase {
                 RequestInfo(data: "", requestNumber: 1, connectionNumber: 0)
             )
         }
-        #endif
     }
 
     func testSimplePostRequest() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -346,11 +333,9 @@ final class TransactionTests: XCTestCase {
             XCTAssertEqual(response.version, .http1_1)
             XCTAssertEqual(response.headers, ["foo": "bar"])
         }
-        #endif
     }
 
     func testPostStreamFails() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -391,11 +376,9 @@ final class TransactionTests: XCTestCase {
             }
             XCTAssertNoThrow(try executor.receiveCancellation())
         }
-        #endif
     }
 
     func testResponseStreamFails() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 30) {
             let embeddedEventLoop = EmbeddedEventLoop()
@@ -456,11 +439,9 @@ final class TransactionTests: XCTestCase {
                 XCTAssertEqual($0 as? HTTPClientError, .readTimeout)
             }
         }
-        #endif
     }
 
     func testBiDirectionalStreamingHTTP2() {
-        #if compiler(>=5.5.2) && canImport(_Concurrency)
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
@@ -531,11 +512,8 @@ final class TransactionTests: XCTestCase {
             XCTAssertNil(final)
             XCTAssertEqual(delegate.hitStreamClosed, 1)
         }
-        #endif
     }
 }
-
-#if compiler(>=5.5.2) && canImport(_Concurrency)
 
 // This needs a small explanation. If an iterator is a struct, it can't be used across multiple
 // tasks. Since we want to wait for things to happen in tests, we need to `async let`, which creates
@@ -633,4 +611,3 @@ extension Transaction {
         return (await transactionPromise.value, task)
     }
 }
-#endif

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -26,7 +26,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if compiler(>=5.5.2) && canImport(_Concurrency)
+
 import XCTest
 
 extension XCTestCase {
@@ -89,5 +89,3 @@ internal func XCTAssertNoThrowWithResult<Result>(
     }
     return nil
 }
-
-#endif


### PR DESCRIPTION
### Motivation
We only support Swift 5.5.2+. 

### Modification
Remove a lot of our `#if swift(>=5.5)` conditional compilation blocks.

### Result
less branching


