### PR TITLE
Drop support for Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_5_9_enabled: false
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
@@ -22,3 +22,5 @@ jobs:
         name: Static SDK
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+        with:
+            linux_5_9_enabled: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,5 +22,3 @@ jobs:
         name: Static SDK
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
-        with:
-            linux_5_9_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+            linux_5_9_enabled: false
             linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
@@ -24,8 +24,12 @@ jobs:
     cxx-interop:
         name: Cxx interop
         uses: apple/swift-nio/.github/workflows/cxx_interop.yml@main
+        with:
+            linux_5_9_enabled: false
 
     static-sdk:
         name: Static SDK
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+        with:
+            linux_5_9_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -31,5 +31,3 @@ jobs:
         name: Static SDK
         # Workaround https://github.com/nektos/act/issues/1875
         uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
-        with:
-            linux_5_9_enabled: false

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the AsyncHTTPClient open source project

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Please have a look at [SECURITY.md](SECURITY.md) for AsyncHTTPClient's security 
 
 ## Supported Versions
 
-The most recent versions of AsyncHTTPClient support Swift 5.6 and newer. The minimum Swift version supported by AsyncHTTPClient releases are detailed below:
+The most recent versions of AsyncHTTPClient support Swift 5.9 and newer. The minimum Swift version supported by AsyncHTTPClient releases are detailed below:
 
 AsyncHTTPClient     | Minimum Swift Version
 --------------------|----------------------
@@ -316,4 +316,5 @@ AsyncHTTPClient     | Minimum Swift Version
 `1.13.0 ..< 1.18.0` | 5.5.2
 `1.18.0 ..< 1.20.0` | 5.6
 `1.20.0 ..< 1.21.0` | 5.7
-`1.21.0 ...`        | 5.8
+`1.21.0 ..< 1.26.0` | 5.8
+`1.26.0 ...`        | 5.9


### PR DESCRIPTION
Motivation:

Now that Swift 6.1 has been released, Swift 5.9 has dropped out of the support window.

Modifications:

- Bumpt tools versions to 5.9
- Disable 5.9 workflows

Result:

5.9 is no longer supported