### PR TITLE
HTTPClientRequest: allow custom TLS config

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClient+execute.swift
@@ -78,7 +78,7 @@ extension HTTPClient {
         // this loop is there to follow potential redirects
         while true {
             let preparedRequest = try HTTPClientRequest.Prepared(currentRequest, dnsOverride: configuration.dnsOverride)
-            let response = try await executeCancellable(preparedRequest, deadline: deadline, logger: logger)
+            let response = try await self.executeCancellable(preparedRequest, deadline: deadline, logger: logger)
 
             guard var redirectState = currentRedirectState else {
                 // a `nil` redirectState means we should not follow redirects

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -15,6 +15,7 @@
 import struct Foundation.URL
 import NIOCore
 import NIOHTTP1
+import NIOSSL
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientRequest {
@@ -37,6 +38,7 @@ extension HTTPClientRequest {
         var requestFramingMetadata: RequestFramingMetadata
         var head: HTTPRequestHead
         var body: Body?
+        var tlsConfiguration: TLSConfiguration?
     }
 }
 
@@ -58,7 +60,7 @@ extension HTTPClientRequest.Prepared {
 
         self.init(
             url: url,
-            poolKey: .init(url: deconstructedURL, tlsConfiguration: nil, dnsOverride: dnsOverride),
+            poolKey: .init(url: deconstructedURL, tlsConfiguration: request.tlsConfiguration, dnsOverride: dnsOverride),
             requestFramingMetadata: metadata,
             head: .init(
                 version: .http1_1,
@@ -66,7 +68,8 @@ extension HTTPClientRequest.Prepared {
                 uri: deconstructedURL.uri,
                 headers: headers
             ),
-            body: request.body.map { .init($0) }
+            body: request.body.map { .init($0) },
+            tlsConfiguration: request.tlsConfiguration
         )
     }
 }

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
@@ -15,6 +15,7 @@
 import Algorithms
 import NIOCore
 import NIOHTTP1
+import NIOSSL
 
 @usableFromInline
 let bagOfBytesToByteBufferConversionChunkSize = 1024 * 1024 * 4
@@ -32,6 +33,9 @@ let byteBufferMaxSize = Int(UInt32.max)
 /// A representation of an HTTP request for the Swift Concurrency HTTPClient API.
 ///
 /// This object is similar to ``HTTPClient/Request``, but used for the Swift Concurrency API.
+///
+/// - note: For many ``HTTPClientRequest/body-swift.property`` configurations, this type is _not_ a value type
+///    (https://github.com/swift-server/async-http-client/issues/708).
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 public struct HTTPClientRequest: Sendable {
     /// The request URL, including scheme, hostname, and optionally port.
@@ -46,11 +50,15 @@ public struct HTTPClientRequest: Sendable {
     /// The request body, if any.
     public var body: Body?
 
+    /// Request-specific TLS configuration, defaults to no request-specific TLS configuration.
+    public var tlsConfiguration: TLSConfiguration?
+
     public init(url: String) {
         self.url = url
         self.method = .GET
         self.headers = .init()
         self.body = .none
+        self.tlsConfiguration = nil
     }
 }
 

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction.swift
@@ -146,7 +146,7 @@ import NIOSSL
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Transaction: HTTPSchedulableRequest {
     var poolKey: ConnectionPool.Key { self.request.poolKey }
-    var tlsConfiguration: TLSConfiguration? { return nil }
+    var tlsConfiguration: TLSConfiguration? { return self.request.tlsConfiguration }
     var requiredEventLoop: EventLoop? { return nil }
 
     func requestWasQueued(_ scheduler: HTTPRequestScheduler) {


### PR DESCRIPTION
In the transition from `HTTPClient.Request` to `HTTPClientRequest` we unfortunately lost some important functionality: Custom TLS configuration.

The can be important to override on a per-request basis but more importantly it was the most significant step which allows us to unlock the 3-tier architecture (#392). For the 3-tier architecture it's very important to get rid of any top-level configuration.

This PR brings back the lost functionality.