### PR TITLE
Correctly shutdown `HTTP2ConnectionPool` if connection creation fails.

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+HTTP2StateMachineTests+XCTest.swift
@@ -27,6 +27,7 @@ extension HTTPConnectionPool_HTTP2StateMachineTests {
         return [
             ("testCreatingOfConnection", testCreatingOfConnection),
             ("testConnectionFailureBackoff", testConnectionFailureBackoff),
+            ("testConnectionFailureWhileShuttingDown", testConnectionFailureWhileShuttingDown),
             ("testConnectionFailureWithoutRetry", testConnectionFailureWithoutRetry),
             ("testCancelRequestWorks", testCancelRequestWorks),
             ("testExecuteOnShuttingDownPool", testExecuteOnShuttingDownPool),


### PR DESCRIPTION
### Motivation 
Previous code assumed that we were always in the running state. We therefore never transition from the shuttingDown to the shutDown state if the last connection in the pool fails.

### Modifications
- don't start new connection and instead correctly shutdown the pool if the last connection failed
- add test which previously failed

### Result
HTTPClient is correctly shut down if HTTP2 connections establishment fails while shut down is in progress.

Resolves https://github.com/swift-server/async-http-client/issues/638