### PR TITLE
Add support for Musl.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,12 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
     ],
     targets: [
-        .target(name: "CAsyncHTTPClient"),
+        .target(
+            name: "CAsyncHTTPClient",
+            cSettings: [
+                .define("_GNU_SOURCE"),
+            ]
+        ),
         .target(
             name: "AsyncHTTPClient",
             dependencies: [

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -16,6 +16,8 @@ import NIOSSL
 
 #if canImport(Darwin)
 import Darwin.C
+#elseif canImport(Musl)
+import Musl
 #elseif os(Linux) || os(FreeBSD) || os(Android)
 import Glibc
 #else

--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+Backoff.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+Backoff.swift
@@ -15,6 +15,8 @@
 import NIOCore
 #if canImport(Darwin)
 import func Darwin.pow
+#elseif canImport(Musl)
+import func Musl.pow
 #else
 import func Glibc.pow
 #endif

--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -15,6 +15,8 @@
 import NIOHTTP1
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif

--- a/Sources/CAsyncHTTPClient/CAsyncHTTPClient.c
+++ b/Sources/CAsyncHTTPClient/CAsyncHTTPClient.c
@@ -15,7 +15,6 @@
 #if __APPLE__
     #include <xlocale.h>
 #elif __linux__
-    #define _GNU_SOURCE
     #include <locale.h>
 #endif
 
@@ -32,7 +31,11 @@ bool swiftahc_cshims_strptime(const char * string, const char * format, struct t
 
 bool swiftahc_cshims_strptime_l(const char * string, const char * format, struct tm * result, void * locale) {
     // The pointer cast is fine as long we make sure it really points to a locale_t.
+#ifdef __musl__
+    const char * firstNonProcessed = strptime(string, format, result);
+#else
     const char * firstNonProcessed = strptime_l(string, format, result, (locale_t)locale);
+#endif
     if (firstNonProcessed) {
         return *firstNonProcessed == 0;
     }

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -30,6 +30,8 @@ import NIOTransportServices
 import XCTest
 #if canImport(Darwin)
 import Darwin
+#elseif canImport(Musl)
+import Musl
 #elseif canImport(Glibc)
 import Glibc
 #endif


### PR DESCRIPTION
## Motivation

We would like to make this work for Musl so that we can build fully statically linked binaries that use AsyncHTTPClient.

## Modifications

Define `_GNU_SOURCE` as a compiler argument; doing it in a source file doesn't work properly with modular headers.

Add imports of `Musl` in appropriate places.

`Musl` doesn't have `strptime_l`, so avoid using that.

## Result

async-http-client will build for Musl.