### PR TITLE
Fix request head continuation misuse

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -208,7 +208,7 @@ extension Transaction {
                 return .none
             case .deadlineExceededWhileQueued(let continuation):
                 let error = HTTPClientError.deadlineExceeded
-                state = .finished(error: error, nil)
+                self.state = .finished(error: error, nil)
                 return .cancelAndFail(executor, continuation, with: error)
 
             case .finished(error: .some, .none):

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -207,7 +207,9 @@ extension Transaction {
                 self.state = .executing(context, .requestHeadSent, .waitingForResponseHead)
                 return .none
             case .deadlineExceededWhileQueued(let continuation):
-                return .cancelAndFail(executor, continuation, with: HTTPClientError.deadlineExceeded)
+                let error = HTTPClientError.deadlineExceeded
+                state = .finished(error: error, nil)
+                return .cancelAndFail(executor, continuation, with: error)
 
             case .finished(error: .some, .none):
                 return .cancel(executor)

--- a/Tests/AsyncHTTPClientTests/TransactionTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests+XCTest.swift
@@ -26,6 +26,7 @@ extension TransactionTests {
     static var allTests: [(String, (TransactionTests) -> () throws -> Void)] {
         return [
             ("testCancelAsyncRequest", testCancelAsyncRequest),
+            ("testDeadlineExceededWhileQueuedAndExecutorImmediatelyCancelsTask", testDeadlineExceededWhileQueuedAndExecutorImmediatelyCancelsTask),
             ("testResponseStreamingWorks", testResponseStreamingWorks),
             ("testIgnoringResponseBodyWorks", testIgnoringResponseBodyWorks),
             ("testWriteBackpressureWorks", testWriteBackpressureWorks),

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -58,7 +58,7 @@ final class TransactionTests: XCTestCase {
             XCTAssertEqual(queuer.hitCancelCount, 1)
         }
     }
-    
+
     func testDeadlineExceededWhileQueuedAndExecutorImmediatelyCancelsTask() {
         guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
@@ -79,29 +79,29 @@ final class TransactionTests: XCTestCase {
 
             let queuer = MockTaskQueuer()
             transaction.requestWasQueued(queuer)
-            
+
             transaction.deadlineExceeded()
-            
+
             struct Executor: HTTPRequestExecutor {
                 func writeRequestBodyPart(_: NIOCore.IOData, request: AsyncHTTPClient.HTTPExecutableRequest, promise: NIOCore.EventLoopPromise<Void>?) {
                     XCTFail()
                 }
-                
+
                 func finishRequestBodyStream(_ task: AsyncHTTPClient.HTTPExecutableRequest, promise: NIOCore.EventLoopPromise<Void>?) {
                     XCTFail()
                 }
-                
-                func demandResponseBodyStream(_ task: AsyncHTTPClient.HTTPExecutableRequest) {
+
+                func demandResponseBodyStream(_: AsyncHTTPClient.HTTPExecutableRequest) {
                     XCTFail()
                 }
-                
+
                 func cancelRequest(_ task: AsyncHTTPClient.HTTPExecutableRequest) {
                     task.fail(HTTPClientError.cancelled)
                 }
             }
-            
+
             transaction.willExecuteRequest(Executor())
-            
+
             await XCTAssertThrowsError(try await responseTask.value) { error in
                 XCTAssertEqualTypeAndValue(error, HTTPClientError.deadlineExceeded)
             }

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -89,17 +89,3 @@ internal func XCTAssertNoThrowWithResult<Result>(
     }
     return nil
 }
-
-@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-internal func XCTAssertNoThrowAsync(
-    _ expression: @autoclosure () async throws -> Void,
-    file: StaticString = #filePath,
-    line: UInt = #line
-) async {
-    do {
-        return try await expression()
-    } catch {
-        XCTFail("Expression did throw: \(error)", file: file, line: line)
-    }
-    return
-}

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -89,3 +89,17 @@ internal func XCTAssertNoThrowWithResult<Result>(
     }
     return nil
 }
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+internal func XCTAssertNoThrowAsync(
+    _ expression: @autoclosure () async throws -> Void,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) async {
+    do {
+        return try await expression()
+    } catch {
+        XCTFail("Expression did throw: \(error)", file: file, line: line)
+    }
+    return
+}


### PR DESCRIPTION
We simply forgot to set the state to `.failed`.
Added a test which previously crashed.

Fixes #664