### PR TITLE
Fix leading slash issue in relative URL requests

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -639,7 +639,7 @@ extension URL {
         if self.path.isEmpty {
             return "/"
         }
-        return URLComponents(url: self, resolvingAgainstBaseURL: false)?.percentEncodedPath ?? self.path
+        return URLComponents(url: self, resolvingAgainstBaseURL: true)?.percentEncodedPath ?? self.path
     }
 
     var uri: String {

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -142,6 +142,24 @@ class HTTPClientInternalTests: XCTestCase {
         XCTAssertEqual(request12.url.uri, "/some%2Fpathsegment1/pathsegment2")
     }
 
+    func testURIOfRelativeURLRequest() throws {
+        let requestNoLeadingSlash = try Request(
+            url: URL(
+                string: "percent%2Fencoded/hello",
+                relativeTo: URL(string: "http://127.0.0.1")!
+            )!
+        )
+
+        let requestWithLeadingSlash = try Request(
+            url: URL(
+                string: "/percent%2Fencoded/hello",
+                relativeTo: URL(string: "http://127.0.0.1")!
+            )!
+        )
+
+        XCTAssertEqual(requestNoLeadingSlash.url.uri, requestWithLeadingSlash.url.uri)
+    }
+
     func testChannelAndDelegateOnDifferentEventLoops() throws {
         class Delegate: HTTPClientResponseDelegate {
             typealias Response = ([Message], [Message])

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -157,7 +157,8 @@ class HTTPClientInternalTests: XCTestCase {
             )!
         )
 
-        XCTAssertEqual(requestNoLeadingSlash.url.uri, requestWithLeadingSlash.url.uri)
+        XCTAssertEqual(requestNoLeadingSlash.url.uri, "/percent%2Fencoded/hello")
+        XCTAssertEqual(requestWithLeadingSlash.url.uri, "/percent%2Fencoded/hello")
     }
 
     func testChannelAndDelegateOnDifferentEventLoops() throws {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -505,7 +505,8 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         let noLeadingSlashURLResponse = try self.defaultClient.execute(request: noLeadingSlashURLRequest).wait()
         let withLeadingSlashURLResponse = try self.defaultClient.execute(request: withLeadingSlashURLRequest).wait()
 
-        XCTAssertEqual(noLeadingSlashURLResponse.status, withLeadingSlashURLResponse.status)
+        XCTAssertEqual(noLeadingSlashURLResponse.status, .ok)
+        XCTAssertEqual(withLeadingSlashURLResponse.status, .ok)
     }
 
     func testMultipleContentLengthHeaders() throws {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -495,6 +495,19 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         XCTAssertEqual(.ok, response.status)
     }
 
+    func testLeadingSlashRelativeURL() throws {
+        let noLeadingSlashURL = URL(string: "percent%2Fencoded/hello", relativeTo: URL(string: self.defaultHTTPBinURLPrefix)!)!
+        let withLeadingSlashURL = URL(string: "/percent%2Fencoded/hello", relativeTo: URL(string: self.defaultHTTPBinURLPrefix)!)!
+
+        let noLeadingSlashURLRequest = try HTTPClient.Request(url: noLeadingSlashURL, method: .GET)
+        let withLeadingSlashURLRequest = try HTTPClient.Request(url: withLeadingSlashURL, method: .GET)
+
+        let noLeadingSlashURLResponse = try self.defaultClient.execute(request: noLeadingSlashURLRequest).wait()
+        let withLeadingSlashURLResponse = try self.defaultClient.execute(request: withLeadingSlashURLRequest).wait()
+
+        XCTAssertEqual(noLeadingSlashURLResponse.status, withLeadingSlashURLResponse.status)
+    }
+
     func testMultipleContentLengthHeaders() throws {
         let body = ByteBuffer(string: "hello world!")
 


### PR DESCRIPTION
### Motivation:

- When the leading slash is omitted in the `string` argument of a relative `URL` instance constructed from `init(string:relativeTo)`, requests made with this `URL` instance fail. This is because the underlying HTTP parser fails when there is no leading slash in the URI.

### Modifications:

- The URI of a `URL` instance is obtained from a computed property `uri` in `HTTPHandler.swift`, which in turn calls the `percentEncodedPath` computed property.
  - The `percentEncodedPath` property uses `URLComponents` to extract out the path.
  - The `resolvingAgainstBaseURL` argument to the `URLComponents` constructor was modified from `false` to `true` 

### Result:

- Regardless of whether a user provides or omits a leading slash in the path of a relative `URL`, the `uri` property will always contain a leading slash.