### PR TITLE
switch from main to 0.0.7 for swiftlang workflows

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
     soundness:
         name: Soundness
-        uses: swiftlang/github-workflows/.github/workflows/soundness.yml@main
+        uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.7
         with:
             license_header_check_project_name: "AsyncHTTPClient"
     unit-tests:


### PR DESCRIPTION
Motivation

* `@main` references to `swiftlang/github-workflows` are deprecated.

Modifications

* Replace `@main` with `@0.0.7` in all workflow files.

Result

* Workflow files reference a pinned version of `swiftlang/github-workflows`.
