### PR TITLE
Add releases.yml config for github

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: SemVer Major
+      labels:
+        - semver/major
+    - title: SemVer Minor
+      labels:
+        - semver/minor
+    - title: SemVer Patch
+      labels:
+        - semver/patch
+    - title: Other Changes
+      labels:
+        - semver/none


### PR DESCRIPTION
Motivation:

Would like to use github to autogenerate release notes.

Modifications:

Bring over configuration consistent with NIO and other popular repos.

Result:

Once labels are synchronised release notes can be generated by github