### PR TITLE
Increase decompression limit ratio of `HTTPClient.shared` 10 -> 25

### DIFF
--- a/Sources/AsyncHTTPClient/Configuration+BrowserLike.swift
+++ b/Sources/AsyncHTTPClient/Configuration+BrowserLike.swift
@@ -34,7 +34,7 @@ extension HTTPClient.Configuration {
             connectionPool: .seconds(600),
             proxy: nil,
             ignoreUncleanSSLShutdown: false,
-            decompression: .enabled(limit: .ratio(10)),
+            decompression: .enabled(limit: .ratio(25)),
             backgroundActivityLogger: nil
         )
     }


### PR DESCRIPTION
This enables the decompressor to decompress files that have been 96% compressed, instead of the previous 90%, when using `HTTPClient.shared`.

See https://github.com/swift-server/async-http-client/issues/739.

I'm also fine with decreasing the ratio to 20, if 25 seems too high.