### PR TITLE
Fix potential race conditions when cancelling read/write idle timers

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP1/HTTP1ClientChannelHandler.swift
@@ -60,17 +60,13 @@ final class HTTP1ClientChannelHandler: ChannelDuplexHandler {
     private var idleReadTimeoutStateMachine: IdleReadStateMachine?
     private var idleReadTimeoutTimer: Scheduled<Void>?
 
-    /// Cancelling a task in NIO does *not* guarantee that the task will not execute under certain race conditions.
-    /// We therefore give each timer an ID and increase the ID every time we reset or cancel it.
-    /// We check in the task if the timer ID has changed in the meantime and do not execute any action if has changed.
-    private var currentIdleReadTimeoutTimerID: Int = 0
-
     private var idleWriteTimeoutStateMachine: IdleWriteStateMachine?
     private var idleWriteTimeoutTimer: Scheduled<Void>?
 
     /// Cancelling a task in NIO does *not* guarantee that the task will not execute under certain race conditions.
     /// We therefore give each timer an ID and increase the ID every time we reset or cancel it.
     /// We check in the task if the timer ID has changed in the meantime and do not execute any action if has changed.
+    private var currentIdleReadTimeoutTimerID: Int = 0
     private var currentIdleWriteTimeoutTimerID: Int = 0
 
     private let backgroundLogger: Logger


### PR DESCRIPTION
## Motivation
This PR is a follow-up to https://github.com/swift-server/async-http-client/pull/718. It applies the same modifications done in https://github.com/swift-server/async-http-client/pull/455 to the HTTP2 request handler to avoid a race condition when cancelling idle timers.

## Modifications
A new timer ID for each timer (read and write idle timeouts) has been added to keep track of the current idle timers, just like it's done in the HTTP1 implementation.

## Result
No more race conditions when cancelling timers in HTTP2.