### PR TITLE
Make syncShutdown unavailable from async

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ httpClient.get(url: "https://apple.com/").whenComplete { result in
 }
 ```
 
-You should always shut down `HTTPClient` instances you created using `try httpClient.syncShutdown()`. Please note that you must not call `httpClient.syncShutdown` before all requests of the HTTP client have finished, or else the in-flight requests will likely fail because their network connections are interrupted.
+You should always shut down `HTTPClient` instances you created using `try httpClient.shutdown()`. Please note that you must not call `httpClient.shutdown` before all requests of the HTTP client have finished, or else the in-flight requests will likely fail because their network connections are interrupted.
 
 ### async/await examples
 

--- a/Sources/AsyncHTTPClient/Docs.docc/index.md
+++ b/Sources/AsyncHTTPClient/Docs.docc/index.md
@@ -71,7 +71,7 @@ httpClient.get(url: "https://apple.com/").whenComplete { result in
 }
 ```
 
-You should always shut down ``HTTPClient`` instances you created using ``HTTPClient/syncShutdown()``. Please note that you must not call ``HTTPClient/syncShutdown()`` before all requests of the HTTP client have finished, or else the in-flight requests will likely fail because their network connections are interrupted.
+You should always shut down ``HTTPClient`` instances you created using ``HTTPClient/shutdown()-96ayw()``. Please note that you must not call ``HTTPClient/shutdown()-96ayw()`` before all requests of the HTTP client have finished, or else the in-flight requests will likely fail because their network connections are interrupted.
 
 ### async/await examples
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -146,6 +146,7 @@ public class HTTPClient {
         }
     }
 
+    #if swift(>=5.7)
     /// Shuts down the client and `EventLoopGroup` if it was created by the client.
     ///
     /// This method blocks the thread indefinitely, prefer using ``shutdown()-96ayw``.
@@ -153,6 +154,14 @@ public class HTTPClient {
     public func syncShutdown() throws {
         try self.syncShutdown(requiresCleanClose: false)
     }
+    #else
+    /// Shuts down the client and `EventLoopGroup` if it was created by the client.
+    ///
+    /// This method blocks the thread indefinitely, prefer using ``shutdown()-96ayw``.
+    public func syncShutdown() throws {
+        try self.syncShutdown(requiresCleanClose: false)
+    }
+    #endif
 
     /// Shuts down the client and `EventLoopGroup` if it was created by the client.
     ///

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -139,7 +139,7 @@ public class HTTPClient {
                 """)
             case .upAndRunning:
                 preconditionFailure("""
-                Client not shut down before the deinit. Please call client.syncShutdown() when no \
+                Client not shut down before the deinit. Please call client.shutdown() when no \
                 longer needed. Otherwise memory will leak.
                 """)
             }
@@ -147,6 +147,9 @@ public class HTTPClient {
     }
 
     /// Shuts down the client and `EventLoopGroup` if it was created by the client.
+    ///
+    /// This method blocks the thread indefinitely, prefer using ``shutdown()-96ayw``.
+    @available(*, noasync, message: "syncShutdown() can block indefinitely, prefer shutdown()", renamed: "shutdown()")
     public func syncShutdown() throws {
         try self.syncShutdown(requiresCleanClose: false)
     }


### PR DESCRIPTION
Motivation

syncShutdown can cause unbounded thread blocking, we shouldn't allow it in concurrent code.

Modification

Mark syncShutdown unavailable from async.

Result

Users are warned if they try to syncShutdown in an async context