### PR TITLE
Fix building transaction extension for Apple Platforms

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -325,7 +325,7 @@ extension Transaction: HTTPExecutableRequest {
     }
 }
 
-@available(macOS 10.15, *)
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Transaction: NIOAsyncSequenceProducerDelegate {
     @usableFromInline
     func produceMore() {


### PR DESCRIPTION
The repo currently won't build for other OS's because the extension doesn't match: https://github.com/swift-server/async-http-client/blob/2588b8cdd4be62f72da849f42ec1d1b25c985937/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift#L21-L22