### PR TITLE
Work around Foundation revert

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -46,7 +46,7 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
         let request3 = try Request(url: "unix:///tmp/file")
         XCTAssertEqual(request3.host, "")
-        #if os(Linux) && compiler(>=6.0)
+        #if os(Linux) && compiler(>=6.0) && compiler(<6.2)
         XCTAssertEqual(request3.url.host, "")
         #else
         XCTAssertNil(request3.url.host)


### PR DESCRIPTION
Motivation

Foundation has reverted several of the changes of behaviour in the URL type, leaving 6.0 and 6.1 with a different behaviour on non-Apple platforms than all other versions.

We should tolerate that.

Modifications

Update the tests to understand the difference.

Result

Tests pass