### PR TITLE
Use Int64.random instead of .randomElement in HTTPConnectionPool.calculateBackoff

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+Backoff.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/State Machine/HTTPConnectionPool+Backoff.swift
@@ -61,7 +61,7 @@ extension HTTPConnectionPool {
         // Calculate a 3% jitter range
         let jitterRange = (backoff.nanoseconds / 100) * 3
         // Pick a random element from the range +/- jitter range.
-        let jitter: TimeAmount = .nanoseconds((-jitterRange...jitterRange).randomElement()!)
+        let jitter: TimeAmount = .nanoseconds(Int64.random(in: -jitterRange...jitterRange))
         let jitteredBackoff = backoff + jitter
         return jitteredBackoff
     }


### PR DESCRIPTION
Fixes #847. 

Motivation:

On 32-bit systems, using .randomElement on a range larger than what can fit in Int32 (Int) causes a crash. After only 26 or 27 retries of a request using HTTPClient, the calculateBackoff method would run into this and crash consistently on an armv7 (32-bit) device.

Modifications:

A one-line fix to opt to using Int64.random on the same jitterRange instead of .randomElement, which works as expected without crashing on 32-bit systems.

Result:

The HTTPClient now works as expected and can perform as many retries as needed without crashing.

I tested this on my armv7 board doing the retries, and ran up to several hundred repetitions after a few hours with no crashes as was happening before.

@Lukasa 