### PR TITLE
Disable SETTINGS_ENABLE_PUSH HTTP/2 setting

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
@@ -29,6 +29,8 @@ struct HTTP2PushNotSupportedError: Error {}
 struct HTTP2ReceivedGoAwayBeforeSettingsError: Error {}
 
 final class HTTP2Connection {
+    private static let defaultSettings = nioDefaultSettings + [HTTP2Setting(parameter: .enablePush, value: 0)]
+
     let channel: Channel
     let multiplexer: HTTP2StreamMultiplexer
     let logger: Logger
@@ -196,7 +198,7 @@ final class HTTP2Connection {
             // can be scheduled on this connection.
             let sync = self.channel.pipeline.syncOperations
 
-            let http2Handler = NIOHTTP2Handler(mode: .client, initialSettings: nioDefaultSettings)
+            let http2Handler = NIOHTTP2Handler(mode: .client, initialSettings: Self.defaultSettings)
             let idleHandler = HTTP2IdleHandler(delegate: self, logger: self.logger, maximumConnectionUses: self.maximumConnectionUses)
 
             try sync.addHandler(http2Handler, position: .last)

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2Connection.swift
@@ -29,7 +29,7 @@ struct HTTP2PushNotSupportedError: Error {}
 struct HTTP2ReceivedGoAwayBeforeSettingsError: Error {}
 
 final class HTTP2Connection {
-    private static let defaultSettings = nioDefaultSettings + [HTTP2Setting(parameter: .enablePush, value: 0)]
+    internal static let defaultSettings = nioDefaultSettings + [HTTP2Setting(parameter: .enablePush, value: 0)]
 
     let channel: Channel
     let multiplexer: HTTP2StreamMultiplexer

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -18,6 +18,7 @@ import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
 import NIOHTTP1
+import NIOHTTP2
 import NIOPosix
 import NIOSSL
 import NIOTestUtils
@@ -337,6 +338,28 @@ class HTTP2ConnectionTests: XCTestCase {
             retryCount += 1
         }
         XCTAssertLessThan(retryCount, maxRetries)
+    }
+    
+    func testServerPushIsDisabled() {
+        let embedded = EmbeddedChannel()
+        let logger = Logger(label: "test.http2.connection")
+        let connection = HTTP2Connection(
+            channel: embedded,
+            connectionID: 0,
+            decompression: .disabled,
+            maximumConnectionUses: nil,
+            delegate: TestHTTP2ConnectionDelegate(),
+            logger: logger
+        )
+        _ = connection._start0()
+        
+        let settingsFrame = HTTP2Frame(streamID: 0, payload: .settings(.settings([])))
+        XCTAssertNoThrow(try connection.channel.writeAndFlush(settingsFrame).wait())
+
+        let pushPromiseFrame = HTTP2Frame(streamID: 0, payload: .pushPromise(.init(pushedStreamID: 1, headers: [:])))
+        XCTAssertThrowsError(try connection.channel.writeAndFlush(pushPromiseFrame).wait()) { error in
+            XCTAssertNotNil(error as? NIOHTTP2Errors.PushInViolationOfSetting)
+        }
     }
 }
 

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -339,7 +339,7 @@ class HTTP2ConnectionTests: XCTestCase {
         }
         XCTAssertLessThan(retryCount, maxRetries)
     }
-    
+
     func testServerPushIsDisabled() {
         let embedded = EmbeddedChannel()
         let logger = Logger(label: "test.http2.connection")
@@ -352,7 +352,7 @@ class HTTP2ConnectionTests: XCTestCase {
             logger: logger
         )
         _ = connection._start0()
-        
+
         let settingsFrame = HTTP2Frame(streamID: 0, payload: .settings(.settings([])))
         XCTAssertNoThrow(try connection.channel.writeAndFlush(settingsFrame).wait())
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import AsyncHTTPClient
+@testable import AsyncHTTPClient
 import Atomics
 import Foundation
 import Logging
@@ -361,10 +361,7 @@ internal final class HTTPBin<RequestHandler: ChannelInboundHandler> where
         var httpSettings: HTTP2Settings {
             switch self {
             case .http1_1, .http2(_, _, nil), .refuse:
-                return [
-                    HTTP2Setting(parameter: .maxConcurrentStreams, value: 10),
-                    HTTP2Setting(parameter: .maxHeaderListSize, value: HPACKDecoder.defaultMaxHeaderListSize),
-                ]
+                return HTTP2Connection.defaultSettings
             case .http2(_, _, .some(let customSettings)):
                 return customSettings
             }


### PR DESCRIPTION
This solves https://github.com/swift-server/async-http-client/issues/737

We are currently creating H2 connections using the default NIO settings, but this means we weren't sending `SETTING_ENABLE_PUSH=0`. This caused the server to push streams to the client, which messed up the stream count logic (as we were assuming only the client could create new streams), resulting in a precondition failure when releasing streams.

This PR updates the settings to disable the `enablePush` setting.