### PR TITLE
Use a smaller max buffer size on 32-bit platforms

### DIFF
--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -543,7 +543,8 @@ public final class ResponseAccumulator: HTTPClientResponseDelegate {
     let requestMethod: HTTPMethod
     let requestHost: String
 
-    static let maxByteBufferSize = Int(UInt32.max)
+    // This is either UInt32.max, or Int.max on platforms where that value is smaller.
+    static let maxByteBufferSize = Int(exactly: UInt32.max) ?? Int(Int32.max)
 
     /// Maximum size in bytes of the HTTP response body that ``ResponseAccumulator`` will accept
     /// until it will abort the request and throw an ``ResponseTooBigError``.

--- a/Tests/AsyncHTTPClientTests/HTTP1ClientChannelHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP1ClientChannelHandlerTests.swift
@@ -946,6 +946,16 @@ class HTTP1ClientChannelHandlerTests: XCTestCase {
             ]
         )
     }
+
+    func testDefaultMaxBufferSize() {
+        if MemoryLayout<Int>.size == 8 {
+            XCTAssertEqual(ResponseAccumulator.maxByteBufferSize, Int(UInt32.max))
+        } else if MemoryLayout<Int>.size == 4 {
+            XCTAssertEqual(ResponseAccumulator.maxByteBufferSize, Int(Int32.max))
+        } else {
+            XCTFail("What platform is this?")
+        }
+    }
 }
 
 final class TestBackpressureWriter: Sendable {


### PR DESCRIPTION
Resolves #884 