### PR TITLE
Add unit tests for NWWaitingHandler, closes #589

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.22.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.13.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.13.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
@@ -60,7 +60,7 @@ class NWWaitingHandlerTests: XCTestCase {
         let embedded = EmbeddedChannel(handlers: [waitingEventHandler])
         embedded.pipeline.fireUserInboundEventTriggered(NIOTSNetworkEvents.BetterPathAvailable())
 
-        XCTAssertFalse(requester.waitingForConnectivityCalled, "Should not call .waitingForConnectitivy on unrelated events")
+        XCTAssertFalse(requester.waitingForConnectivityCalled, "Should not call .waitingForConnectivity on unrelated events")
     }
 
     func testWaitingHandlerPassesTheEventDownTheContext() {
@@ -71,7 +71,7 @@ class NWWaitingHandlerTests: XCTestCase {
 
         embedded.pipeline.fireErrorCaught(NIOSSLError.handshakeFailed(BoringSSLError.wantConnect))
         XCTAssertThrowsError(try XCTUnwrap(tlsEventsHandler.tlsEstablishedFuture).wait()) {
-            XCTAssertEqual($0 as? NIOSSLError, .handshakeFailed(BoringSSLError.wantConnect))
+            XCTAssertEqualTypeAndValue($0, NIOSSLError.handshakeFailed(BoringSSLError.wantConnect))
         }
     }
 }

--- a/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the AsyncHTTPClient open source project
+//
+// Copyright (c) 2023 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+@testable import AsyncHTTPClient
+import Network
+import NIOCore
+import NIOTransportServices
+import NIOEmbedded
+import NIOSSL
+import XCTest
+
+@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+class NWWaitingHandlerTests: XCTestCase {
+
+    class MockRequester: HTTPConnectionRequester {
+        var waitingForConnectivityCalled = false
+        var connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID? = nil
+        var transientError: NWError? = nil
+
+        func http1ConnectionCreated(_: AsyncHTTPClient.HTTP1Connection) {
+        }
+        
+        func http2ConnectionCreated(_: AsyncHTTPClient.HTTP2Connection, maximumStreams: Int) {
+        }
+        
+        func failedToCreateHTTPConnection(_: AsyncHTTPClient.HTTPConnectionPool.Connection.ID, error: Error) {
+        }
+        
+        func waitingForConnectivity(_ connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID, error: Error) {
+            self.waitingForConnectivityCalled = true
+            self.connectionID = connectionID
+            self.transientError = error as? NWError
+        }
+    }
+
+    func testWaitingHandlerInvokesWaitingForConnectivity() {
+        let requester = MockRequester()
+        let connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID = 1
+        let waitingEventHandler = NWWaitingHandler(requester: requester, connectionID: connectionID)
+        let embedded = EmbeddedChannel(handlers: [waitingEventHandler])
+        
+        embedded.pipeline.fireUserInboundEventTriggered(NIOTSNetworkEvents.WaitingForConnectivity(transientError: .dns(1)))
+        
+        XCTAssertTrue(requester.waitingForConnectivityCalled, "Expected the handler to invoke .waitingForConnectivity on the requester")
+        XCTAssertEqual(requester.connectionID, connectionID, "Expected the handler to pass connectionID to requester")
+        XCTAssertEqual(requester.transientError, NWError.dns(1))
+    }
+
+    func testWaitingHandlerDoesNotInvokeWaitingForConnectionOnUnrelatedErrors() {
+        let requester = MockRequester()
+        let waitingEventHandler = NWWaitingHandler(requester: requester, connectionID: 1)
+        let embedded = EmbeddedChannel(handlers: [waitingEventHandler])
+        embedded.pipeline.fireUserInboundEventTriggered(NIOTSNetworkEvents.BetterPathAvailable())
+
+        XCTAssertFalse(requester.waitingForConnectivityCalled, "Should not call .waitingForConnectitivy on unrelated events")
+    }
+
+    func testWaitingHandlerPassesTheEventDownTheContext() {
+        let requester = MockRequester()
+        let waitingEventHandler = NWWaitingHandler(requester: requester, connectionID: 1)
+        let tlsEventsHandler = TLSEventsHandler(deadline: nil)
+        let embedded = EmbeddedChannel(handlers: [waitingEventHandler, tlsEventsHandler])
+
+        embedded.pipeline.fireErrorCaught(NIOSSLError.handshakeFailed(BoringSSLError.wantConnect))
+        XCTAssertThrowsError(try XCTUnwrap(tlsEventsHandler.tlsEstablishedFuture).wait()) {
+            XCTAssertEqual($0 as? NIOSSLError, .handshakeFailed(BoringSSLError.wantConnect))
+        }
+    }
+}
+
+#endif
+

--- a/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
@@ -16,28 +16,24 @@
 @testable import AsyncHTTPClient
 import Network
 import NIOCore
-import NIOTransportServices
 import NIOEmbedded
 import NIOSSL
+import NIOTransportServices
 import XCTest
 
 @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
 class NWWaitingHandlerTests: XCTestCase {
-
     class MockRequester: HTTPConnectionRequester {
         var waitingForConnectivityCalled = false
-        var connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID? = nil
-        var transientError: NWError? = nil
+        var connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID?
+        var transientError: NWError?
 
-        func http1ConnectionCreated(_: AsyncHTTPClient.HTTP1Connection) {
-        }
-        
-        func http2ConnectionCreated(_: AsyncHTTPClient.HTTP2Connection, maximumStreams: Int) {
-        }
-        
-        func failedToCreateHTTPConnection(_: AsyncHTTPClient.HTTPConnectionPool.Connection.ID, error: Error) {
-        }
-        
+        func http1ConnectionCreated(_: AsyncHTTPClient.HTTP1Connection) {}
+
+        func http2ConnectionCreated(_: AsyncHTTPClient.HTTP2Connection, maximumStreams: Int) {}
+
+        func failedToCreateHTTPConnection(_: AsyncHTTPClient.HTTPConnectionPool.Connection.ID, error: Error) {}
+
         func waitingForConnectivity(_ connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID, error: Error) {
             self.waitingForConnectivityCalled = true
             self.connectionID = connectionID
@@ -50,9 +46,9 @@ class NWWaitingHandlerTests: XCTestCase {
         let connectionID: AsyncHTTPClient.HTTPConnectionPool.Connection.ID = 1
         let waitingEventHandler = NWWaitingHandler(requester: requester, connectionID: connectionID)
         let embedded = EmbeddedChannel(handlers: [waitingEventHandler])
-        
+
         embedded.pipeline.fireUserInboundEventTriggered(NIOTSNetworkEvents.WaitingForConnectivity(transientError: .dns(1)))
-        
+
         XCTAssertTrue(requester.waitingForConnectivityCalled, "Expected the handler to invoke .waitingForConnectivity on the requester")
         XCTAssertEqual(requester.connectionID, connectionID, "Expected the handler to pass connectionID to requester")
         XCTAssertEqual(requester.transientError, NWError.dns(1))
@@ -81,4 +77,3 @@ class NWWaitingHandlerTests: XCTestCase {
 }
 
 #endif
-


### PR DESCRIPTION
**Motivation:**

Closes #589. Since we already have a public initializer for `NIOTSNetworkEvents.WaitingForConnectivity`, we should add unit tests for the handler now that it's straightforward.

I'm here to learn — first patch in `async-http-client`.

**Modifications:**

The tests are in their own file `Tests/NWWaitingHandlerTests.swift`.