### PR TITLE
[Tracing] Default tracer to global bootstrapped tracer

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -1095,7 +1095,11 @@ public final class HTTPClient: Sendable {
         package var attributeKeys: AttributeKeys
 
         public init() {
-            self._tracer = nil
+            if #available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *) {
+                self._tracer = InstrumentationSystem.tracer
+            } else {
+                self._tracer = nil
+            }
             self.attributeKeys = .init()
         }
 


### PR DESCRIPTION
The default tracer should be picked up at configuration creation time from the bootstrapped one, so we don't have to manually configure it in the simplest cases.

It is possible to disable it by explicitly setting `nil` on the tracing configuration, even if the global tracer was bootstrapped.

FYI @slashmo 