### PR TITLE
Add timeout to `RequestBagTests.testCancelFailsTaskAfterRequestIsSent` test

### DIFF
--- a/Tests/AsyncHTTPClientTests/RequestBagTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests.swift
@@ -345,7 +345,7 @@ final class RequestBagTests: XCTestCase {
         bag.fail(HTTPClientError.cancelled)
         XCTAssertTrue(executor.isCancelled, "The request bag, should call cancel immediately on the executor")
 
-        XCTAssertThrowsError(try bag.task.futureResult.wait()) {
+        XCTAssertThrowsError(try bag.task.futureResult.timeout(after: .seconds(10)).wait()) {
             XCTAssertEqual($0 as? HTTPClientError, .cancelled)
         }
     }


### PR DESCRIPTION
We have seen that the `RequestBagTests.testCancelFailsTaskAfterRequestIsSent` can timeout the CI in #698. To better understand where it fails we can add a timeout that will throw with a timeout error and fail the error check below it. This will make will allow us in the future to better analyse the failure and will no longer timeout the CI.