### PR TITLE
Update async usages in README and examples to shutdown properly

### DIFF
--- a/Examples/GetHTML/GetHTML.swift
+++ b/Examples/GetHTML/GetHTML.swift
@@ -29,6 +29,6 @@ struct GetHTML {
             print("request failed:", error)
         }
         // it is important to shutdown the httpClient after all requests are done, even if one failed
-        try await httpClient.shutdown()
+        try await httpClient.shutdown().get()
     }
 }

--- a/Examples/GetJSON/GetJSON.swift
+++ b/Examples/GetJSON/GetJSON.swift
@@ -47,6 +47,6 @@ struct GetJSON {
             print("request failed:", error)
         }
         // it is important to shutdown the httpClient after all requests are done, even if one failed
-        try await httpClient.shutdown()
+        try await httpClient.shutdown().get()
     }
 }

--- a/Examples/StreamingByteCounter/StreamingByteCounter.swift
+++ b/Examples/StreamingByteCounter/StreamingByteCounter.swift
@@ -45,6 +45,6 @@ struct StreamingByteCounter {
             print("request failed:", error)
         }
         // it is important to shutdown the httpClient after all requests are done, even if one failed
-        try await httpClient.shutdown()
+        try await httpClient.shutdown().get()
     }
 }

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ do {
     // handle error
 }
 // it's important to shutdown the httpClient after all requests are done, even if one failed
-try await httpClient.shutdown()
+try await httpClient.shutdown().get()
 ```
 
 #### Using SwiftNIO EventLoopFuture
@@ -175,7 +175,7 @@ do {
     print("request failed:", error)
 }
 // it is important to shutdown the httpClient after all requests are done, even if one failed
-try await httpClient.shutdown()
+try await httpClient.shutdown().get()
 ```
 
 #### Using HTTPClientResponseDelegate and SwiftNIO EventLoopFuture


### PR DESCRIPTION
Motivation:

In several examples of async/await support, the call to shutdown() on the HTTPClient are made with await but do not call get() on the EventLoopFuture.

Modifications:

Add the .get() call in four locations that need it.

Result:

After fixing this, the client should properly get closed down and there are no longer warnings emitted by the compiler.