### PR TITLE
Add `head` property to `FileDownloadDelegate`'s `Progress`/`Response` struct

### DIFF
--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -23,10 +23,10 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
     public struct Progress: Sendable {
         public var totalBytes: Int?
         public var receivedBytes: Int
-        public var responseHead: HTTPResponseHead!
+        public var head: HTTPResponseHead!
     }
 
-    private var progress = Progress(totalBytes: nil, receivedBytes: 0, responseHead: nil)
+    private var progress = Progress(totalBytes: nil, receivedBytes: 0, head: nil)
 
     public typealias Response = Progress
 
@@ -136,7 +136,7 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
     ) -> EventLoopFuture<Void> {
         self.reportHead?(task, head)
 
-        self.progress.responseHead = head
+        self.progress.head = head
 
         if let totalBytesString = head.headers.first(name: "Content-Length"),
             let totalBytes = Int(totalBytesString)

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -29,7 +29,8 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
             get {
                 assert(self._head != nil)
                 return self._head!
-            } set {
+            }
+            set {
                 self._head = newValue
             }
         }

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -27,13 +27,10 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
 
         public var head: HTTPResponseHead {
             get {
-                #if DEBUG
-                _head!
-                #else
-                _head ?? .init(version: .init(major: 0, minor: 0), status: .init(statusCode: 0))
-                #endif
+                assert(self._head != nil)
+                return self._head!
             } set {
-                _head = newValue
+                self._head = newValue
             }
         }
 

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -23,9 +23,10 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
     public struct Progress: Sendable {
         public var totalBytes: Int?
         public var receivedBytes: Int
+        public var responseHead: HTTPResponseHead!
     }
 
-    private var progress = Progress(totalBytes: nil, receivedBytes: 0)
+    private var progress = Progress(totalBytes: nil, receivedBytes: 0, responseHead: nil)
 
     public typealias Response = Progress
 
@@ -134,6 +135,8 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
         _ head: HTTPResponseHead
     ) -> EventLoopFuture<Void> {
         self.reportHead?(task, head)
+
+        self.progress.responseHead = head
 
         if let totalBytesString = head.headers.first(name: "Content-Length"),
             let totalBytes = Int(totalBytesString)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -3917,7 +3917,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         request.headers.add(name: "Accept", value: "text/event-stream")
 
         let response =
-            try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Progress in
+            try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Response in
                 let delegate = try FileDownloadDelegate(path: path)
 
                 let response = try self.defaultClient.execute(

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -744,7 +744,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                 return response
             }
 
-        XCTAssertEqual(response.head.status, .ok)
+        XCTAssertEqual(.ok, response.head.status)
         XCTAssertEqual("50", response.head.headers.first(name: "content-length"))
 
         XCTAssertEqual(50, response.totalBytes)
@@ -775,7 +775,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                 return response
             }
 
-        XCTAssertEqual(response.head.status, .notFound)
+        XCTAssertEqual(.notFound, response.head.status)
         XCTAssertFalse(response.head.headers.contains(name: "content-length"))
 
         XCTAssertEqual(nil, response.totalBytes)

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -729,11 +729,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         var request = try Request(url: self.defaultHTTPBinURLPrefix + "events/10/content-length")
         request.headers.add(name: "Accept", value: "text/event-stream")
 
-        let progress =
-            try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Progress in
+        let response =
+            try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Response in
                 let delegate = try FileDownloadDelegate(path: path)
 
-                let progress = try self.defaultClient.execute(
+                let response = try self.defaultClient.execute(
                     request: request,
                     delegate: delegate
                 )
@@ -741,19 +741,22 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                 try XCTAssertEqual(50, TemporaryFileHelpers.fileSize(path: path))
 
-                return progress
+                return response
             }
 
-        XCTAssertEqual(50, progress.totalBytes)
-        XCTAssertEqual(50, progress.receivedBytes)
+        XCTAssertEqual(response.head.status, .ok)
+        XCTAssertEqual("50", response.head.headers.first(name: "content-length"))
+
+        XCTAssertEqual(50, response.totalBytes)
+        XCTAssertEqual(50, response.receivedBytes)
     }
 
     func testFileDownloadError() throws {
         var request = try Request(url: self.defaultHTTPBinURLPrefix + "not-found")
         request.headers.add(name: "Accept", value: "text/event-stream")
 
-        let progress =
-            try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Progress in
+        let response =
+            try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Response in
                 let delegate = try FileDownloadDelegate(
                     path: path,
                     reportHead: {
@@ -761,7 +764,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                     }
                 )
 
-                let progress = try self.defaultClient.execute(
+                let response = try self.defaultClient.execute(
                     request: request,
                     delegate: delegate
                 )
@@ -769,11 +772,14 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                 XCTAssertFalse(TemporaryFileHelpers.fileExists(path: path))
 
-                return progress
+                return response
             }
 
-        XCTAssertEqual(nil, progress.totalBytes)
-        XCTAssertEqual(0, progress.receivedBytes)
+        XCTAssertEqual(response.head.status, .notFound)
+        XCTAssertFalse(response.head.headers.contains(name: "content-length"))
+
+        XCTAssertEqual(nil, response.totalBytes)
+        XCTAssertEqual(0, response.receivedBytes)
     }
 
     func testFileDownloadCustomError() throws {
@@ -3910,11 +3916,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
         var request = try Request(url: self.defaultHTTPBinURLPrefix + "chunked")
         request.headers.add(name: "Accept", value: "text/event-stream")
 
-        let progress =
+        let response =
             try TemporaryFileHelpers.withTemporaryFilePath { path -> FileDownloadDelegate.Progress in
                 let delegate = try FileDownloadDelegate(path: path)
 
-                let progress = try self.defaultClient.execute(
+                let response = try self.defaultClient.execute(
                     request: request,
                     delegate: delegate
                 )
@@ -3922,11 +3928,15 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                 try XCTAssertEqual(50, TemporaryFileHelpers.fileSize(path: path))
 
-                return progress
+                return response
             }
 
-        XCTAssertEqual(nil, progress.totalBytes)
-        XCTAssertEqual(50, progress.receivedBytes)
+        XCTAssertEqual(.ok, response.head.status)
+        XCTAssertEqual("chunked", response.head.headers.first(name: "transfer-encoding"))
+        XCTAssertFalse(response.head.headers.contains(name: "content-length"))
+
+        XCTAssertEqual(nil, response.totalBytes)
+        XCTAssertEqual(50, response.receivedBytes)
     }
 
     func testCloseWhileBackpressureIsExertedIsFine() throws {


### PR DESCRIPTION
I needed a way to use a `FileDownloadDelegate` task to fish out the recommended file name.
```swift
let response = try await downloadTask.get()

// access content-disposition
response.head.headers.first(name: "Content-Disposition")
```

The `head` property is an explicitly unwrapped optional because there is no "default value" to set it to, and it won't be accessed by the user until it's already been set anyway. This is a little inelegant, so I could change it to something like below where I fill in bogus init data, but that seems worse for some reason.
```swift
public struct Progress: Sendable {
    public var totalBytes: Int?
    public var receivedBytes: Int
    public var head: HTTPResponseHead
}

private var progress = Progress(
    totalBytes: nil,
    receivedBytes: 0,
    head: .init(
        version: .init(major: 0, minor: 0),
        status: .badRequest
    )
)
```