### PR TITLE
mark HTTPClient.Response Sendable

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -288,7 +288,7 @@ extension HTTPClient {
     }
 
     /// Represents an HTTP response.
-    public struct Response {
+    public struct Response: Sendable {
         /// Remote host of the request.
         public var host: String
         /// Response HTTP status.


### PR DESCRIPTION
`HTTPClient.Response` is trivially `Sendable`, let's mark it `Sendable`.