### PR TITLE
Remove tests relying on OS-dependent behaviour

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -155,12 +155,6 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
             XCTAssertEqual(url.path, "/file/path")
             XCTAssertEqual(url.absoluteString, "https+unix://%2Ftmp%2Ffile%20with%20spaces%E3%81%A8%E6%BC%A2%E5%AD%97/file/path")
         }
-
-        let url9 = URL(httpURLWithSocketPath: "/tmp/file", uri: " ")
-        XCTAssertNil(url9)
-
-        let url10 = URL(httpsURLWithSocketPath: "/tmp/file", uri: " ")
-        XCTAssertNil(url10)
     }
 
     func testBadUnixWithBaseURL() {


### PR DESCRIPTION
Motivation

URL parsing has changed in macOS Sonoma and associated releases. Our tests were reliant on the old behaviour. The behaviour is controlled by the OS on which the program was linked, which makes it impossible for us to programmatically work out which result we should see.

The affected tests are not actually useful, we don't really care how the URLs parse, so we can safely just remove them.

Modifications

Remove the affected tests.

Result

Tests pass!