### PR TITLE
Resolve ambiguity issue for the `stream` function

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -111,8 +111,8 @@ extension HTTPClient {
         ///     - length: Body size. If nil, `Transfer-Encoding` will automatically be set to `chunked`. Otherwise a `Content-Length`
         /// header is set with the given `length`.
         ///     - stream: Body chunk provider.
+        @_disfavoredOverload
         @preconcurrency
-        @available(*, deprecated, renamed: "stream(contentLength:bodyStream:)")
         public static func stream(length: Int? = nil, _ stream: @Sendable @escaping (StreamWriter) -> EventLoopFuture<Void>) -> Body {
             return Body(contentLength: length.flatMap { Int64($0) }, stream: stream)
         }
@@ -123,8 +123,8 @@ extension HTTPClient {
         ///     - contentLength: Body size. If nil, `Transfer-Encoding` will automatically be set to `chunked`. Otherwise a `Content-Length`
         /// header is set with the given `contentLength`.
         ///     - bodyStream: Body chunk provider.
-        public static func stream(contentLength: Int64? = nil, bodyStream: @Sendable @escaping (StreamWriter) -> EventLoopFuture<Void>) -> Body {
-            return Body(contentLength: contentLength, stream: bodyStream)
+        public static func stream(contentLength: Int64? = nil, _ stream: @Sendable @escaping (StreamWriter) -> EventLoopFuture<Void>) -> Body {
+            return Body(contentLength: contentLength, stream: stream)
         }
 
         /// Create and stream body using a collection of bytes.

--- a/Tests/AsyncHTTPClientTests/RequestBagTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestBagTests.swift
@@ -872,11 +872,11 @@ final class RequestBagTests: XCTestCase {
 
             let writerPromise = group.any().makePromise(of: HTTPClient.Body.StreamWriter.self)
             let donePromise = group.any().makePromise(of: Void.self)
-            request.body = .stream(bodyStream: { [leakDetector] writer in
+            request.body = .stream { [leakDetector] writer in
                 _ = leakDetector
                 writerPromise.succeed(writer)
                 return donePromise.futureResult
-            })
+            }
 
             let resultFuture = httpClient.execute(request: request)
             request.body = nil


### PR DESCRIPTION
### Motivation:

- The `stream` function in `HTTPClientRequest.Body` (newly added in #746) is ambiguous with the existing `stream` function as the first argument has a default value and the second argument is a closure. This is API-breaking. 

### Modifications:

- Removed the `@deprecated` marking from the original `stream` function and instead added `@_disfavoredOverload`.

### Result:

- There are no more ambiguity issues.