### PR TITLE
workaround Foundation.URL behavior changes

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -45,7 +45,7 @@ extension HTTPClientRequest {
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientRequest.Prepared {
     init(_ request: HTTPClientRequest, dnsOverride: [String: String] = [:]) throws {
-        guard let url = URL(string: request.url) else {
+        guard !request.url.isEmpty, let url = URL(string: request.url) else {
             throw HTTPClientError.invalidURL
         }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -43,8 +43,12 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         XCTAssertEqual(request2.url.path, "")
 
         let request3 = try Request(url: "unix:///tmp/file")
-        XCTAssertNil(request3.url.host)
         XCTAssertEqual(request3.host, "")
+        #if os(Linux) && compiler(>=6.0)
+        XCTAssertEqual(request3.url.host, "")
+        #else
+        XCTAssertNil(request3.url.host)
+        #endif
         XCTAssertEqual(request3.url.path, "/tmp/file")
         XCTAssertEqual(request3.port, 80)
         XCTAssertFalse(request3.useTLS)


### PR DESCRIPTION
`Foundation.URL` has various behavior changes in Swift 6 to better match RFC 3986 which impact AHC.

In particular it now no longer strips the square brackets in IPv6 hosts which are not tolerated by `inet_pton` so these must be manually stripped.

https://github.com/swiftlang/swift-foundation/issues/957
https://github.com/swiftlang/swift-foundation/issues/958
https://github.com/swiftlang/swift-foundation/issues/962