### PR TITLE
Mark `HTTPClientRequest.Prepared` as Sendable

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/HTTPClientRequest+Prepared.swift
@@ -22,8 +22,8 @@ import struct Foundation.URL
 
 @available(macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0, *)
 extension HTTPClientRequest {
-    struct Prepared {
-        enum Body {
+    struct Prepared: Sendable {
+        enum Body: Sendable {
             case asyncSequence(
                 length: RequestBodyLength,
                 makeAsyncIterator: @Sendable () -> ((ByteBufferAllocator) async throws -> ByteBuffer?)
@@ -31,7 +31,7 @@ extension HTTPClientRequest {
             case sequence(
                 length: RequestBodyLength,
                 canBeConsumedMultipleTimes: Bool,
-                makeCompleteBody: (ByteBufferAllocator) -> ByteBuffer
+                makeCompleteBody: @Sendable (ByteBufferAllocator) -> ByteBuffer
             )
             case byteBuffer(ByteBuffer)
         }


### PR DESCRIPTION
`Transaction` is @unchecked Sendable, since its NIOLockedValueBox can not infer Sendability if its value isn't Sendable. The @unchecked Sendable annotation has hidden the fact, that `HTTPClientRequest.Prepared` needs to be Sendable as well. Let's make this right in this PR.