### PR TITLE
Make the file download delegate sendable

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientInternalTests.swift
@@ -658,7 +658,7 @@ class HTTPClientInternalTests: XCTestCase {
             ).futureResult
         }
         _ = try EventLoopFuture.whenAllSucceed(resultFutures, on: self.clientGroup.next()).wait()
-        let threadPools = delegates.map { $0.fileIOThreadPool }
+        let threadPools = delegates.map { $0._fileIOThreadPool }
         let firstThreadPool = threadPools.first ?? nil
         XCTAssert(threadPools.dropFirst().allSatisfy { $0 === firstThreadPool })
     }


### PR DESCRIPTION
Motivation:

Delegates can be passed from any thread and are executed on an arbitrary event loop. That means they need to be Sendable. Rather than making them all Sendable in one go, we'll do the larger ones separately.

Modifications:

- Make FileDownloadDelegate sendable

Result:

Safe to pass FileDownloadDelegate across isolation domains