### PR TITLE
Remove obsolete notes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,13 @@
 This package provides an HTTP Client library built on top of SwiftNIO.
 
 This library provides the following:
-- First class support for Swift Concurrency (since version 1.9.0)
+- First class support for Swift Concurrency
 - Asynchronous and non-blocking request methods
 - Simple follow-redirects (cookie headers are dropped)
 - Streaming body download
 - TLS support
-- Automatic HTTP/2 over HTTPS (since version 1.7.0)
+- Automatic HTTP/2 over HTTPS
 - Cookie parsing (but not storage)
-
----
-
-**NOTE**: You will need [Xcode 13.2](https://apps.apple.com/gb/app/xcode/id497799835?mt=12) or [Swift 5.5.2](https://swift.org/download/#swift-552) to try out `AsyncHTTPClient`s new async/await APIs.
-
----
 
 ## Getting Started
 


### PR DESCRIPTION
AsyncHTTPClient now requires at least Swift 5.5.2. The async/await APIs are therefore available in all supported Swift compiler versions.

Swift Concurrency and HTTP/2 are now also supported for some time now. No need to call out the specific version in the readme. This information can still be found in the release notes if needed.