### PR TITLE
Move availability guard to correct test

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -3574,7 +3574,6 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         XCTAssertEqual(.ok, response.status)
     }
 
-    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testSingletonClientWorks() throws {
         let response = try HTTPClient.shared.get(url: self.defaultHTTPBinURLPrefix + "get").wait()
         XCTAssertEqual(.ok, response.status)
@@ -3586,6 +3585,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         }
     }
 
+    @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
     func testAsyncExecuteWithCustomTLS() async throws {
         let httpsBin = HTTPBin(.http1_1(ssl: true))
         defer {


### PR DESCRIPTION
It was previously (https://github.com/swift-server/async-http-client/pull/705/files#diff-5c6f847a120449cc304f0b6bf128d6815957bc27adb6c8af024809e132210529R3577) accidentally (i assume) moved to a different test, which does not need it 

Async tests need the guard for macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0