### PR TITLE
Explicitly import locale modules

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import NIOHTTP1
-#if canImport(Darwin)
+#if canImport(xlocale)
+import xlocale
+#elseif canImport(locale_h)
+import locale_h
+#elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Musl)
 import Musl

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -28,7 +28,11 @@ import NIOSSL
 import NIOTLS
 import NIOTransportServices
 import XCTest
-#if canImport(Darwin)
+#if canImport(xlocale)
+import xlocale
+#elseif canImport(locale_h)
+import locale_h
+#elseif canImport(Darwin)
 import Darwin
 #elseif canImport(Musl)
 import Musl


### PR DESCRIPTION
The Darwin module is slowly being split up, and as it gets further along, it will stop importing some of the split-out modules like the one for locale.h that provides newlocale() and other locale API. However, there's a wrinkle that on platforms with xlocale, it's xlocale.h that provides most of the POSIX locale.h functions and not locale.h, so prefer the xlocale module when available.