### PR TITLE
Replace os() with canImport(Darwin)

### DIFF
--- a/Sources/AsyncHTTPClient/Base64.swift
+++ b/Sources/AsyncHTTPClient/Base64.swift
@@ -150,7 +150,7 @@ extension String {
 // this declaration on having the 5.3 compiler. This has caused a number of build issues. While updating
 // to newer Xcodes does work, we can save ourselves some hassle and just wait until 5.4 to get this
 // enhancement on Apple platforms.
-#if (compiler(>=5.3) && !(os(macOS) || os(iOS) || os(tvOS) || os(watchOS))) || compiler(>=5.4)
+#if (compiler(>=5.3) && !canImport(Darwin)) || compiler(>=5.4)
 extension String {
 
   @inlinable

--- a/Sources/AsyncHTTPClient/Base64.swift
+++ b/Sources/AsyncHTTPClient/Base64.swift
@@ -146,11 +146,6 @@ extension String {
   }
 }
 
-// Frustratingly, Swift 5.3 shipped before the macOS 11 SDK did, so we cannot gate the availability of
-// this declaration on having the 5.3 compiler. This has caused a number of build issues. While updating
-// to newer Xcodes does work, we can save ourselves some hassle and just wait until 5.4 to get this
-// enhancement on Apple platforms.
-#if (compiler(>=5.3) && !canImport(Darwin)) || compiler(>=5.4)
 extension String {
 
   @inlinable
@@ -163,12 +158,3 @@ extension String {
     }
   }
 }
-#else
-extension String {
-  @inlinable
-  init(customUnsafeUninitializedCapacity capacity: Int,
-     initializingUTF8With initializer: (_ buffer: UnsafeMutableBufferPointer<UInt8>) throws -> Int) rethrows {
-    try self.init(backportUnsafeUninitializedCapacity: capacity, initializingUTF8With: initializer)
-  }
-}
-#endif


### PR DESCRIPTION
This increase the code verification with the right statement including all platforms that use Darwin.