### PR TITLE
Fix crash if connection is closed very early

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -372,7 +372,7 @@ extension HTTPConnectionPool.ConnectionFactory {
                     channel.pipeline.removeHandler(tlsEventHandler).map { (channel, negotiated) }
                 }
             } catch {
-                precondition(channel.isActive == false, "if the channel is still active then TLSEventsHandler must be present but got error \(error)")
+                assert(channel.isActive == false, "if the channel is still active then TLSEventsHandler must be present but got error \(error)")
                 return channel.eventLoop.makeFailedFuture(HTTPClientError.remoteConnectionClosed)
             }
         }

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -365,7 +365,7 @@ extension HTTPConnectionPool.ConnectionFactory {
                 // if the channel is closed before flatMap is executed, all ChannelHandler are removed
                 // and TLSEventsHandler is therefore not present either
                 let tlsEventHandler = try channel.pipeline.syncOperations.handler(type: TLSEventsHandler.self)
-                
+
                 // The tlsEstablishedFuture is set as soon as the TLSEventsHandler is in a
                 // pipeline. It is created in TLSEventsHandler's handlerAdded method.
                 return tlsEventHandler.tlsEstablishedFuture!.flatMap { negotiated in


### PR DESCRIPTION
If the channel is closed before flatMap is executed, all ChannelHandler are removed and `TLSEventsHandler` is therefore not present either. We need to tolerate this even though it is very rare.

Testing ideas welcome.

Fixes #670