### PR TITLE
FileDownloadDelegate: pass response header through

### DIFF
--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -21,7 +21,7 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
     /// The response type for this delegate: the response header, the total count of bytes as reported 
     /// by the response "Content-Length" header (if available) and the count of bytes downloaded.
     public struct Progress: Sendable {
-        public var reponseHead: HTTPResponseHead?
+        public var responseHead: HTTPResponseHead?
         public var totalBytes: Int?
         public var receivedBytes: Int
     }

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -18,9 +18,10 @@ import NIOPosix
 
 /// Handles a streaming download to a given file path, allowing headers and progress to be reported.
 public final class FileDownloadDelegate: HTTPClientResponseDelegate {
-    /// The response type for this delegate: the total count of bytes as reported by the response
-    /// "Content-Length" header (if available) and the count of bytes downloaded.
+    /// The response type for this delegate: the response header, the total count of bytes as reported 
+    /// by the response "Content-Length" header (if available) and the count of bytes downloaded.
     public struct Progress: Sendable {
+        public var reponseHead: HTTPResponseHead?
         public var totalBytes: Int?
         public var receivedBytes: Int
     }
@@ -97,6 +98,7 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
         task: HTTPClient.Task<Response>,
         _ head: HTTPResponseHead
     ) -> EventLoopFuture<Void> {
+        self.progress.responseHead = head
         self.reportHead?(head)
 
         if let totalBytesString = head.headers.first(name: "Content-Length"),

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -18,7 +18,7 @@ import NIOPosix
 
 /// Handles a streaming download to a given file path, allowing headers and progress to be reported.
 public final class FileDownloadDelegate: HTTPClientResponseDelegate {
-    /// The response type for this delegate: the response header, the total count of bytes as reported 
+    /// The response type for this delegate: the response header, the total count of bytes as reported,
     /// by the response "Content-Length" header (if available) and the count of bytes downloaded.
     public struct Progress: Sendable {
         public var responseHead: HTTPResponseHead?


### PR DESCRIPTION
Currently `FileDownloadDelegate` doesn't pass the response header through in its `Response` associated type, which is satisfied by the `Progress` inner type declaration. This makes it hard to use in the Swift Concurrency context, since it's no trivial to pass response header around from `reportHead` closure. Let's fix that by adding a new field that passes the response header in the delegate's response.

This change is not source-breaking and is purely additive, since no existing properties were changed.