### PR TITLE
Fix sendability issues in tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,18 +15,36 @@
 
 import PackageDescription
 
+let strictConcurrencyDevelopment = false
+
+let strictConcurrencySettings: [SwiftSetting] = {
+    var initialSettings: [SwiftSetting] = []
+    initialSettings.append(contentsOf: [
+        .enableUpcomingFeature("StrictConcurrency"),
+        .enableUpcomingFeature("InferSendableFromCaptures"),
+    ])
+
+    if strictConcurrencyDevelopment {
+        // -warnings-as-errors here is a workaround so that IDE-based development can
+        // get tripped up on -require-explicit-sendable.
+        initialSettings.append(.unsafeFlags(["-Xfrontend", "-require-explicit-sendable", "-warnings-as-errors"]))
+    }
+
+    return initialSettings
+}()
+
 let package = Package(
     name: "async-http-client",
     products: [
         .library(name: "AsyncHTTPClient", targets: ["AsyncHTTPClient"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.78.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.27.1"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
-        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.13.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.19.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.4.4"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.81.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.30.0"),
+        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.36.0"),
+        .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.26.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.24.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
     ],
@@ -55,7 +73,8 @@ let package = Package(
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "Atomics", package: "swift-atomics"),
                 .product(name: "Algorithms", package: "swift-algorithms"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
         .testTarget(
             name: "AsyncHTTPClientTests",
@@ -79,7 +98,8 @@ let package = Package(
                 .copy("Resources/self_signed_key.pem"),
                 .copy("Resources/example.com.cert.pem"),
                 .copy("Resources/example.com.private-key.pem"),
-            ]
+            ],
+            swiftSettings: strictConcurrencySettings
         ),
     ]
 )

--- a/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncAwaitEndToEndTests.swift
@@ -526,6 +526,8 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
     }
 
     func testConnectTimeout() {
+        let serverGroup = self.serverGroup!
+        let clientGroup = self.clientGroup!
         XCTAsyncTest(timeout: 60) {
             #if os(Linux)
             // 198.51.100.254 is reserved for documentation only and therefore should not accept any TCP connection
@@ -542,7 +544,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertNoThrow(try group.syncShutdownGracefully())
             }
 
-            let serverChannel = try await ServerBootstrap(group: self.serverGroup)
+            let serverChannel = try await ServerBootstrap(group: serverGroup)
                 .serverChannelOption(ChannelOptions.backlog, value: 1)
                 .serverChannelOption(ChannelOptions.autoRead, value: false)
                 .bind(host: "127.0.0.1", port: 0)
@@ -551,7 +553,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
                 XCTAssertNoThrow(try serverChannel.close().wait())
             }
             let port = serverChannel.localAddress!.port!
-            let firstClientChannel = try await ClientBootstrap(group: self.serverGroup)
+            let firstClientChannel = try await ClientBootstrap(group: serverGroup)
                 .connect(host: "127.0.0.1", port: port)
                 .get()
             defer {
@@ -561,7 +563,7 @@ final class AsyncAwaitEndToEndTests: XCTestCase {
             #endif
 
             let httpClient = HTTPClient(
-                eventLoopGroupProvider: .shared(self.clientGroup),
+                eventLoopGroupProvider: .shared(clientGroup),
                 configuration: .init(timeout: .init(connect: .milliseconds(100), read: .milliseconds(150)))
             )
 

--- a/Tests/AsyncHTTPClientTests/AsyncTestHelpers.swift
+++ b/Tests/AsyncHTTPClientTests/AsyncTestHelpers.swift
@@ -17,7 +17,7 @@ import NIOCore
 
 /// ``AsyncSequenceWriter`` is `Sendable` because its state is protected by a Lock
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-final class AsyncSequenceWriter<Element>: AsyncSequence, @unchecked Sendable {
+final class AsyncSequenceWriter<Element: Sendable>: AsyncSequence, @unchecked Sendable {
     typealias AsyncIterator = Iterator
 
     struct Iterator: AsyncIteratorProtocol {

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientRequestHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientRequestHandlerTests.swift
@@ -568,10 +568,11 @@ class HTTP2ClientRequestHandlerTests: XCTestCase {
         )
         try channel.connect(to: .init(ipAddress: "127.0.0.1", port: 80)).wait()
 
-        let request = MockHTTPExecutableRequest()
         // non empty body is important to trigger this bug as we otherwise finish the request in a single flush
-        request.requestFramingMetadata.body = .fixedSize(1)
-        request.raiseErrorIfUnimplementedMethodIsCalled = false
+        let request = MockHTTPExecutableRequest(
+            framingMetadata: RequestFramingMetadata(connectionClose: false, body: .fixedSize(1)),
+            raiseErrorIfUnimplementedMethodIsCalled: false
+        )
         channel.writeAndFlush(request, promise: nil)
         XCTAssertEqual(request.events.map(\.kind), [.willExecuteRequest, .requestHeadSent])
     }

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+FactoryTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+FactoryTests.swift
@@ -184,7 +184,7 @@ class HTTPConnectionPool_FactoryTests: XCTestCase {
     }
 }
 
-class NeverrespondServerHandler: ChannelInboundHandler {
+final class NeverrespondServerHandler: ChannelInboundHandler, Sendable {
     typealias InboundIn = NIOAny
 
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {

--- a/Tests/AsyncHTTPClientTests/HTTPConnectionPool+RequestQueueTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPConnectionPool+RequestQueueTests.swift
@@ -83,7 +83,7 @@ class HTTPConnectionPool_RequestQueueTests: XCTestCase {
     }
 }
 
-private class MockScheduledRequest: HTTPSchedulableRequest {
+final private class MockScheduledRequest: HTTPSchedulableRequest {
     let requiredEventLoop: EventLoop?
 
     init(requiredEventLoop: EventLoop?) {

--- a/Tests/AsyncHTTPClientTests/Mocks/MockRequestExecutor.swift
+++ b/Tests/AsyncHTTPClientTests/Mocks/MockRequestExecutor.swift
@@ -25,7 +25,7 @@ final class MockRequestExecutor {
         case unexpectedByteBuffer
     }
 
-    enum RequestParts: Equatable {
+    enum RequestParts: Equatable, Sendable {
         case body(IOData)
         case endOfStream
 
@@ -58,10 +58,15 @@ final class MockRequestExecutor {
     private let responseBodyDemandLock = ConditionLock(value: false)
     private let cancellationLock = ConditionLock(value: false)
 
-    private var request: HTTPExecutableRequest?
-    private var _signaledDemandForRequestBody: Bool = false
+    private struct State: Sendable {
+        var request: HTTPExecutableRequest?
+        var _signaledDemandForRequestBody: Bool = false
+    }
+
+    private let state: NIOLockedValueBox<State>
 
     init(pauseRequestBodyPartStreamAfterASingleWrite: Bool = false, eventLoop: EventLoop) {
+        self.state = NIOLockedValueBox(State())
         self.pauseRequestBodyPartStreamAfterASingleWrite = pauseRequestBodyPartStreamAfterASingleWrite
         self.eventLoop = eventLoop
     }
@@ -77,8 +82,10 @@ final class MockRequestExecutor {
     }
 
     private func runRequest0(_ request: HTTPExecutableRequest) {
-        precondition(self.request == nil)
-        self.request = request
+        self.state.withLockedValue {
+            precondition($0.request == nil)
+            $0.request = request
+        }
         request.willExecuteRequest(self)
         request.requestHeadSent()
     }
@@ -127,10 +134,16 @@ final class MockRequestExecutor {
     }
 
     private func pauseRequestBodyStream0() {
-        if self._signaledDemandForRequestBody == true {
-            self._signaledDemandForRequestBody = false
-            self.request!.pauseRequestBodyStream()
+        let request = self.state.withLockedValue {
+            if $0._signaledDemandForRequestBody == true {
+                $0._signaledDemandForRequestBody = false
+                return $0.request
+            } else {
+                return nil
+            }
         }
+
+        request?.pauseRequestBodyStream()
     }
 
     func resumeRequestBodyStream() {
@@ -144,10 +157,16 @@ final class MockRequestExecutor {
     }
 
     private func resumeRequestBodyStream0() {
-        if self._signaledDemandForRequestBody == false {
-            self._signaledDemandForRequestBody = true
-            self.request!.resumeRequestBodyStream()
+        let request = self.state.withLockedValue {
+            if $0._signaledDemandForRequestBody == false {
+                $0._signaledDemandForRequestBody = true
+                return $0.request
+            } else {
+                return nil
+            }
         }
+
+        request?.resumeRequestBodyStream()
     }
 
     func resetResponseStreamDemandSignal() {
@@ -204,11 +223,13 @@ extension MockRequestExecutor: HTTPRequestExecutor {
             case none
         }
 
-        let stateChange = { () -> WriteAction in
+        let stateChange = { @Sendable () -> WriteAction in
             var pause = false
             if self.blockingQueue.isEmpty && self.pauseRequestBodyPartStreamAfterASingleWrite && part.isBody {
                 pause = true
-                self._signaledDemandForRequestBody = false
+                self.state.withLockedValue {
+                    $0._signaledDemandForRequestBody = false
+                }
             }
 
             self.blockingQueue.append(.success(part))
@@ -283,3 +304,5 @@ extension MockRequestExecutor {
         }
     }
 }
+
+extension MockRequestExecutor.BlockingQueue: @unchecked Sendable where Element: Sendable {}

--- a/Tests/AsyncHTTPClientTests/SOCKSEventsHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSEventsHandlerTests.swift
@@ -38,7 +38,7 @@ class SOCKSEventsHandlerTests: XCTestCase {
         let embedded = EmbeddedChannel(handlers: [socksEventsHandler])
         XCTAssertNotNil(socksEventsHandler.socksEstablishedFuture)
 
-        XCTAssertNoThrow(try embedded.pipeline.removeHandler(socksEventsHandler).wait())
+        XCTAssertNoThrow(try embedded.pipeline.syncOperations.removeHandler(socksEventsHandler).wait())
         XCTAssertThrowsError(try XCTUnwrap(socksEventsHandler.socksEstablishedFuture).wait())
     }
 

--- a/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/SOCKSTestUtils.swift
@@ -53,7 +53,9 @@ class MockSOCKSServer {
             bootstrap = ServerBootstrap(group: elg)
                 .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
                 .childChannelInitializer { channel in
-                    channel.pipeline.addHandler(TestSOCKSBadServerHandler())
+                    channel.eventLoop.makeCompletedFuture {
+                        try channel.pipeline.syncOperations.addHandler(TestSOCKSBadServerHandler())
+                    }
                 }
         } else {
             bootstrap = ServerBootstrap(group: elg)

--- a/Tests/AsyncHTTPClientTests/TLSEventsHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/TLSEventsHandlerTests.swift
@@ -39,7 +39,7 @@ class TLSEventsHandlerTests: XCTestCase {
         let embedded = EmbeddedChannel(handlers: [tlsEventsHandler])
         XCTAssertNotNil(tlsEventsHandler.tlsEstablishedFuture)
 
-        XCTAssertNoThrow(try embedded.pipeline.removeHandler(tlsEventsHandler).wait())
+        XCTAssertNoThrow(try embedded.pipeline.syncOperations.removeHandler(tlsEventsHandler).wait())
         XCTAssertThrowsError(try XCTUnwrap(tlsEventsHandler.tlsEstablishedFuture).wait())
     }
 

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -657,6 +657,7 @@ private actor Promise<Value: Sendable> {
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Transaction {
+    #if compiler(>=6.0)
     fileprivate static func makeWithResultTask(
         request: sending PreparedRequest,
         requestOptions: RequestOptions = .forTests(),
@@ -684,4 +685,40 @@ extension Transaction {
 
         return (await transactionPromise.value, task)
     }
+    #else
+    fileprivate static func makeWithResultTask(
+        request: PreparedRequest,
+        requestOptions: RequestOptions = .forTests(),
+        logger: Logger = Logger(label: "test"),
+        connectionDeadline: NIODeadline = .distantFuture,
+        preferredEventLoop: EventLoop
+    ) async -> (Transaction, _Concurrency.Task<HTTPClientResponse, Error>) {
+        // It isn't sendable ... but on 6.0 and later we use 'sending'.
+        struct UnsafePrepareRequest: @unchecked Sendable {
+            var value: PreparedRequest
+        }
+
+        let transactionPromise = Promise<Transaction>()
+        let unsafe = UnsafePrepareRequest(value: request)
+        let task = Task {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<HTTPClientResponse, Error>) in
+                let request = unsafe.value
+                let transaction = Transaction(
+                    request: request,
+                    requestOptions: requestOptions,
+                    logger: logger,
+                    connectionDeadline: connectionDeadline,
+                    preferredEventLoop: preferredEventLoop,
+                    responseContinuation: continuation
+                )
+                Task {
+                    await transactionPromise.fulfil(transaction)
+                }
+            }
+        }
+
+        return (await transactionPromise.value, task)
+    }
+    #endif
 }

--- a/Tests/AsyncHTTPClientTests/TransactionTests.swift
+++ b/Tests/AsyncHTTPClientTests/TransactionTests.swift
@@ -29,11 +29,9 @@ typealias PreparedRequest = HTTPClientRequest.Prepared
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 final class TransactionTests: XCTestCase {
     func testCancelAsyncRequest() {
-        // creating the `XCTestExpectation` off the main thread crashes on Linux with Swift 5.6
-        // therefore we create it here as a workaround which works fine
-        let scheduledRequestCanceled = self.expectation(description: "scheduled request canceled")
         XCTAsyncTest {
             let loop = NIOAsyncTestingEventLoop()
+            let scheduledRequestCanceled = loop.makePromise(of: Void.self)
             defer { XCTAssertNoThrow(try loop.syncShutdownGracefully()) }
 
             var request = HTTPClientRequest(url: "https://localhost/")
@@ -49,7 +47,7 @@ final class TransactionTests: XCTestCase {
             )
 
             let queuer = MockTaskQueuer { _ in
-                scheduledRequestCanceled.fulfill()
+                scheduledRequestCanceled.succeed()
             }
             transaction.requestWasQueued(queuer)
 
@@ -64,9 +62,7 @@ final class TransactionTests: XCTestCase {
             }
 
             // self.fulfillment(of:) is not available on Linux
-            _ = {
-                self.wait(for: [scheduledRequestCanceled], timeout: 1)
-            }()
+            try await scheduledRequestCanceled.futureResult.timeout(after: .seconds(1)).get()
         }
     }
 
@@ -590,22 +586,31 @@ final class TransactionTests: XCTestCase {
 // tasks. Since we want to wait for things to happen in tests, we need to `async let`, which creates
 // implicit tasks. Therefore we need to wrap our iterator struct.
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-actor SharedIterator<Wrapped: AsyncSequence> where Wrapped.Element: Sendable {
-    private var wrappedIterator: Wrapped.AsyncIterator
-    private var nextCallInProgress: Bool = false
+final class SharedIterator<Wrapped: AsyncSequence>: Sendable where Wrapped.Element: Sendable {
+    private struct State: @unchecked Sendable {
+        var wrappedIterator: Wrapped.AsyncIterator
+        var nextCallInProgress: Bool = false
+    }
+
+    private let state: NIOLockedValueBox<State>
 
     init(_ sequence: Wrapped) {
-        self.wrappedIterator = sequence.makeAsyncIterator()
+        self.state = NIOLockedValueBox(State(wrappedIterator: sequence.makeAsyncIterator()))
     }
 
     func next() async throws -> Wrapped.Element? {
-        precondition(self.nextCallInProgress == false)
-        self.nextCallInProgress = true
-        var iter = self.wrappedIterator
+        var iter = self.state.withLockedValue {
+            precondition($0.nextCallInProgress == false)
+            $0.nextCallInProgress = true
+            return $0.wrappedIterator
+        }
+
         defer {
-            precondition(self.nextCallInProgress == true)
-            self.nextCallInProgress = false
-            self.wrappedIterator = iter
+            self.state.withLockedValue {
+                precondition($0.nextCallInProgress == true)
+                $0.nextCallInProgress = false
+                $0.wrappedIterator = iter
+            }
         }
         return try await iter.next()
     }
@@ -613,7 +618,7 @@ actor SharedIterator<Wrapped: AsyncSequence> where Wrapped.Element: Sendable {
 
 /// non fail-able promise that only supports one observer
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
-private actor Promise<Value> {
+private actor Promise<Value: Sendable> {
     private enum State {
         case initialised
         case fulfilled(Value)
@@ -653,7 +658,7 @@ private actor Promise<Value> {
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension Transaction {
     fileprivate static func makeWithResultTask(
-        request: PreparedRequest,
+        request: sending PreparedRequest,
         requestOptions: RequestOptions = .forTests(),
         logger: Logger = Logger(label: "test"),
         connectionDeadline: NIODeadline = .distantFuture,


### PR DESCRIPTION
Motivation:

The tests shouldn't be making sendability violations.

Modifications:

Fix the warnings

Result:

- No warnings
- Strict concurrency is adopted!