### PR TITLE
Weakly capture the `HTTPConnectionPool` in the idle connection timeout task

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool.swift
@@ -394,7 +394,10 @@ final class HTTPConnectionPool:
                 "ahc-connection-id": "\(connectionID)"
             ]
         )
-        let scheduled = eventLoop.scheduleTask(in: self.idleConnectionTimeout) {
+        let scheduled = eventLoop.scheduleTask(in: self.idleConnectionTimeout) { [weak self] in
+            guard let self else {
+                return
+            }
             // there might be a race between a cancelTimer call and the triggering
             // of this scheduled task. both want to acquire the lock
             self.modifyStateAndRunActions { stateMachine in


### PR DESCRIPTION
Currently, the `HTTPConnectionPool` will be kept alive until the idle connection timeout has fired. I don’t see a reason to keep the `HTTPConnectionPool` around if the idle connection timeout future is the only thing that’s still referencing the `HTTPConnectionPool`.