### PR TITLE
Fix 5.9 build

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,7 +14,7 @@ jobs:
         name: Unit tests
         uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
         with:
-            linux_5_9_enabled: false
+            linux_5_9_enabled: true
             linux_5_10_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"
             linux_6_1_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors"

--- a/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient+HTTPCookie.swift
@@ -216,12 +216,21 @@ extension String.UTF8View.SubSequence {
     }
 }
 
+#if compiler(>=5.10)
 nonisolated(unsafe) private let posixLocale: UnsafeMutableRawPointer = {
     // All POSIX systems must provide a "POSIX" locale, and its date/time formats are US English.
     // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_05
     let _posixLocale = newlocale(LC_TIME_MASK | LC_NUMERIC_MASK, "POSIX", nil)!
     return UnsafeMutableRawPointer(_posixLocale)
 }()
+#else
+private let posixLocale: UnsafeMutableRawPointer = {
+    // All POSIX systems must provide a "POSIX" locale, and its date/time formats are US English.
+    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap07.html#tag_07_03_05
+    let _posixLocale = newlocale(LC_TIME_MASK | LC_NUMERIC_MASK, "POSIX", nil)!
+    return UnsafeMutableRawPointer(_posixLocale)
+}()
+#endif
 
 private func parseTimestamp(_ utf8: String.UTF8View.SubSequence, format: String) -> tm? {
     var timeComponents = tm()


### PR DESCRIPTION
Motivation:

An oversight in 373862a meant that 5.9 wasn't actually dropped which means that the use of 'nonisolated(unsafe)' in 0e715a27 broke users of 5.9.

Modifications:

- Add back a 5.9 path

Result:

- Builds on 5.9
- Resolves #843