### PR TITLE
Update minimum swift-nio version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.58.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.22.0"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.13.0"),


### PR DESCRIPTION
## Motivation

https://github.com/swift-server/async-http-client/pull/718 moved to `TransactionBody.makeSequence(backPressureStrategy:finishOnDeinit:delegate:)` (from `TransactionBody.makeSequence(backPressureStrategy:delegate:)`). This change was introduced in `swift-nil`, v2.62.0 - however, the minimum version of NIO for this package was not updated, which can cause some dependency issues for some users.

## Modifications

Update the required min version of `swift-nio` to 2.62.0 (up from 2.58.0).

## Result

No more dependency issues.