### PR TITLE
Deflake HTTP2ConnectionTests/testSimpleGetRequest

### DIFF
--- a/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ConnectionTests.swift
@@ -115,7 +115,6 @@ class HTTP2ConnectionTests: XCTestCase {
 
         http2Connection.executeRequest(requestBag)
 
-        XCTAssertEqual(delegate.hitStreamClosed, 0)
         var maybeResponse: HTTPClient.Response?
         XCTAssertNoThrow(maybeResponse = try requestBag.task.futureResult.wait())
         XCTAssertEqual(maybeResponse?.status, .ok)


### PR DESCRIPTION
Motivation:

testSimpleGetRequest asserts right after submitting the request for execution that no streams have been closed. While unlikely there's nothing to prevent this assertion from failing (and indeed it has failed): the request may have executed immediately and the stream closed before checking the delegate.

Modifications:

- Remove the assertion

Result:

Tests are less flaky