### PR TITLE
Fix write timeout not being initialised

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -961,6 +961,7 @@ extension HTTPClient.Configuration {
         ) {
             self.connect = connect
             self.read = read
+            self.write = write
         }
     }
 


### PR DESCRIPTION
## Motivation
The write timeout was being received as a parameter in the config's initialiser, but it wasn't being set on the config struct. Also tests for the write timeout were missing.

## Modifications
- The write timeout value is now set on init.
- There are now tests for the write timeout.

## Result
Proper idle write timeouts and tests.