### PR TITLE
Make body stream writer sendable

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -53,6 +53,7 @@ extension HTTPClient {
             }
 
             @inlinable
+            @preconcurrency
             func writeChunks<Bytes: Collection>(
                 of bytes: Bytes,
                 maxChunkSize: Int

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -93,7 +93,8 @@ extension HTTPClient {
                         loop.assertInEventLoop()
 
                         if let (index, element) = iterator.next() {
-                            self.write(.byteBuffer(ByteBuffer(bytes: chunk.element))).hop(to: loop).assumeIsolated().map {
+                            self.write(.byteBuffer(ByteBuffer(bytes: chunk.element))).hop(to: loop).assumeIsolated().map
+                            {
                                 if (index + 1) % 4 == 0 {
                                     // Let's not stack-overflow if the futures insta-complete which they at least in HTTP/2
                                     // mode.


### PR DESCRIPTION
Motivation:

The body stream writer can be sent across isolation domains so should be sendable.

Modifications:

- Make it explicitly sendable
- Add appropriate preconcurrency annotations
- Wrap an iterator from swift-algorithms as it hasn't yet annotated its types with Sendable

Result:

Body stream writer is sendable