### PR TITLE
Fix Request streaming memory leak

### DIFF
--- a/Sources/AsyncHTTPClient/RequestBag.swift
+++ b/Sources/AsyncHTTPClient/RequestBag.swift
@@ -33,7 +33,7 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
     }
 
     private let delegate: Delegate
-    private let request: HTTPClient.Request
+    private var request: HTTPClient.Request
 
     // the request state is synchronized on the task eventLoop
     private var state: StateMachine
@@ -126,6 +126,7 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
             guard let body = self.request.body else {
                 preconditionFailure("Expected to have a body, if the `HTTPRequestStateMachine` resume a request stream")
             }
+            self.request.body = nil
 
             let writer = HTTPClient.Body.StreamWriter {
                 self.writeNextRequestPart($0)

--- a/Tests/AsyncHTTPClientTests/RequestBagTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests+XCTest.swift
@@ -40,6 +40,7 @@ extension RequestBagTests {
             ("testRedirectWith3KBBody", testRedirectWith3KBBody),
             ("testRedirectWith4KBBodyAnnouncedInResponseHead", testRedirectWith4KBBodyAnnouncedInResponseHead),
             ("testRedirectWith4KBBodyNotAnnouncedInResponseHead", testRedirectWith4KBBodyNotAnnouncedInResponseHead),
+            ("testWeDontLeakTheRequestIfTheRequestWriterWasCapturedByAPromise", testWeDontLeakTheRequestIfTheRequestWriterWasCapturedByAPromise),
         ]
     }
 }


### PR DESCRIPTION
Fixes #663.

### Changes

- We need to drop references to the request body, that we execute in the RequestBag as soon as we can to destroy the reference cycle.
- To make this easier to read I moved the `redirectHandler` into the state enum
- We also don't retain the request in the `ResponseAccumulator` anymore