### PR TITLE
Fix wrong/outdated `connect` timeout documentation

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -923,7 +923,7 @@ extension HTTPClient: @unchecked Sendable {}
 extension HTTPClient.Configuration {
     /// Timeout configuration.
     public struct Timeout: Sendable {
-        /// Specifies connect timeout. If no connect timeout is given, a default 30 seconds timeout will applied.
+        /// Specifies connect timeout. If no connect timeout is given, a default 10 seconds timeout will be applied.
         public var connect: TimeAmount?
         /// Specifies read timeout.
         public var read: TimeAmount?


### PR DESCRIPTION
The documentation states `30 seconds` but other documentations and the implementation all agree on `10 seconds` timeout as `HTTPClient.Configuration.connect`.