### PR TITLE
Tolerate new request after connection error happened

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
@@ -316,6 +316,8 @@ extension HTTP1ConnectionStateMachine.Action: Equatable {
 
         case (.fireChannelInactive, .fireChannelInactive):
             return true
+        case (.fireChannelError(_, let lhsCloseConnection), .fireChannelError(_, let rhsCloseConnection)):
+            return lhsCloseConnection == rhsCloseConnection
 
         case (.sendRequestHead(let lhsHead, let lhsStartBody), .sendRequestHead(let rhsHead, let rhsStartBody)):
             return lhsHead == rhsHead && lhsStartBody == rhsStartBody
@@ -390,6 +392,7 @@ extension HTTP1ConnectionStateMachine.Action.FinalFailedStreamAction: Equatable 
             return lhsPromise?.futureResult == rhsPromise?.futureResult
         case (.none, .none):
             return true
+
         default:
             return false
         }

--- a/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ConnectionStateMachineTests.swift
@@ -200,6 +200,19 @@ class HTTP1ConnectionStateMachineTests: XCTestCase {
         XCTAssertEqual(state.requestCancelled(closeConnection: false), .failRequest(HTTPClientError.cancelled, .close(nil)))
     }
 
+    func testNewRequestAfterErrorHappened() {
+        var state = HTTP1ConnectionStateMachine()
+        XCTAssertEqual(state.channelActive(isWritable: false), .fireChannelActive)
+        struct MyError: Error, Equatable {}
+        XCTAssertEqual(state.errorHappened(MyError()), .fireChannelError(MyError(), closeConnection: true))
+        let requestHead = HTTPRequestHead(version: .http1_1, method: .POST, uri: "/", headers: ["content-length": "4"])
+        let metadata = RequestFramingMetadata(connectionClose: false, body: .fixedSize(4))
+        let action = state.runNewRequest(head: requestHead, metadata: metadata)
+        guard case .failRequest = action else {
+            return XCTFail("unexpected action \(action)")
+        }
+    }
+
     func testCancelRequestIsIgnoredWhenConnectionIsIdle() {
         var state = HTTP1ConnectionStateMachine()
         XCTAssertEqual(state.channelActive(isWritable: true), .fireChannelActive)


### PR DESCRIPTION
### Motivation
A connection and the connection pool may be on different threads and therefore run concurrently. If a connection error happens the connections closes itself and notifies the pool about it. While this is happening the connection pool could already decide to run a new connection on the closing connection. We need to tolerate this happening. We already partially do but only if the connection is fully closed but not currently still closing.

### Result
- change all `preconditionFailure`s in `HTTP1ConnectionStateMachine.swift` to `fatalError`s to see the message in release builds
- tolerate `.closing` in addition to `.closed` in `runNewRequest`
- add test which previously crashed

### Result
AHC no longer crashes in the race condition described above.