### PR TITLE
Update Examples to use `.singleton`

### DIFF
--- a/Examples/GetHTML/GetHTML.swift
+++ b/Examples/GetHTML/GetHTML.swift
@@ -18,7 +18,7 @@ import NIOCore
 @main
 struct GetHTML {
     static func main() async throws {
-        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         do {
             let request = HTTPClientRequest(url: "https://apple.com")
             let response = try await httpClient.execute(request, timeout: .seconds(30))

--- a/Examples/GetJSON/GetJSON.swift
+++ b/Examples/GetJSON/GetJSON.swift
@@ -33,7 +33,7 @@ struct Comic: Codable {
 @main
 struct GetJSON {
     static func main() async throws {
-        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         do {
             let request = HTTPClientRequest(url: "https://xkcd.com/info.0.json")
             let response = try await httpClient.execute(request, timeout: .seconds(30))

--- a/Examples/StreamingByteCounter/StreamingByteCounter.swift
+++ b/Examples/StreamingByteCounter/StreamingByteCounter.swift
@@ -18,7 +18,7 @@ import NIOCore
 @main
 struct StreamingByteCounter {
     static func main() async throws {
-        let httpClient = HTTPClient(eventLoopGroupProvider: .createNew)
+        let httpClient = HTTPClient(eventLoopGroupProvider: .singleton)
         do {
             let request = HTTPClientRequest(url: "https://apple.com")
             let response = try await httpClient.execute(request, timeout: .seconds(30))


### PR DESCRIPTION
The README was updated to use `.singleton` in all the examples as a part of this PR: https://github.com/swift-server/async-http-client/pull/697, but it looks like the files in /Examples were missed.