### PR TITLE
Add explicit sendability annotations

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/AnyAsyncSequence.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/AnyAsyncSequence.swift
@@ -46,3 +46,6 @@ struct AnyAsyncSequence<Element>: Sendable, AsyncSequence {
         .init(nextCallback: self.makeAsyncIteratorCallback())
     }
 }
+
+@available(*, unavailable)
+extension AnyAsyncSequence.AsyncIterator: Sendable {}

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientResponse.swift
@@ -259,3 +259,9 @@ extension HTTPClientResponse.Body {
         .stream(CollectionOfOne(byteBuffer).async)
     }
 }
+
+@available(*, unavailable)
+extension HTTPClientResponse.Body.AsyncIterator: Sendable {}
+
+@available(*, unavailable)
+extension HTTPClientResponse.Body.Storage.AsyncIterator: Sendable {}

--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -552,3 +552,6 @@ extension Transaction {
         }
     }
 }
+
+@available(*, unavailable)
+extension Transaction.StateMachine: Sendable {}

--- a/Sources/AsyncHTTPClient/Base64.swift
+++ b/Sources/AsyncHTTPClient/Base64.swift
@@ -29,7 +29,7 @@ extension String {
 
 // swift-format-ignore: DontRepeatTypeInStaticProperties
 @usableFromInline
-internal struct Base64 {
+internal struct Base64: Sendable {
 
     @inlinable
     static func encode<Buffer: Collection>(

--- a/Sources/AsyncHTTPClient/Utils.swift
+++ b/Sources/AsyncHTTPClient/Utils.swift
@@ -18,10 +18,10 @@ import NIOCore
 ///
 /// ``HTTPClientCopyingDelegate`` discards most parts of a HTTP response, but streams the body
 /// to the `chunkHandler` provided on ``init(chunkHandler:)``. This is mostly useful for testing.
-public final class HTTPClientCopyingDelegate: HTTPClientResponseDelegate {
+public final class HTTPClientCopyingDelegate: HTTPClientResponseDelegate, Sendable {
     public typealias Response = Void
 
-    let chunkHandler: (ByteBuffer) -> EventLoopFuture<Void>
+    let chunkHandler: @Sendable (ByteBuffer) -> EventLoopFuture<Void>
 
     @preconcurrency
     public init(chunkHandler: @Sendable @escaping (ByteBuffer) -> EventLoopFuture<Void>) {


### PR DESCRIPTION
Motivation:

As part of adopting strict concurrency all public types should be explicit about whether they are sendable or not.

Modifications:

- Add explicit sendability annotations to a number of types

Result:

Sendability is explicit