### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -83,3 +83,14 @@ let package = Package(
         ),
     ]
 )
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Sources/AsyncHTTPClient/Configuration+BrowserLike.swift
+++ b/Sources/AsyncHTTPClient/Configuration+BrowserLike.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import NIOCore
+import NIOHTTPCompression
+import NIOSSL
 
 // swift-format-ignore: DontRepeatTypeInStaticProperties
 extension HTTPClient.Configuration {

--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import CNIOLinux
+import NIOCore
 import NIOSSL
 
 #if canImport(Darwin)

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -14,6 +14,8 @@
 
 import Logging
 import NIOCore
+import NIOFoundationCompat
+import NIOHTTP1
 import NIOPosix
 import NIOSSL
 import XCTest

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientTests.swift
@@ -15,6 +15,7 @@
 import AsyncHTTPClient  // NOT @testable - tests that really need @testable go into HTTP2ClientInternalTests.swift
 import Logging
 import NIOCore
+import NIOFoundationCompat
 import NIOHTTP1
 import NIOHTTP2
 import NIOPosix

--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -16,6 +16,7 @@ import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2
 import NIOPosix

--- a/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
@@ -15,6 +15,7 @@
 import AsyncHTTPClient  // NOT @testable - tests that need @testable go into HTTPClientInternalTests.swift
 import Logging
 import NIOCore
+import NIOHTTP1
 import NIOPosix
 import NIOSOCKS
 import XCTest

--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -15,6 +15,7 @@
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import NIOFoundationCompat
 import NIOHTTP1
 import NIOPosix
 import NIOTestUtils

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -14,6 +14,7 @@
 
 import Algorithms
 import NIOCore
+import NIOHTTP1
 import XCTest
 
 @testable import AsyncHTTPClient

--- a/Tests/AsyncHTTPClientTests/HTTPClientResponseTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientResponseTests.swift
@@ -14,6 +14,7 @@
 
 import Logging
 import NIOCore
+import NIOHTTP1
 import XCTest
 
 @testable import AsyncHTTPClient

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -18,6 +18,7 @@ import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import NIOFoundationCompat
 import NIOHPACK
 import NIOHTTP1
 import NIOHTTP2

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -20,6 +20,7 @@ import NIOCore
 import NIOEmbedded
 import NIOFoundationCompat
 import NIOHTTP1
+import NIOHTTP2
 import NIOHTTPCompression
 import NIOPosix
 import NIOSSL

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+ManagerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+ManagerTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Logging
 import NIOCore
 import NIOHTTP1
 import NIOPosix

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -16,6 +16,7 @@ import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOEmbedded
+import NIOFoundationCompat
 import NIOHTTP1
 import NIOPosix
 import XCTest


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.