### PR TITLE
Fix trailing space in ConnectionPool.Key string

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool.swift
@@ -76,7 +76,7 @@ enum ConnectionPool {
                 hostDescription = socketPath
             }
             return
-                "\(self.scheme)://\(hostDescription)\(self.serverNameIndicatorOverride.map { " SNI: \($0)" } ?? "") TLS-hash: \(hash) "
+                "\(self.scheme)://\(hostDescription)\(self.serverNameIndicatorOverride.map { " SNI: \($0)" } ?? "") TLS-hash: \(hash)"
         }
     }
 }


### PR DESCRIPTION
Motivation:

The trailing space is visible in log message metadata, and depending upon the log handler in use, will sometimes be visible due to quoting.

Modifications:

Just remove the trailing space.

Result:

There won't be a trailing space in the key anymore. This has no functional impact whatsoever as far as I was able to determine.