### PR TITLE
Use #fileID/#filePath instead of #file

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -641,7 +641,7 @@ extension Transaction {
         private func verifyStreamIDIsEqual(
             registered: TransactionBody.AsyncIterator.ID,
             this: TransactionBody.AsyncIterator.ID,
-            file: StaticString = #file,
+            file: StaticString = #fileID,
             line: UInt = #line
         ) {
             if registered != this {

--- a/Tests/AsyncHTTPClientTests/ConnectionPoolSizeConfigValueIsRespectedTests.swift
+++ b/Tests/AsyncHTTPClientTests/ConnectionPoolSizeConfigValueIsRespectedTests.swift
@@ -52,7 +52,7 @@ final class ConnectionPoolSizeConfigValueIsRespectedTests: XCTestCaseHTTPClientT
 
         let g = DispatchGroup()
         for workerID in 0..<numberOfParallelWorkers {
-            DispatchQueue(label: "\(#file):\(#line):worker-\(workerID)").async(group: g) {
+            DispatchQueue(label: "\(#filePath):\(#line):worker-\(workerID)").async(group: g) {
                 func makeRequest() {
                     let url = "http://127.0.0.1:\(httpBin.port)"
                     XCTAssertNoThrow(try client.get(url: url).wait())

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1008,7 +1008,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         let url = "http://127.0.0.1:\(server?.localAddress?.port ?? -1)/hello"
         let g = DispatchGroup()
         for workerID in 0..<numberOfParallelWorkers {
-            DispatchQueue(label: "\(#file):\(#line):worker-\(workerID)").async(group: g) {
+            DispatchQueue(label: "\(#filePath):\(#line):worker-\(workerID)").async(group: g) {
                 func makeRequest() {
                     XCTAssertNoThrow(try self.defaultClient.get(url: url).wait())
                 }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests.swift
@@ -1331,7 +1331,7 @@ class HTTPConnectionPool_HTTP2StateMachineTests: XCTestCase {
 func XCTAssertEqualTypeAndValue<Left, Right: Equatable>(
     _ lhs: @autoclosure () throws -> Left,
     _ rhs: @autoclosure () throws -> Right,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     XCTAssertNoThrow(try {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests.swift
@@ -419,7 +419,7 @@ class HTTPConnectionPoolTests: XCTestCase {
 
         let dispatchGroup = DispatchGroup()
         for workerID in 0..<numberOfParallelWorkers {
-            DispatchQueue(label: "\(#file):\(#line):worker-\(workerID)").async(group: dispatchGroup) {
+            DispatchQueue(label: "\(#filePath):\(#line):worker-\(workerID)").async(group: dispatchGroup) {
                 func makeRequest() {
                     let url = "http://localhost:\(httpBin.port)"
                     var maybeRequest: HTTPClient.Request?

--- a/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPRequestStateMachineTests.swift
@@ -746,7 +746,7 @@ extension HTTPRequestStateMachine.Action {
     fileprivate func assertFailRequest<Error>(
         _ expectedError: Error,
         _ expectedFinalStreamAction: HTTPRequestStateMachine.Action.FinalFailedRequestAction,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) where Error: Swift.Error & Equatable {
         guard case .failRequest(let actualError, let actualFinalStreamAction) = self else {

--- a/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
@@ -40,7 +40,7 @@ class MockSOCKSServer {
         self.channel.localAddress!.port!
     }
 
-    init(expectedURL: String, expectedResponse: String, misbehave: Bool = false, file: String = #file, line: UInt = #line) throws {
+    init(expectedURL: String, expectedResponse: String, misbehave: Bool = false, file: String = #filePath, line: UInt = #line) throws {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let bootstrap: ServerBootstrap
         if misbehave {

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -65,7 +65,7 @@ extension XCTestCase {
 internal func XCTAssertThrowsError<T>(
     _ expression: @autoclosure () async throws -> T,
     verify: (Error) -> Void = { _ in },
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) async {
     do {
@@ -79,7 +79,7 @@ internal func XCTAssertThrowsError<T>(
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal func XCTAssertNoThrowWithResult<Result>(
     _ expression: @autoclosure () async throws -> Result,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) async -> Result? {
     do {


### PR DESCRIPTION
Motivation:

#fileID introduced in Swift 5.3, so no longer need to use #file anywhere                                  

Modifications:

Changed #file to #filePath or #fileID depending on the situation
