### PR TITLE
Add Request/Response History to all public `Response` types

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
@@ -15,6 +15,8 @@
 import NIOCore
 import NIOHTTP1
 
+import struct Foundation.URL
+
 /// A representation of an HTTP response for the Swift Concurrency HTTPClient API.
 ///
 /// This object is similar to ``HTTPClient/Response``, but used for the Swift Concurrency API.
@@ -32,16 +34,30 @@ public struct HTTPClientResponse: Sendable {
     /// The body of this HTTP response.
     public var body: Body
 
+    /// The history of all requests and responses in redirect order.
+    public var history: [HTTPClientRequestResponse]
+
+    /// The target URL (after redirects) of the response.
+    public var url: URL? {
+        guard let lastRequestURL = self.history.last?.request.url else {
+            return nil
+        }
+
+        return URL(string: lastRequestURL)
+    }
+
     @inlinable public init(
         version: HTTPVersion = .http1_1,
         status: HTTPResponseStatus = .ok,
         headers: HTTPHeaders = [:],
-        body: Body = Body()
+        body: Body = Body(),
+        history: [HTTPClientRequestResponse] = []
     ) {
         self.version = version
         self.status = status
         self.headers = headers
         self.body = body
+        self.history = history
     }
 
     init(
@@ -49,7 +65,8 @@ public struct HTTPClientResponse: Sendable {
         version: HTTPVersion,
         status: HTTPResponseStatus,
         headers: HTTPHeaders,
-        body: TransactionBody
+        body: TransactionBody,
+        history: [HTTPClientRequestResponse] = []
     ) {
         self.init(
             version: version,
@@ -64,8 +81,20 @@ public struct HTTPClientResponse: Sendable {
                         status: status
                     )
                 )
-            )
+            ),
+            history: history
         )
+    }
+}
+
+@available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
+public struct HTTPClientRequestResponse: Sendable {
+    public var request: HTTPClientRequest
+    public var responseHead: HTTPResponseHead
+
+    public init(request: HTTPClientRequest, responseHead: HTTPResponseHead) {
+        self.request = request
+        self.responseHead = responseHead
     }
 }
 

--- a/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
+++ b/Sources/AsyncHTTPClient/FileDownloadDelegate.swift
@@ -16,14 +16,24 @@ import NIOCore
 import NIOHTTP1
 import NIOPosix
 
+import struct Foundation.URL
+
 /// Handles a streaming download to a given file path, allowing headers and progress to be reported.
 public final class FileDownloadDelegate: HTTPClientResponseDelegate {
     /// The response type for this delegate: the total count of bytes as reported by the response
-    /// "Content-Length" header (if available), the count of bytes downloaded, and the
-    /// response head.
+    /// "Content-Length" header (if available), the count of bytes downloaded, the
+    /// response head, and a history of requests and responses.
     public struct Progress: Sendable {
         public var totalBytes: Int?
         public var receivedBytes: Int
+
+        /// The history of all requests and responses in redirect order.
+        public var history: [HTTPClient.RequestResponse] = []
+
+        /// The target URL (after redirects) of the response.
+        public var url: URL? {
+            self.history.last?.request.url
+        }
 
         public var head: HTTPResponseHead {
             get {
@@ -148,6 +158,10 @@ public final class FileDownloadDelegate: HTTPClientResponseDelegate {
                 }
             }
         )
+    }
+
+    public func didVisitURL(task: HTTPClient.Task<Progress>, _ request: HTTPClient.Request, _ head: HTTPResponseHead) {
+        self.progress.history.append(.init(request: request, responseHead: head))
     }
 
     public func didReceiveHead(

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -76,6 +76,8 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 return
             }
 
+            XCTAssertEqual(response.url?.absoluteString, request.url)
+            XCTAssertEqual(response.history.map(\.request.url), [request.url])
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.version, .http2)
         }
@@ -98,6 +100,8 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 return
             }
 
+            XCTAssertEqual(response.url?.absoluteString, request.url)
+            XCTAssertEqual(response.history.map(\.request.url), [request.url])
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.version, .http2)
         }
@@ -734,9 +738,10 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             defer { XCTAssertNoThrow(try client.syncShutdown()) }
             let logger = Logger(label: "HTTPClient", factory: StreamLogHandler.standardOutput(label:))
             var request = HTTPClientRequest(url: "https://127.0.0.1:\(bin.port)/redirect/target")
+            let redirectURL = "https://localhost:\(bin.port)/echohostheader"
             request.headers.replaceOrAdd(
                 name: "X-Target-Redirect-URL",
-                value: "https://localhost:\(bin.port)/echohostheader"
+                value: redirectURL
             )
 
             guard
@@ -753,6 +758,8 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             XCTAssertNoThrow(maybeRequestInfo = try JSONDecoder().decode(RequestInfo.self, from: body))
             guard let requestInfo = maybeRequestInfo else { return }
 
+            XCTAssertEqual(response.url?.absoluteString, redirectURL)
+            XCTAssertEqual(response.history.map(\.request.url), [request.url, redirectURL])
             XCTAssertEqual(response.status, .ok)
             XCTAssertEqual(response.version, .http2)
             XCTAssertEqual(requestInfo.data, "localhost:\(bin.port)")

--- a/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTests.swift
@@ -469,6 +469,14 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
         var response = try localClient.get(url: self.defaultHTTPBinURLPrefix + "redirect/302").wait()
         XCTAssertEqual(response.status, .ok)
+        XCTAssertEqual(response.url?.absoluteString, self.defaultHTTPBinURLPrefix + "ok")
+        XCTAssertEqual(
+            response.history.map(\.request.url.absoluteString),
+            [
+                self.defaultHTTPBinURLPrefix + "redirect/302",
+                self.defaultHTTPBinURLPrefix + "ok",
+            ]
+        )
 
         response = try localClient.get(url: self.defaultHTTPBinURLPrefix + "redirect/https?port=\(httpsBin.port)")
             .wait()
@@ -501,6 +509,8 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                         var response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .found)
                         XCTAssertEqual(response.headers.first(name: "Location"), targetURL)
+                        XCTAssertEqual(response.url, request.url)
+                        XCTAssertEqual(response.history.map(\.request.url), [request.url])
 
                         request = try Request(
                             url: "https://localhost:\(httpsBin.port)/redirect/target",
@@ -512,6 +522,8 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .found)
                         XCTAssertEqual(response.headers.first(name: "Location"), targetURL)
+                        XCTAssertEqual(response.url, request.url)
+                        XCTAssertEqual(response.history.map(\.request.url), [request.url])
 
                         // From HTTP or HTTPS to HTTPS+UNIX should also fail to redirect
                         targetURL =
@@ -526,6 +538,8 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .found)
                         XCTAssertEqual(response.headers.first(name: "Location"), targetURL)
+                        XCTAssertEqual(response.url, request.url)
+                        XCTAssertEqual(response.history.map(\.request.url), [request.url])
 
                         request = try Request(
                             url: "https://localhost:\(httpsBin.port)/redirect/target",
@@ -537,6 +551,8 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .found)
                         XCTAssertEqual(response.headers.first(name: "Location"), targetURL)
+                        XCTAssertEqual(response.url, request.url)
+                        XCTAssertEqual(response.history.map(\.request.url), [request.url])
 
                         // ... while HTTP+UNIX to HTTP, HTTPS, or HTTP(S)+UNIX should succeed
                         targetURL = self.defaultHTTPBinURLPrefix + "ok"
@@ -550,6 +566,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         targetURL = "https://localhost:\(httpsBin.port)/ok"
                         request = try Request(
@@ -562,6 +583,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         targetURL =
                             "http+unix://\(httpSocketPath.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)/ok"
@@ -575,6 +601,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         targetURL =
                             "https+unix://\(httpsSocketPath.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)/ok"
@@ -588,6 +619,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         // ... and HTTPS+UNIX to HTTP, HTTPS, or HTTP(S)+UNIX should succeed
                         targetURL = self.defaultHTTPBinURLPrefix + "ok"
@@ -601,6 +637,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         targetURL = "https://localhost:\(httpsBin.port)/ok"
                         request = try Request(
@@ -613,6 +654,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         targetURL =
                             "http+unix://\(httpSocketPath.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)/ok"
@@ -626,6 +672,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
 
                         targetURL =
                             "https+unix://\(httpsSocketPath.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)!)/ok"
@@ -639,6 +690,11 @@ final class HTTPClientTests: XCTestCaseHTTPClientTestsBaseClass {
 
                         response = try localClient.execute(request: request).wait()
                         XCTAssertEqual(response.status, .ok)
+                        XCTAssertEqual(response.url?.absoluteString, targetURL)
+                        XCTAssertEqual(
+                            response.history.map(\.request.url.absoluteString),
+                            [request.url.absoluteString, targetURL]
+                        )
                     }
                 )
             }


### PR DESCRIPTION
Work to close https://github.com/swift-server/async-http-client/issues/790

The fact that `HTTPClient.Request` is not Sendable make me think we're going to need to store something else, such as a `URL` and `HTTPRequestHead`, instead?