### PR TITLE
FileDownloadDelegate: mark `Progress` as `Sendable`

### DIFF
--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -20,7 +20,7 @@ import NIOPosix
 public final class FileDownloadDelegate: HTTPClientResponseDelegate {
     /// The response type for this delegate: the total count of bytes as reported by the response
     /// "Content-Length" header (if available) and the count of bytes downloaded.
-    public struct Progress {
+    public struct Progress: Sendable {
         public var totalBytes: Int?
         public var receivedBytes: Int
     }


### PR DESCRIPTION
This is a trivial struct that should be `Sendable`, as it's a common use case to pass `Progress` values to `@Sendable` closures.