### PR TITLE
Add missing availability guards in tests

### DIFF
--- a/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
+++ b/Sources/AsyncHTTPClient/NIOTransportServices/TLSConfiguration.swift
@@ -57,7 +57,7 @@ extension TLSVersion {
     }
 }
 
-@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
 extension TLSConfiguration {
     /// Dispatch queue used by Network framework TLS to control certificate verification
     static var tlsDispatchQueue = DispatchQueue(label: "TLSDispatch")

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -33,6 +33,7 @@ private func makeDefaultHTTPClient(
     )
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class AsyncAwaitEndToEndTests: XCTestCase {
     var clientGroup: EventLoopGroup!
     var serverGroup: EventLoopGroup!
@@ -56,7 +57,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testSimpleGet() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -77,7 +77,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testSimplePost() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -98,7 +97,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithByteBuffer() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -121,7 +119,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithSequenceOfUInt8() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -144,7 +141,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithCollectionOfUInt8() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -167,7 +163,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithRandomAccessCollectionOfUInt8() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -190,7 +185,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithAsyncSequenceOfByteBuffers() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -217,7 +211,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithAsyncSequenceOfUInt8() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -240,7 +233,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithFragmentedAsyncSequenceOfByteBuffers() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -280,7 +272,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testPostWithFragmentedAsyncSequenceOfLargeByteBuffers() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -321,7 +312,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testCanceling() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -344,7 +334,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testCancelingResponseBody() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false)) { _ in
                 HTTPEchoHandler()
@@ -373,7 +362,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testDeadline() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -398,7 +386,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testImmediateDeadline() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -423,7 +410,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testConnectTimeout() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 60) {
             #if os(Linux)
             // 198.51.100.254 is reserved for documentation only and therefore should not accept any TCP connection
@@ -480,7 +466,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testSelfSignedCertificateIsRejectedWithCorrectErrorIfRequestDeadlineIsExceeded() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             /// key + cert was created with the follwing command:
             /// openssl req -x509 -newkey rsa:4096 -keyout self_signed_key.pem -out self_signed_cert.pem -sha256 -days 99999 -nodes -subj '/CN=localhost'
@@ -526,7 +511,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testDnsOverride() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             /// key + cert was created with the following code (depends on swift-certificates)
             /// ```
@@ -584,7 +568,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testInvalidURL() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 5) {
             let client = makeDefaultHTTPClient()
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -598,7 +581,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testRedirectChangesHostHeader() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -625,7 +607,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testShutdown() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let client = makeDefaultHTTPClient()
             try await client.shutdown()
@@ -637,7 +618,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
 
     /// Regression test for https://github.com/swift-server/async-http-client/issues/612
     func testCancelingBodyDoesNotCrash() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let client = makeDefaultHTTPClient()
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
@@ -654,7 +634,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testAsyncSequenceReuse() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false)) { _ in HTTPEchoHandler() }
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -698,7 +677,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     private func _rejectsInvalidCharactersInHeaderFieldNames(mode: HTTPBin<HTTPBinHandler>.Mode) {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(mode)
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -759,7 +737,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     private func _rejectsInvalidCharactersInHeaderFieldValues(mode: HTTPBin<HTTPBinHandler>.Mode) {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(mode)
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -818,7 +795,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testUsingGetMethodInsteadOfWait() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }
@@ -838,7 +814,6 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testSimpleContentLengthErrorNoBody() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let bin = HTTPBin(.http2(compress: false))
             defer { XCTAssertNoThrow(try bin.shutdown()) }

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -17,15 +17,13 @@ import Algorithms
 import NIOCore
 import XCTest
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 class HTTPClientRequestTests: XCTestCase {
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     private typealias Request = HTTPClientRequest
 
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     private typealias PreparedRequest = HTTPClientRequest.Prepared
 
     func testCustomHeadersAreRespected() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "https://example.com/get")
             request.headers = [
@@ -60,7 +58,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testUnixScheme() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "unix://%2Fexample%2Ffolder.sock/some_path")
             request.headers = ["custom-header": "custom-value"]
@@ -90,7 +87,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testHTTPUnixScheme() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http+unix://%2Fexample%2Ffolder.sock/some_path")
             request.headers = ["custom-header": "custom-value"]
@@ -120,7 +116,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testHTTPSUnixScheme() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "https+unix://%2Fexample%2Ffolder.sock/some_path")
             request.headers = ["custom-header": "custom-value"]
@@ -150,7 +145,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testGetWithoutBody() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let request = Request(url: "https://example.com/get")
             var preparedRequest: PreparedRequest?
@@ -179,7 +173,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithoutBody() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -213,7 +206,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithEmptyByteBuffer() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -248,7 +240,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithByteBuffer() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -282,7 +273,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithSequenceOfUnknownLength() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -317,7 +307,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithSequenceWithFixedLength() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -353,7 +342,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithRandomAccessCollection() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -388,7 +376,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithAsyncSequenceOfUnknownLength() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -428,7 +415,6 @@ class HTTPClientRequestTests: XCTestCase {
     }
 
     func testPostWithAsyncSequenceWithKnownLength() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             var request = Request(url: "http://example.com/post")
             request.method = .POST
@@ -602,6 +588,7 @@ class HTTPClientRequestTests: XCTestCase {
     }
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension AsyncSequence {
     func collect() async throws -> [Element] {
         try await self.reduce(into: []) { $0 += CollectionOfOne($1) }

--- a/Tests/AsyncHTTPClientTests/HTTPClientResponseTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientResponseTests.swift
@@ -17,6 +17,7 @@ import Logging
 import NIOCore
 import XCTest
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class HTTPClientResponseTests: XCTestCase {
     func testSimpleResponse() {
         let response = HTTPClientResponse.expectedContentLength(requestMethod: .GET, headers: ["content-length": "1025"], status: .ok)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -3526,6 +3526,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         XCTAssertEqual(.ok, response.status)
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testAsyncExecuteWithCustomTLS() async throws {
         let httpsBin = HTTPBin(.http1_1(ssl: true))
         defer {

--- a/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/NWWaitingHandlerTests.swift
@@ -21,7 +21,7 @@ import NIOSSL
 import NIOTransportServices
 import XCTest
 
-@available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+@available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)
 class NWWaitingHandlerTests: XCTestCase {
     class MockRequester: HTTPConnectionRequester {
         var waitingForConnectivityCalled = false

--- a/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests.swift
+++ b/Tests/AsyncHTTPClientTests/Transaction+StateMachineTests.swift
@@ -23,9 +23,9 @@ struct NoOpAsyncSequenceProducerDelegate: NIOAsyncSequenceProducerDelegate {
     func didTerminate() {}
 }
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class Transaction_StateMachineTests: XCTestCase {
     func testRequestWasQueuedAfterWillExecuteRequestWasCalled() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
@@ -53,7 +53,6 @@ final class Transaction_StateMachineTests: XCTestCase {
     }
 
     func testRequestBodyStreamWasPaused() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
@@ -75,7 +74,6 @@ final class Transaction_StateMachineTests: XCTestCase {
 
     func testQueuedRequestGetsRemovedWhenDeadlineExceeded() {
         struct MyError: Error, Equatable {}
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
                 var state = Transaction.StateMachine(continuation)
@@ -106,7 +104,6 @@ final class Transaction_StateMachineTests: XCTestCase {
 
     func testDeadlineExceededAndFullyFailedRequestCanBeCanceledWithNoEffect() {
         struct MyError: Error, Equatable {}
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
                 var state = Transaction.StateMachine(continuation)
@@ -141,7 +138,6 @@ final class Transaction_StateMachineTests: XCTestCase {
     }
 
     func testScheduledRequestGetsRemovedWhenDeadlineExceeded() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
@@ -166,7 +162,6 @@ final class Transaction_StateMachineTests: XCTestCase {
     }
 
     func testDeadlineExceededRaceWithRequestWillExecute() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {
@@ -198,7 +193,6 @@ final class Transaction_StateMachineTests: XCTestCase {
     }
 
     func testRequestWithHeadReceivedGetNotCancelledWhenDeadlineExceeded() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         let eventLoop = EmbeddedEventLoop()
         XCTAsyncTest {
             func workaround(_ continuation: CheckedContinuation<HTTPClientResponse, Error>) {

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -24,9 +24,9 @@ import XCTest
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 typealias PreparedRequest = HTTPClientRequest.Prepared
 
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class TransactionTests: XCTestCase {
     func testCancelAsyncRequest() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         // creating the `XCTestExpectation` off the main thread crashes on Linux with Swift 5.6
         // therefore we create it here as a workaround which works fine
         let scheduledRequestCanceled = self.expectation(description: "scheduled request canceled")
@@ -69,7 +69,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testDeadlineExceededWhileQueuedAndExecutorImmediatelyCancelsTask() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -118,7 +117,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testResponseStreamingWorks() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -178,7 +176,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testIgnoringResponseBodyWorks() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -227,7 +224,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testWriteBackpressureWorks() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -299,7 +295,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testSimpleGetRequest() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             let eventLoop = eventLoopGroup.next()
@@ -355,7 +350,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testSimplePostRequest() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -393,7 +387,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testPostStreamFails() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -436,7 +429,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testResponseStreamFails() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest(timeout: 30) {
             let embeddedEventLoop = EmbeddedEventLoop()
             defer { XCTAssertNoThrow(try embeddedEventLoop.syncShutdownGracefully()) }
@@ -499,7 +491,6 @@ final class TransactionTests: XCTestCase {
     }
 
     func testBiDirectionalStreamingHTTP2() {
-        guard #available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *) else { return }
         XCTAsyncTest {
             let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
             let eventLoop = eventLoopGroup.next()

--- a/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
+++ b/Tests/AsyncHTTPClientTests/XCTest+AsyncAwait.swift
@@ -30,7 +30,6 @@
 import XCTest
 
 extension XCTestCase {
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     /// Cross-platform XCTest support for async-await tests.
     ///
     /// Currently the Linux implementation of XCTest doesn't have async-await support.
@@ -39,6 +38,7 @@ extension XCTestCase {
     ///
     /// - NOTE: Support for Linux is tracked by https://bugs.swift.org/browse/SR-14403.
     /// - NOTE: Implementation currently in progress: https://github.com/apple/swift-corelibs-xctest/pull/326
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func XCTAsyncTest(
         expectationDescription: String = "Async operation",
         timeout: TimeInterval = 30,


### PR DESCRIPTION
## Motivation

Some of the test code was missing availability guards for Apple platforms, resulting in build failures for these platforms, e.g.

```
error: 'AsyncSequence' is only available in iOS 13.0 or newer
```

## Modifications

Add missing availability guards. I've tried to keep them as scoped as possible.

## Result

Tests can now build for run on iOS and other Apple platforms.