### PR TITLE
Fix OOM issue when setting `concurrentHTTP1ConnectionsPerHostSoftLimit` to `Int.max`

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+HTTP1Connections.swift
@@ -261,7 +261,7 @@ extension HTTPConnectionPool {
 
         init(maximumConcurrentConnections: Int, generator: Connection.ID.Generator, maximumConnectionUses: Int?) {
             self.connections = []
-            self.connections.reserveCapacity(maximumConcurrentConnections)
+            self.connections.reserveCapacity(min(maximumConcurrentConnections, 1024))
             self.overflowIndex = self.connections.endIndex
             self.maximumConcurrentConnections = maximumConcurrentConnections
             self.generator = generator

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -642,7 +642,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         }
     }
 
-    func testInsanelyHighConcurrentHTTP1ConnectionLimitDoesNotCrash() throws {
+    func testInsanelyHighConcurrentHTTP1ConnectionLimitDoesNotCrash() async throws {
         let bin = HTTPBin(.http1_1(compress: false))
         defer { XCTAssertNoThrow(try bin.shutdown()) }
 
@@ -654,11 +654,10 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         httpClientConfig.timeout = .init(connect: .seconds(10), read: .seconds(100), write: .seconds(100))
 
         let httpClient = HTTPClient(eventLoopGroupProvider: .shared(self.clientGroup), configuration: httpClientConfig)
-        defer {
-            XCTAssertNoThrow(try httpClient.syncShutdown())
-        }
+        defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
 
-        let response = httpClient.get(url: "https://localhost:\(bin.port)", deadline: .now() + .seconds(2))
+        let request = HTTPClientRequest(url: "http://localhost:\(bin.port)")
+        let _ = try await httpClient.execute(request, deadline: .now() + .seconds(2))
     }
 
     func testRedirectChangesHostHeader() {

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -657,7 +657,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
         defer { XCTAssertNoThrow(try httpClient.syncShutdown()) }
 
         let request = HTTPClientRequest(url: "http://localhost:\(bin.port)")
-        let _ = try await httpClient.execute(request, deadline: .now() + .seconds(2))
+        _ = try await httpClient.execute(request, deadline: .now() + .seconds(2))
     }
 
     func testRedirectChangesHostHeader() {


### PR DESCRIPTION
### Motivation:

When a user wishes to make the connection pool create as many concurrent connections as possible, a natural way to achieve this would be to set `.max` to the `concurrentHTTP1ConnectionsPerHostSoftLimit` property.

```swift
HTTPClient.Configuration().connectionPool = .init(
    idleTimeout: .hours(1),
    concurrentHTTP1ConnectionsPerHostSoftLimit: .max
)
```

The `concurrentHTTP1ConnectionsPerHostSoftLimit` property is of type `Int`. Setting it to `Int.max` leads to `Int.max` being passed as an argument to `Array`s `.reserveCapacity(_:)` method, causing an OOM issue.

Addresses Github Issue #751 

### Modifications:

Capped the argument to `self.connections.reserveCapacity(_:)` to 1024 in `HTTPConnectionPool.HTTP1Connections`

### Result:

Users can now set the `concurrentHTTP1ConnectionsPerHostSoftLimit` property to `.max` without causing an OOM issue.