### PR TITLE
import FoundationEssentials instead of Foundation when available

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+auth.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+auth.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientRequest {

--- a/Sources/AsyncHTTPClient/BasicAuth.swift
+++ b/Sources/AsyncHTTPClient/BasicAuth.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import NIOHTTP1
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 /// Generates base64 encoded username + password for http basic auth.
 ///

--- a/Sources/AsyncHTTPClient/FoundationExtensions.swift
+++ b/Sources/AsyncHTTPClient/FoundationExtensions.swift
@@ -15,7 +15,11 @@
 // Extensions which provide better ergonomics when using Foundation types,
 // or by using Foundation APIs.
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension HTTPClient.Cookie {
     /// The cookie's expiration date.

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
-import Foundation
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -23,6 +22,12 @@ import NIOPosix
 import NIOSSL
 import NIOTLS
 import NIOTransportServices
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension Logger {
     private func requestInfo(_ request: HTTPClient.Request) -> Logger.Metadata.Value {

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -13,13 +13,18 @@
 //===----------------------------------------------------------------------===//
 
 import Algorithms
-import Foundation
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
 import NIOHTTP1
 import NIOPosix
 import NIOSSL
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 extension HTTPClient {
     /// A request body.

--- a/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientCookieTests.swift
@@ -14,8 +14,13 @@
 
 import AsyncHTTPClient
 import CAsyncHTTPClient
-import Foundation
 import XCTest
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 class HTTPClientCookieTests: XCTestCase {
     func testCookie() {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Atomics
-import Foundation
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -30,6 +29,12 @@ import NIOTransportServices
 import XCTest
 
 @testable import AsyncHTTPClient
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
 
 #if canImport(xlocale)
 import xlocale


### PR DESCRIPTION
This PR replaces `import Foundation` with `import FoundationEssentials` when available.

Linking `Foundation` on Linux comes with a significant binary size increase due to the included icu data. None of this is necessary for the HTTP client. Instead we can use `FoundationEssentials` to get access to the essential types like `URL`, `Data`, `Date`, ... without including icu data.

According to @Lukasa, sadly, this might be a semver major change. :( 