### PR TITLE
Make ConnectionPool's `retryConnectionEstablishment` public

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1031,10 +1031,10 @@ extension HTTPClient.Configuration {
             self.init(idleTimeout: idleTimeout, concurrentHTTP1ConnectionsPerHostSoftLimit: 8)
         }
 
-        public init(idleTimeout: TimeAmount, concurrentHTTP1ConnectionsPerHostSoftLimit: Int) {
+        public init(idleTimeout: TimeAmount, concurrentHTTP1ConnectionsPerHostSoftLimit: Int, retryConnectionEstablishment: Bool = true) {
             self.idleTimeout = idleTimeout
             self.concurrentHTTP1ConnectionsPerHostSoftLimit = concurrentHTTP1ConnectionsPerHostSoftLimit
-            self.retryConnectionEstablishment = true
+            self.retryConnectionEstablishment = retryConnectionEstablishment
         }
     }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1012,11 +1012,11 @@ extension HTTPClient.Configuration {
     public struct ConnectionPool: Hashable, Sendable {
         /// Specifies amount of time connections are kept idle in the pool. After this time has passed without a new
         /// request the connections are closed.
-        public var idleTimeout: TimeAmount
+        public var idleTimeout: TimeAmount = .seconds(60)
 
         /// The maximum number of connections that are kept alive in the connection pool per host. If requests with
         /// an explicit eventLoopRequirement are sent, this number might be exceeded due to overflow connections.
-        public var concurrentHTTP1ConnectionsPerHostSoftLimit: Int
+        public var concurrentHTTP1ConnectionsPerHostSoftLimit: Int = 8
 
         /// If true, ``HTTPClient`` will try to create new connections on connection failure with an exponential backoff.
         /// Requests will only fail after the ``HTTPClient/Configuration/Timeout-swift.struct/connect`` timeout exceeded.
@@ -1025,22 +1025,17 @@ extension HTTPClient.Configuration {
         /// - warning: We highly recommend leaving this on.
         /// It is very common that connections establishment is flaky at scale.
         /// ``HTTPClient`` will automatically mitigate these kind of issues if this flag is turned on.
-        public var retryConnectionEstablishment: Bool
+        public var retryConnectionEstablishment: Bool = true
 
-        public init() {
-            self.idleTimeout = .seconds(60)
-            self.concurrentHTTP1ConnectionsPerHostSoftLimit = 8
-            self.retryConnectionEstablishment = true
-        }
-
-        public init(idleTimeout: TimeAmount = .seconds(60)) {
-            self.init(idleTimeout: idleTimeout, concurrentHTTP1ConnectionsPerHostSoftLimit: 8)
+        public init() {}
+        
+        public init(idleTimeout: TimeAmount) {
+            self.idleTimeout = idleTimeout
         }
 
         public init(idleTimeout: TimeAmount, concurrentHTTP1ConnectionsPerHostSoftLimit: Int) {
             self.idleTimeout = idleTimeout
             self.concurrentHTTP1ConnectionsPerHostSoftLimit = concurrentHTTP1ConnectionsPerHostSoftLimit
-            self.retryConnectionEstablishment = true
         }
     }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1028,7 +1028,6 @@ extension HTTPClient.Configuration {
         public var retryConnectionEstablishment: Bool = true
 
         public init() {}
-        
         public init(idleTimeout: TimeAmount) {
             self.idleTimeout = idleTimeout
         }

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1027,6 +1027,12 @@ extension HTTPClient.Configuration {
         /// ``HTTPClient`` will automatically mitigate these kind of issues if this flag is turned on.
         public var retryConnectionEstablishment: Bool
 
+        public init() {
+            self.idleTimeout = .seconds(60)
+            self.concurrentHTTP1ConnectionsPerHostSoftLimit = 8
+            self.retryConnectionEstablishment = true
+        }
+
         public init(idleTimeout: TimeAmount = .seconds(60)) {
             self.init(idleTimeout: idleTimeout, concurrentHTTP1ConnectionsPerHostSoftLimit: 8)
         }

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1031,10 +1031,10 @@ extension HTTPClient.Configuration {
             self.init(idleTimeout: idleTimeout, concurrentHTTP1ConnectionsPerHostSoftLimit: 8)
         }
 
-        public init(idleTimeout: TimeAmount, concurrentHTTP1ConnectionsPerHostSoftLimit: Int, retryConnectionEstablishment: Bool = true) {
+        public init(idleTimeout: TimeAmount, concurrentHTTP1ConnectionsPerHostSoftLimit: Int) {
             self.idleTimeout = idleTimeout
             self.concurrentHTTP1ConnectionsPerHostSoftLimit = concurrentHTTP1ConnectionsPerHostSoftLimit
-            self.retryConnectionEstablishment = retryConnectionEstablishment
+            self.retryConnectionEstablishment = true
         }
     }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1025,7 +1025,7 @@ extension HTTPClient.Configuration {
         /// - warning: We highly recommend leaving this on.
         /// It is very common that connections establishment is flaky at scale.
         /// ``HTTPClient`` will automatically mitigate these kind of issues if this flag is turned on.
-        var retryConnectionEstablishment: Bool
+        public var retryConnectionEstablishment: Bool
 
         public init(idleTimeout: TimeAmount = .seconds(60)) {
             self.init(idleTimeout: idleTimeout, concurrentHTTP1ConnectionsPerHostSoftLimit: 8)

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1028,6 +1028,7 @@ extension HTTPClient.Configuration {
         public var retryConnectionEstablishment: Bool = true
 
         public init() {}
+
         public init(idleTimeout: TimeAmount) {
             self.idleTimeout = idleTimeout
         }

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -55,9 +55,8 @@ class HTTPClientNIOTSTests: XCTestCase {
         guard isTestingNIOTS() else { return }
 
         let httpBin = HTTPBin(.http1_1(ssl: true))
-        var config = HTTPClient.Configuration()
-        config.networkFrameworkWaitForConnectivity = false
-        config.connectionPool.retryConnectionEstablishment = false
+        let config = HTTPClient.Configuration()
+            .enableFastFailureModeForTesting()
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                     configuration: config)
         defer {
@@ -84,9 +83,8 @@ class HTTPClientNIOTSTests: XCTestCase {
         guard isTestingNIOTS() else { return }
         #if canImport(Network)
         let httpBin = HTTPBin(.http1_1(ssl: false))
-        var config = HTTPClient.Configuration()
-        config.networkFrameworkWaitForConnectivity = false
-        config.connectionPool.retryConnectionEstablishment = false
+        let config = HTTPClient.Configuration()
+            .enableFastFailureModeForTesting()
 
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup),
                                     configuration: config)
@@ -140,9 +138,8 @@ class HTTPClientNIOTSTests: XCTestCase {
         tlsConfig.minimumTLSVersion = .tlsv11
         tlsConfig.maximumTLSVersion = .tlsv1
 
-        var clientConfig = HTTPClient.Configuration(tlsConfiguration: tlsConfig)
-        clientConfig.networkFrameworkWaitForConnectivity = false
-        clientConfig.connectionPool.retryConnectionEstablishment = false
+        let clientConfig = HTTPClient.Configuration(tlsConfiguration: tlsConfig)
+            .enableFastFailureModeForTesting()
         let httpClient = HTTPClient(
             eventLoopGroupProvider: .shared(self.clientGroup),
             configuration: clientConfig


### PR DESCRIPTION
Currently, there is no way to instantly return when a connection attempt fails. The connection timeout is always awaited, regardless of the connection error. When used within a service, this behavior makes sense – network conditions may temporarily prevent establishing a connection. However, in a user-interactive environment, it's preferable to fail quickly and display the error to the user.

#625 introduced the property [`retryConnectionEstablishment`](https://github.com/swift-server/async-http-client/blob/0ae99db85b2b9d1e79b362bd31fd1ffe492f7c47/Sources/AsyncHTTPClient/HTTPClient.swift#L1028), which defaults to `true` but can be set to `false` to **not** retry on connection failure. The property was added to speed up unit tests, but would also be suitable for the use-case mentioned above.

This PR makes the property `retryConnectionEstablishment`, which is already documented and well tested, `public`.

This would fix #743.

The PR also cleans up some unit tests to consistently use [`enableFastFailureModeForTesting()`](https://github.com/swift-server/async-http-client/blob/0ae99db85b2b9d1e79b362bd31fd1ffe492f7c47/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift#L595) instead of setting `retryConnectionEstablishment` directly.

**Questions:**

- When using NIOTS, the HTTPClient.Configuration's property [`networkFrameworkWaitForConnectivity`](https://github.com/swift-server/async-http-client/blob/0ae99db85b2b9d1e79b362bd31fd1ffe492f7c47/Sources/AsyncHTTPClient/HTTPClient.swift#L727) **also** needs to be set to `false` to enable fast fail. Would it be worthwhile to have the ability to set both properties at once?