### PR TITLE
Use the given connection pool idle timeout in the HTTPClient.Configuration inits

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -775,7 +775,7 @@ public class HTTPClient {
             self.init(tlsConfiguration: tlsConfig,
                       redirectConfiguration: redirectConfiguration,
                       timeout: timeout,
-                      connectionPool: ConnectionPool(),
+                      connectionPool: ConnectionPool(idleTimeout: maximumAllowedIdleTimeInConnectionPool),
                       proxy: proxy,
                       ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                       decompression: decompression)
@@ -794,7 +794,7 @@ public class HTTPClient {
             self.init(tlsConfiguration: tlsConfig,
                       redirectConfiguration: redirectConfiguration,
                       timeout: timeout,
-                      connectionPool: ConnectionPool(),
+                      connectionPool: ConnectionPool(idleTimeout: connectionPool),
                       proxy: proxy,
                       ignoreUncleanSSLShutdown: ignoreUncleanSSLShutdown,
                       decompression: decompression)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -1851,13 +1851,13 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
             certificateVerification: .none,
             maximumAllowedIdleTimeInConnectionPool: .milliseconds(100)
         )
-        
+
         let localClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                      configuration: configuration)
         defer {
             XCTAssertNoThrow(try localClient.syncShutdown())
         }
-        
+
         // Make sure that the idle timeout of the connection pool is properly propagated
         // to the connection pool itself, when using both inits.
         XCTAssertEqual(configuration.connectionPool.idleTimeout, .milliseconds(100))


### PR DESCRIPTION
## Motivation
We provide some initialisers for `HTTPClient.Configuration` where users can provide idle timeouts for the connection pools used. However, we don't propagate those values down to the connection pool. This caused bugs in adopters' code.

## Modifications
Propagate the idle timeout down to the connection pool.

## Result
The given idle timeout is now actually used.