### PR TITLE
Automatically chunk large request bodies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,6 +29,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     ],
     targets: [
         .target(name: "CAsyncHTTPClient"),
@@ -48,6 +49,7 @@ let package = Package(
                 .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "Algorithms", package: "swift-algorithms"),
             ]
         ),
         .testTarget(
@@ -64,6 +66,7 @@ let package = Package(
                 .product(name: "NIOSOCKS", package: "swift-nio-extras"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Atomics", package: "swift-atomics"),
+                .product(name: "Algorithms", package: "swift-algorithms"),
             ],
             resources: [
                 .copy("Resources/self_signed_cert.pem"),

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
@@ -151,8 +151,7 @@ extension HTTPClientRequest.Body {
             byteBufferMaxSize: byteBufferMaxSize
         )
     }
-    
-    
+
     /// internal method to test chunking
     @inlinable
     @preconcurrency
@@ -192,7 +191,7 @@ extension HTTPClientRequest.Body {
         if let body = body {
             return body
         }
-        
+
         // slow path
         return Self(.asyncSequence(
             length: length.storage
@@ -347,7 +346,7 @@ extension HTTPClientRequest.Body {
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientRequest.Body: AsyncSequence {
     public typealias Element = ByteBuffer
-    
+
     @inlinable
     public func makeAsyncIterator() -> AsyncIterator {
         switch self.mode {
@@ -366,24 +365,24 @@ extension HTTPClientRequest.Body {
     public struct AsyncIterator: AsyncIteratorProtocol {
         @usableFromInline
         static let allocator = ByteBufferAllocator()
-        
+
         @usableFromInline
         enum Storage {
             case byteBuffer(ByteBuffer?)
             case makeNext((ByteBufferAllocator) async throws -> ByteBuffer?)
         }
-        
+
         @usableFromInline
         var storage: Storage
-        
+
         @inlinable
         init(storage: Storage) {
             self.storage = storage
         }
-        
+
         @inlinable
         public mutating func next() async throws -> ByteBuffer? {
-            switch storage {
+            switch self.storage {
             case .byteBuffer(let buffer):
                 self.storage = .byteBuffer(nil)
                 return buffer

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Algorithms
 import NIOCore
 import NIOHTTP1
-import Algorithms
 
 // TODO: should this be a multiple of a page size?
 @usableFromInline

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Algorithms
 import Foundation
 import Logging
 import NIOConcurrencyHelpers
@@ -19,7 +20,6 @@ import NIOCore
 import NIOHTTP1
 import NIOPosix
 import NIOSSL
-import Algorithms
 
 extension HTTPClient {
     /// A request body.
@@ -45,14 +45,14 @@ extension HTTPClient {
             public func write(_ data: IOData) -> EventLoopFuture<Void> {
                 return self.closure(data)
             }
-            
+
             @inlinable
             func writeChunks<Bytes: Collection>(of bytes: Bytes, maxChunkSize: Int) -> EventLoopFuture<Void> where Bytes.Element == UInt8 {
                 let iterator = UnsafeMutableTransferBox(bytes.chunks(ofCount: maxChunkSize).makeIterator())
                 guard let chunk = iterator.wrappedValue.next() else {
                     return self.write(IOData.byteBuffer(.init()))
                 }
-                
+
                 @Sendable // can't use closure here as we recursively call ourselves which closures can't do
                 func writeNextChunk(_ chunk: Bytes.SubSequence) -> EventLoopFuture<Void> {
                     if let nextChunk = iterator.wrappedValue.next() {
@@ -63,7 +63,7 @@ extension HTTPClient {
                         self.write(.byteBuffer(ByteBuffer(bytes: chunk)))
                     }
                 }
-                
+
                 return writeNextChunk(chunk)
             }
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Algorithms
 @testable import AsyncHTTPClient
 import NIOCore
 import XCTest
-import Algorithms
 
 class HTTPClientRequestTests: XCTestCase {
     @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -466,90 +466,90 @@ class HTTPClientRequestTests: XCTestCase {
             XCTAssertEqual(buffer, .init(string: "post body"))
         }
     }
-    
+
     func testChunkingRandomAccessCollection() async throws {
         let body = try await HTTPClientRequest.Body.bytes(
             Array(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
+                Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
+                Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
         ).collect()
-        
+
         let expectedChunks = [
             ByteBuffer(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize),
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
-    
+
     func testChunkingCollection() async throws {
         let body = try await HTTPClientRequest.Body.bytes(
             (
                 String(repeating: "0", count: bagOfBytesToByteBufferConversionChunkSize) +
-                String(repeating: "1", count: bagOfBytesToByteBufferConversionChunkSize) +
-                String(repeating: "2", count: bagOfBytesToByteBufferConversionChunkSize)
+                    String(repeating: "1", count: bagOfBytesToByteBufferConversionChunkSize) +
+                    String(repeating: "2", count: bagOfBytesToByteBufferConversionChunkSize)
             ).utf8,
             length: .known(bagOfBytesToByteBufferConversionChunkSize * 3)
         ).collect()
-        
+
         let expectedChunks = [
             ByteBuffer(repeating: UInt8(ascii: "0"), count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: UInt8(ascii: "1"), count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: UInt8(ascii: "2"), count: bagOfBytesToByteBufferConversionChunkSize),
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
-    
+
     func testChunkingSequenceThatDoesNotImplementWithContiguousStorageIfAvailable() async throws {
         let bagOfBytesToByteBufferConversionChunkSize = 8
         let body = try await HTTPClientRequest.Body._bytes(
             AnySequence(
                 Array(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize) +
-                Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize)
+                    Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize)
             ),
             length: .known(bagOfBytesToByteBufferConversionChunkSize * 3),
             bagOfBytesToByteBufferConversionChunkSize: bagOfBytesToByteBufferConversionChunkSize,
             byteBufferMaxSize: byteBufferMaxSize
         ).collect()
-        
+
         let expectedChunks = [
             ByteBuffer(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize),
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
-    
+
     func testChunkingSequenceFastPath() async throws {
         func makeBytes() -> some Sequence<UInt8> & Sendable {
             Array(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
+                Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
+                Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
         }
         let body = try await HTTPClientRequest.Body.bytes(
             makeBytes(),
             length: .known(bagOfBytesToByteBufferConversionChunkSize * 3)
         ).collect()
-        
+
         var firstChunk = ByteBuffer(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize)
         firstChunk.writeImmutableBuffer(ByteBuffer(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize))
         firstChunk.writeImmutableBuffer(ByteBuffer(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize))
         let expectedChunks = [
-            firstChunk
+            firstChunk,
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
-    
+
     func testChunkingSequenceFastPathExceedingByteBufferMaxSize() async throws {
         let bagOfBytesToByteBufferConversionChunkSize = 8
         let byteBufferMaxSize = 16
         func makeBytes() -> some Sequence<UInt8> & Sendable {
             Array(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
+                Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
+                Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
         }
         let body = try await HTTPClientRequest.Body._bytes(
             makeBytes(),
@@ -557,7 +557,7 @@ class HTTPClientRequestTests: XCTestCase {
             bagOfBytesToByteBufferConversionChunkSize: bagOfBytesToByteBufferConversionChunkSize,
             byteBufferMaxSize: byteBufferMaxSize
         ).collect()
-        
+
         var firstChunk = ByteBuffer(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize)
         firstChunk.writeImmutableBuffer(ByteBuffer(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize))
         let secondChunk = ByteBuffer(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
@@ -565,46 +565,46 @@ class HTTPClientRequestTests: XCTestCase {
             firstChunk,
             secondChunk,
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
-    
+
     func testBodyStringChunking() throws {
         let body = try HTTPClient.Body.string(
             String(repeating: "0", count: bagOfBytesToByteBufferConversionChunkSize) +
-            String(repeating: "1", count: bagOfBytesToByteBufferConversionChunkSize) +
-            String(repeating: "2", count: bagOfBytesToByteBufferConversionChunkSize)
+                String(repeating: "1", count: bagOfBytesToByteBufferConversionChunkSize) +
+                String(repeating: "2", count: bagOfBytesToByteBufferConversionChunkSize)
         ).collect().wait()
-        
+
         let expectedChunks = [
             ByteBuffer(repeating: UInt8(ascii: "0"), count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: UInt8(ascii: "1"), count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: UInt8(ascii: "2"), count: bagOfBytesToByteBufferConversionChunkSize),
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
-    
+
     func testBodyChunkingRandomAccessCollection() throws {
         let body = try HTTPClient.Body.bytes(
             Array(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
-            Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
+                Array(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize) +
+                Array(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize)
         ).collect().wait()
-        
+
         let expectedChunks = [
             ByteBuffer(repeating: 0, count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: 1, count: bagOfBytesToByteBufferConversionChunkSize),
             ByteBuffer(repeating: 2, count: bagOfBytesToByteBufferConversionChunkSize),
         ]
-        
+
         XCTAssertEqual(body, expectedChunks)
     }
 }
 
 extension AsyncSequence {
     func collect() async throws -> [Element] {
-        try await self.reduce(into: [], { $0 += CollectionOfOne($1) })
+        try await self.reduce(into: []) { $0 += CollectionOfOne($1) }
     }
 }
 


### PR DESCRIPTION
### Motivation
If the `HTTPClientRequest.Body` is created from a type that is not `ByteBuffer`, we need to convert it to it at some point. 
`ByteBuffer` can only hold up to `Int32.max` on 32-bit platforms and `UInt32.max` on 64-bit platforms and crashes if it exceeds this size limit. 

### Modification
- Convert from `some Sequence<UInt8>`, some Collection<UInt8>`, some RandomAccessCollection<UInt8>` and `String` in lazy chunks if the input exceeds 4 MB. 
- `some Sequence<UInt8>` is special as it can't be efficiently chunked lazily. Therefore we need to do the chunking eagerly if it implements the fast path `withContiguousStorageIfAvailable`. Otherwise we do the chunking lazy but "slowly".
- conform `HTTPClientRequest.Body` to `AsyncSequence` to make testing easier.

### Result
Converting from `some Sequence<UInt8>`, some Collection<UInt8>`, some RandomAccessCollection<UInt8>` and `String` to `ByteBuffer` will no longer crash for inputs that are larger than 4GB. Conversion above 4MB is now more memory efficient as we do it lazily and not eagerly all at once. 