### PR TITLE
Fix NIO deprecations after update to `2.71.0`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.62.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.71.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.27.1"),
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.13.0"),

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
@@ -108,7 +108,7 @@ extension HTTPClientResponse {
             case .transaction(_, let expectedContentLength):
                 if let contentLength = expectedContentLength {
                     if contentLength > maxBytes {
-                        throw NIOTooManyBytesError()
+                        throw NIOTooManyBytesError(maxBytes: maxBytes)
                     }
                 }
             case .anyAsyncSequence:

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -907,7 +907,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             await XCTAssertThrowsError(
                 try await response.body.collect(upTo: 3)
             ) {
-                XCTAssertEqualTypeAndValue($0, NIOTooManyBytesError())
+                XCTAssertEqualTypeAndValue($0, NIOTooManyBytesError(maxBytes: 3))
             }
         }
     }


### PR DESCRIPTION
`NIOTooManyBytesError` now requires the `maxBytes` in its initializer.