### PR TITLE
Add `Host` header (#650)

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/ChannelHandler/HTTP1ProxyConnectHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/ChannelHandler/HTTP1ProxyConnectHandler.swift
@@ -155,6 +155,7 @@ final class HTTP1ProxyConnectHandler: ChannelDuplexHandler, RemovableChannelHand
             method: .CONNECT,
             uri: "\(self.targetHost):\(self.targetPort)"
         )
+        head.headers.replaceOrAdd(name: "host", value: "\(self.targetHost)")
         if let authorization = self.proxyAuthorization {
             head.headers.replaceOrAdd(name: "proxy-authorization", value: authorization.headerValue)
         }

--- a/Tests/AsyncHTTPClientTests/HTTP1ProxyConnectHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ProxyConnectHandlerTests.swift
@@ -43,6 +43,7 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
 
         XCTAssertEqual(head.method, .CONNECT)
         XCTAssertEqual(head.uri, "swift.org:443")
+        XCTAssertEqual(head.headers["host"].first, "swift.org")
         XCTAssertNil(head.headers["proxy-authorization"].first)
         XCTAssertEqual(try embedded.readOutbound(as: HTTPClientRequestPart.self), .end(nil))
 
@@ -76,6 +77,7 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
 
         XCTAssertEqual(head.method, .CONNECT)
         XCTAssertEqual(head.uri, "swift.org:443")
+        XCTAssertEqual(head.headers["host"].first, "swift.org")
         XCTAssertEqual(head.headers["proxy-authorization"].first, "Basic abc123")
         XCTAssertEqual(try embedded.readOutbound(as: HTTPClientRequestPart.self), .end(nil))
 
@@ -109,6 +111,7 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
 
         XCTAssertEqual(head.method, .CONNECT)
         XCTAssertEqual(head.uri, "swift.org:443")
+        XCTAssertEqual(head.headers["host"].first, "swift.org")
         XCTAssertNil(head.headers["proxy-authorization"].first)
         XCTAssertEqual(try embedded.readOutbound(as: HTTPClientRequestPart.self), .end(nil))
 
@@ -148,6 +151,7 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
 
         XCTAssertEqual(head.method, .CONNECT)
         XCTAssertEqual(head.uri, "swift.org:443")
+        XCTAssertEqual(head.headers["host"].first, "swift.org")
         XCTAssertNil(head.headers["proxy-authorization"].first)
         XCTAssertEqual(try embedded.readOutbound(as: HTTPClientRequestPart.self), .end(nil))
 
@@ -187,6 +191,7 @@ class HTTP1ProxyConnectHandlerTests: XCTestCase {
 
         XCTAssertEqual(head.method, .CONNECT)
         XCTAssertEqual(head.uri, "swift.org:443")
+        XCTAssertEqual(head.headers["host"].first, "swift.org")
         XCTAssertEqual(try embedded.readOutbound(as: HTTPClientRequestPart.self), .end(nil))
 
         let responseHead = HTTPResponseHead(version: .http1_1, status: .ok)


### PR DESCRIPTION
I realized that `Host` header is missing which causes `400 Bad Request: missing required Host header`.

I added missing header into `HTTP1ProxyConnectionHandler` and now it works like a charm!

Also added `Host` header check into tests.