### PR TITLE
Fix flaky `AsyncAwaitEndToEndTests.testImmediateDeadline` test

### DIFF
--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -389,8 +389,10 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 guard let error = error as? HTTPClientError else {
                     return XCTFail("unexpected error \(error)")
                 }
-                // a race between deadline and connect timer can result in either error
-                XCTAssertTrue([.deadlineExceeded, .connectTimeout].contains(error))
+                // a race between deadline and connect timer can result in either error.
+                // If closing happens really fast we might shutdown the pipeline before we fail the request.
+                // If the pipeline is closed we may receive a  `.remoteConnectionClosed`.
+                XCTAssertTrue([.deadlineExceeded, .connectTimeout, .remoteConnectionClosed].contains(error), "unexpected error \(error)")
             }
         }
     }
@@ -412,8 +414,10 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 guard let error = error as? HTTPClientError else {
                     return XCTFail("unexpected error \(error)")
                 }
-                // a race between deadline and connect timer can result in either error
-                XCTAssertTrue([.deadlineExceeded, .connectTimeout].contains(error), "unexpected error \(error)")
+                // a race between deadline and connect timer can result in either error.
+                // If closing happens really fast we might shutdown the pipeline before we fail the request.
+                // If the pipeline is closed we may receive a  `.remoteConnectionClosed`.
+                XCTAssertTrue([.deadlineExceeded, .connectTimeout, .remoteConnectionClosed].contains(error), "unexpected error \(error)")
             }
         }
     }


### PR DESCRIPTION
We have observed that `AsyncAwaitEndToEndTests.testImmediateDeadline` can also return a `HTTPClientError.remoteConnectionClosed` in rare circumstances. If closing  happens really fast we might shutdown the pipeline before we fail the request. If the pipeline is closed we may receive a  `.remoteConnectionClosed` which can execute before we push the previous error to the request state machine. We can't change this in the current architecture so we will just tolerate this error in tests as well. 

The `AsyncAwaitEndToEndTests.testDeadline()` is less likely to experience this issue but I have changed it there too just to be safe.