### PR TITLE
Add `didVisitURL` delegate method

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -668,7 +668,16 @@ public protocol HTTPClientResponseDelegate: AnyObject {
     ///     - task: Current request context.
     func didSendRequest(task: HTTPClient.Task<Response>)
 
-    /// Called when response head is received. Will be called once.
+    /// Called each time a response head is received (including redirects), and always called before ``HTTPClientResponseDelegate/didReceiveHead(task:_:)-9r4xd``.
+    /// You can use this method to keep an entire history of the request/response chain.
+    ///
+    /// - parameters:
+    ///     - task: Current request context.
+    ///     - request: The request that was sent.
+    ///     - head: Received response head.
+    func didVisitURL(task: HTTPClient.Task<Response>, _ request: HTTPClient.Request, _ head: HTTPResponseHead)
+
+    /// Called when the final response head is received (after redirects).
     /// You must return an `EventLoopFuture<Void>` that you complete when you have finished processing the body part.
     /// You can create an already succeeded future by calling `task.eventLoop.makeSucceededFuture(())`.
     ///
@@ -733,6 +742,11 @@ extension HTTPClientResponseDelegate {
     ///
     /// By default, this does nothing.
     public func didSendRequest(task: HTTPClient.Task<Response>) {}
+
+    /// Default implementation of ``HTTPClientResponseDelegate/didVisitURL(task:_:_:)-2el9y``.
+    ///
+    /// By default, this does nothing.
+    public func didVisitURL(task: HTTPClient.Task<Response>, _: HTTPClient.Request, _: HTTPResponseHead) {}
 
     /// Default implementation of ``HTTPClientResponseDelegate/didReceiveHead(task:_:)-9r4xd``.
     ///

--- a/Sources/AsyncHTTPClient/RequestBag.swift
+++ b/Sources/AsyncHTTPClient/RequestBag.swift
@@ -225,6 +225,8 @@ final class RequestBag<Delegate: HTTPClientResponseDelegate> {
     private func receiveResponseHead0(_ head: HTTPResponseHead) {
         self.task.eventLoop.assertInEventLoop()
 
+        self.delegate.didVisitURL(task: self.task, self.request, head)
+
         // runs most likely on channel eventLoop
         switch self.state.receiveResponseHead(head) {
         case .none:


### PR DESCRIPTION
Trying to pave the way for closing https://github.com/swift-server/async-http-client/issues/790 with some direction from @Lukasa.

I have no idea where is best to insert this new delegate method. I'm currently doing it first thing in `receiveResponseHead0`, and not using an EventLoopFuture for back pressure management.  The state machine seems pretty fragile and I don't want to leave too much of an imprint. Trying to be a part of an EventLoopFuture chain seems really complicated and would really leave a mark on the codebase, so I'm wondering if it's possible to just warn the user "do not block"?

Anyway, just a jumping-off point and happy to take direction!