### PR TITLE
Remove misuse of EmbeddedEventLoop

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClient+StructuredConcurrencyTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+StructuredConcurrencyTests.swift
@@ -15,6 +15,7 @@
 import AsyncHTTPClient
 import NIO
 import NIOFoundationCompat
+import NIOHTTP1
 import XCTest
 
 final class HTTPClientStructuredConcurrencyTests: XCTestCase {


### PR DESCRIPTION
Motivation

EmbeddedEventLoop is not thread-safe, which means that outside of very rare use-cases it's not safe to use it in Swift Concurrency.

Modifications

Replace invalid uses of EmbeddedEventLoop with NIOAsyncTestingEventLoop

Result

Better safety