### PR TITLE
fix 5.10 compile on Ubuntu 24.04 (Noble) for Intel (x86_64)

### DIFF
--- a/Sources/AsyncHTTPClient/StructuredConcurrencyHelpers.swift
+++ b/Sources/AsyncHTTPClient/StructuredConcurrencyHelpers.swift
@@ -11,6 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+// swift-format-ignore
+// Note: Whitespace changes are used to workaround compiler bug
+// https://github.com/swiftlang/swift/issues/79285
 
 #if compiler(>=6.0)
 @inlinable

--- a/Sources/AsyncHTTPClient/StructuredConcurrencyHelpers.swift
+++ b/Sources/AsyncHTTPClient/StructuredConcurrencyHelpers.swift
@@ -17,9 +17,9 @@
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 internal func asyncDo<R>(
     isolation: isolated (any Actor)? = #isolation,
-    _ body: () async throws -> sending R,
-    finally: sending @escaping ((any Error)?) async throws -> Void
-) async throws -> sending R {
+    // DO NOT FIX THE WHITESPACE IN THE NEXT LINE UNTIL 5.10 IS UNSUPPORTED
+    // https://github.com/swiftlang/swift/issues/79285
+    _ body: () async throws -> sending R, finally: sending @escaping ((any Error)?) async throws -> Void) async throws -> sending R {
     let result: R
     do {
         result = try await body()


### PR DESCRIPTION
Specifically Swift 5.10 _on Intel on Ubuntu Noble (24.04)_ has a crazy bug which leads to compilation failures in a `#if compiler(>=6.0)` block: https://github.com/swiftlang/swift/issues/79285 .

This workaround fixes the compilation by _changing the whitespace_.

Thanks @gwynne for finding this workaround!