### PR TITLE
Fix a few more Sendability warnings in Sources

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -24,7 +24,7 @@ extension HTTPClientRequest {
         enum Body {
             case asyncSequence(
                 length: RequestBodyLength,
-                nextBodyPart: (ByteBufferAllocator) async throws -> ByteBuffer?
+                makeAsyncIterator: @Sendable () -> ((ByteBufferAllocator) async throws -> ByteBuffer?)
             )
             case sequence(
                 length: RequestBodyLength,
@@ -80,7 +80,7 @@ extension HTTPClientRequest.Prepared.Body {
     init(_ body: HTTPClientRequest.Body) {
         switch body.mode {
         case .asyncSequence(let length, let makeAsyncIterator):
-            self = .asyncSequence(length: length, nextBodyPart: makeAsyncIterator())
+            self = .asyncSequence(length: length, makeAsyncIterator: makeAsyncIterator)
         case .sequence(let length, let canBeConsumedMultipleTimes, let makeCompleteBody):
             self = .sequence(
                 length: length,

--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest.swift
@@ -421,3 +421,9 @@ extension HTTPClientRequest.Body {
         }
     }
 }
+
+@available(*, unavailable)
+extension HTTPClientRequest.Body.AsyncIterator: Sendable {}
+
+@available(*, unavailable)
+extension HTTPClientRequest.Body.AsyncIterator.Storage: Sendable {}

--- a/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientRequestTests.swift
@@ -766,8 +766,9 @@ extension Optional where Wrapped == HTTPClientRequest.Prepared.Body {
                 throw LengthMismatch(announcedLength: announcedLength, actualLength: Int64(buffer.readableBytes))
             }
             return buffer
-        case .asyncSequence(length: let announcedLength, let generate):
+        case .asyncSequence(length: let announcedLength, let makeAsyncIterator):
             var accumulatedBuffer = ByteBuffer()
+            let generate = makeAsyncIterator()
             while var buffer = try await generate(ByteBufferAllocator()) {
                 accumulatedBuffer.writeBuffer(&buffer)
             }


### PR DESCRIPTION
Motivation:

There are a couple of sendability warnings leftover in Sources.

Transaction moves a closure into a task. The closure isn't Sendable (and shouldn't be). However, higher up the stack there's a closure which generates the non-sendable closure which can be sendable.

Modifications:

- Pass the sendable closure generating closure down rather
- Add a few more explicit sendable annotations

Result:

Fewer warnings