### PR TITLE
add .git extensions to dependency URLs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,8 +28,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-algorithms", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-docc-plugin.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This PR adds .git extensions to the Swift Package Manager dependencies that didn't include them. For me, this resolves issues that I have had with an error produced by Xcode when updating to the latest package versions if I'm editing the project which depends on AHC in an Xcode Workspace. 

<img width="389" alt="image" src="https://github.com/user-attachments/assets/24c3a5de-b555-4da8-a2fa-a4673fecff44">

The complete error is: `github.com: https://github.com/apple/swift-algorithms: The repository could not be found. Make sure a valid repository exists at the specified location and try again.`

Based on conversations in the Vapor Discord server, adding these extensions "shouldn't" make a difference to the dependency resolution done by swift package manager, however adding them resolves the error. 🤷