### PR TITLE
Remove CollectEverythingLogHandler implementation in favour of InMemoryLogHandler from swift-log

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.36.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.26.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.24.0"),
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.7.1"),
         .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
         .package(url: "https://github.com/apple/swift-algorithms.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-distributed-tracing.git", from: "1.3.0"),
@@ -92,6 +92,7 @@ let package = Package(
                 .product(name: "Algorithms", package: "swift-algorithms"),
                 // Observability support
                 .product(name: "Logging", package: "swift-log"),
+                .product(name: "InMemoryLogging", package: "swift-log"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
                 .product(name: "InMemoryTracing", package: "swift-distributed-tracing"),
             ],

--- a/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClient+SOCKSTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import AsyncHTTPClient  // NOT @testable - tests that need @testable go into HTTPClientInternalTests.swift
+import InMemoryLogging
 import Logging
 import NIOCore
 import NIOHTTP1
@@ -27,7 +28,7 @@ class HTTPClientSOCKSTests: XCTestCase {
     var serverGroup: EventLoopGroup!
     var defaultHTTPBin: HTTPBin<HTTPBinHandler>!
     var defaultClient: HTTPClient!
-    var backgroundLogStore: CollectEverythingLogHandler.LogStore!
+    var backgroundLogStore: InMemoryLogHandler!
 
     var defaultHTTPBinURLPrefix: String {
         "http://localhost:\(self.defaultHTTPBin.port)/"
@@ -43,14 +44,8 @@ class HTTPClientSOCKSTests: XCTestCase {
         self.clientGroup = getDefaultEventLoopGroup(numberOfThreads: 1)
         self.serverGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.defaultHTTPBin = HTTPBin()
-        self.backgroundLogStore = CollectEverythingLogHandler.LogStore()
-        var backgroundLogger = Logger(
-            label: "\(#function)",
-            factory: { _ in
-                CollectEverythingLogHandler(logStore: self.backgroundLogStore!)
-            }
-        )
-        backgroundLogger.logLevel = .trace
+        let (backgroundLogStore, backgroundLogger) = InMemoryLogHandler.makeLogger(logLevel: .trace)
+        self.backgroundLogStore = backgroundLogStore
         self.defaultClient = HTTPClient(
             eventLoopGroupProvider: .shared(self.clientGroup),
             backgroundActivityLogger: backgroundLogger

--- a/Tests/AsyncHTTPClientTests/HTTPClientBase.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientBase.swift
@@ -14,6 +14,7 @@
 
 import AsyncHTTPClient
 import Atomics
+import InMemoryLogging
 import Logging
 import NIOConcurrencyHelpers
 import NIOCore
@@ -37,7 +38,7 @@ class XCTestCaseHTTPClientTestsBaseClass: XCTestCase {
     var serverGroup: EventLoopGroup!
     var defaultHTTPBin: HTTPBin<HTTPBinHandler>!
     var defaultClient: HTTPClient!
-    var backgroundLogStore: CollectEverythingLogHandler.LogStore!
+    var backgroundLogStore: InMemoryLogHandler!
 
     var defaultHTTPBinURLPrefix: String {
         self.defaultHTTPBin.baseURL
@@ -53,14 +54,8 @@ class XCTestCaseHTTPClientTestsBaseClass: XCTestCase {
         self.clientGroup = getDefaultEventLoopGroup(numberOfThreads: 1)
         self.serverGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         self.defaultHTTPBin = HTTPBin()
-        self.backgroundLogStore = CollectEverythingLogHandler.LogStore()
-        var backgroundLogger = Logger(
-            label: "\(#function)",
-            factory: { _ in
-                CollectEverythingLogHandler(logStore: self.backgroundLogStore!)
-            }
-        )
-        backgroundLogger.logLevel = .trace
+        let (backgroundLogStore, backgroundLogger) = InMemoryLogHandler.makeLogger(logLevel: .trace)
+        self.backgroundLogStore = backgroundLogStore
 
         self.defaultClient = HTTPClient(
             eventLoopGroupProvider: .shared(self.clientGroup),


### PR DESCRIPTION
Swift log now has an InMemoryLogHandler. Lets depend on that instead of having our own `CollectEverythingLogHandler`.

I've added an extension on top, to make it easier to create the logger too

Result: less code