### PR TITLE
Add support for custom cancellation error

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -688,7 +688,7 @@ extension URL {
 }
 
 protocol HTTPClientTaskDelegate {
-    func cancel()
+    func fail(_ error: Error)
 }
 
 extension HTTPClient {
@@ -780,12 +780,18 @@ extension HTTPClient {
 
         /// Cancels the request execution.
         public func cancel() {
+            self.fail(reason: HTTPClientError.cancelled)
+        }
+
+        /// Cancels the request execution with a custom `Error`.
+        /// - Parameter reason: the error that is used to fail the promise
+        public func fail(reason error: Error) {
             let taskDelegate = self.lock.withLock { () -> HTTPClientTaskDelegate? in
                 self._isCancelled = true
                 return self._taskDelegate
             }
 
-            taskDelegate?.cancel()
+            taskDelegate?.fail(error)
         }
 
         func succeed<Delegate: HTTPClientResponseDelegate>(promise: EventLoopPromise<Response>?,

--- a/Sources/AsyncHTTPClient/RequestBag.swift
+++ b/Sources/AsyncHTTPClient/RequestBag.swift
@@ -394,7 +394,7 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
     }
 }
 
-extension RequestBag: HTTPSchedulableRequest {
+extension RequestBag: HTTPSchedulableRequest, HTTPClientTaskDelegate {
     var tlsConfiguration: TLSConfiguration? {
         self.request.tlsConfiguration
     }
@@ -509,11 +509,5 @@ extension RequestBag: HTTPExecutableRequest {
                 self.succeedRequest0(buffer)
             }
         }
-    }
-}
-
-extension RequestBag: HTTPClientTaskDelegate {
-    func cancel() {
-        self.fail(HTTPClientError.cancelled)
     }
 }

--- a/Tests/AsyncHTTPClientTests/HTTP1ClientChannelHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ClientChannelHandlerTests.swift
@@ -327,7 +327,7 @@ class HTTP1ClientChannelHandlerTests: XCTestCase {
         XCTAssertNoThrow(try embedded.writeInbound(HTTPClientResponsePart.head(responseHead)))
 
         // canceling the request
-        requestBag.cancel()
+        requestBag.fail(HTTPClientError.cancelled)
         XCTAssertThrowsError(try requestBag.task.futureResult.wait()) {
             XCTAssertEqual($0 as? HTTPClientError, .cancelled)
         }

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientRequestHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientRequestHandlerTests.swift
@@ -276,7 +276,7 @@ class HTTP2ClientRequestHandlerTests: XCTestCase {
         XCTAssertNoThrow(try embedded.writeInbound(HTTPClientResponsePart.head(responseHead)))
 
         // canceling the request
-        requestBag.cancel()
+        requestBag.fail(HTTPClientError.cancelled)
         XCTAssertThrowsError(try requestBag.task.futureResult.wait()) {
             XCTAssertEqual($0 as? HTTPClientError, .cancelled)
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests+XCTest.swift
@@ -52,6 +52,7 @@ extension HTTPClientTests {
             ("testStreaming", testStreaming),
             ("testFileDownload", testFileDownload),
             ("testFileDownloadError", testFileDownloadError),
+            ("testFileDownloadCustomError", testFileDownloadCustomError),
             ("testRemoteClose", testRemoteClose),
             ("testReadTimeout", testReadTimeout),
             ("testConnectTimeout", testConnectTimeout),

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPoolTests.swift
@@ -334,7 +334,7 @@ class HTTPConnectionPoolTests: XCTestCase {
 
         pool.executeRequest(requestBag)
         XCTAssertNoThrow(try eventLoop.scheduleTask(in: .seconds(1)) {}.futureResult.wait())
-        requestBag.cancel()
+        requestBag.fail(HTTPClientError.cancelled)
 
         XCTAssertThrowsError(try requestBag.task.futureResult.wait()) {
             XCTAssertEqual($0 as? HTTPClientError, .cancelled)

--- a/Tests/AsyncHTTPClientTests/RequestBagTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests.swift
@@ -220,7 +220,7 @@ final class RequestBagTests: XCTestCase {
         XCTAssert(bag.eventLoop === embeddedEventLoop)
 
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
-        bag.cancel()
+        bag.fail(HTTPClientError.cancelled)
 
         bag.willExecuteRequest(executor)
         XCTAssertTrue(executor.isCancelled, "The request bag, should call cancel immediately on the executor")
@@ -301,7 +301,7 @@ final class RequestBagTests: XCTestCase {
         bag.fail(MyError())
         XCTAssertEqual(delegate.hitDidReceiveError, 1)
 
-        bag.cancel()
+        bag.fail(HTTPClientError.cancelled)
         XCTAssertEqual(delegate.hitDidReceiveError, 1)
 
         XCTAssertThrowsError(try bag.task.futureResult.wait()) {
@@ -342,7 +342,7 @@ final class RequestBagTests: XCTestCase {
         XCTAssertEqual(delegate.hitDidSendRequestHead, 1)
         XCTAssertEqual(delegate.hitDidSendRequest, 1)
 
-        bag.cancel()
+        bag.fail(HTTPClientError.cancelled)
         XCTAssertTrue(executor.isCancelled, "The request bag, should call cancel immediately on the executor")
 
         XCTAssertThrowsError(try bag.task.futureResult.wait()) {
@@ -376,7 +376,7 @@ final class RequestBagTests: XCTestCase {
         bag.requestWasQueued(queuer)
 
         XCTAssertEqual(queuer.hitCancelCount, 0)
-        bag.cancel()
+        bag.fail(HTTPClientError.cancelled)
         XCTAssertEqual(queuer.hitCancelCount, 1)
 
         XCTAssertThrowsError(try bag.task.futureResult.wait()) {
@@ -445,9 +445,9 @@ final class RequestBagTests: XCTestCase {
         let executor = MockRequestExecutor(eventLoop: embeddedEventLoop)
         executor.runRequest(bag)
 
-        // This simulates a race between the user cancelling the task (which invokes `RequestBag.cancel`) and the
+        // This simulates a race between the user cancelling the task (which invokes `RequestBag.fail(_:)`) and the
         // call to `resumeRequestBodyStream` (which comes from the `Channel` event loop and so may have to hop.
-        bag.cancel()
+        bag.fail(HTTPClientError.cancelled)
         bag.resumeRequestBodyStream()
 
         XCTAssertEqual(executor.isCancelled, true)


### PR DESCRIPTION
### Motivation
A users might want to provide more information why a request got cancelled. For example if we cancel a file download because the response status code is not 2xx, it is desirable to propagate which status code was returned.

### Modification
- add `Task.fail(_:)` in addition to `Task.cancel()` that takes a custom Error which is used to complete the underlying request promise.

### Result
Improved error messages.