### PR TITLE
Add missing import of Network module

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -22,6 +22,7 @@ import NIOSSL
 import NIOTLS
 
 #if canImport(Network)
+import Network
 import NIOTransportServices
 #endif
 


### PR DESCRIPTION
### Motivation:

In https://github.com/swift-server/async-http-client/pull/794, the new Swift compiler feature `MemberImportVisibility` was adopted. However, CI for this project does not test building the package with the nightly compiler on macOS, so it was missed that the project no longer builds on macOS with the nightly toolchain due to a missing import.

### Modifications:

Add `import Network` in a file that needs it.

### Result:

The package builds again with the nightly toolchain on macOS.