### PR TITLE
Enable warnings as errors in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_9_enabled: false
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
     static-sdk:
         name: Static SDK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,11 +12,11 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_9_enabled: false
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     static-sdk:
         name: Static SDK

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,11 +15,11 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_9_enabled: false
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
 
     cxx-interop:
         name: Cxx interop

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,11 +15,11 @@ jobs:
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
             linux_5_9_enabled: false
-            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable -Xswiftc -warnings-as-errors"
-            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
-            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -Xfrontend -Xswiftc -require-explicit-sendable"
+            linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
+            linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+            linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
     cxx-interop:
         name: Cxx interop

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -338,6 +338,7 @@ public class HTTPClient {
         }
     }
 
+    @Sendable
     private func makeOrGetFileIOThreadPool() -> NIOThreadPool {
         self.fileIOThreadPoolLock.withLock {
             guard let fileIOThreadPool = self.fileIOThreadPool else {

--- a/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientTestUtils.swift
@@ -287,7 +287,7 @@ enum TemporaryFileHelpers {
             shortEnoughPath = path
             restoreSavedCWD = false
         } catch SocketAddressError.unixDomainSocketPathTooLong {
-            FileManager.default.changeCurrentDirectoryPath(
+            _ = FileManager.default.changeCurrentDirectoryPath(
                 URL(fileURLWithPath: path).deletingLastPathComponent().absoluteString
             )
             shortEnoughPath = URL(fileURLWithPath: path).lastPathComponent
@@ -301,7 +301,7 @@ enum TemporaryFileHelpers {
                 try? FileManager.default.removeItem(atPath: path)
             }
             if restoreSavedCWD {
-                FileManager.default.changeCurrentDirectoryPath(saveCurrentDirectory)
+                _ = FileManager.default.changeCurrentDirectoryPath(saveCurrentDirectory)
             }
         }
         return try body(shortEnoughPath)


### PR DESCRIPTION
Motivation:

Now that strict concurrency has been adopted the AHC should avoid regressing by treating all warnings as errors in CI.

Modifications:

- Treat warnings as errors in CI

Result:

Stricter CI