### PR TITLE
Fix 'occured' -> 'occurred' typos in 3 Swift source files

### DIFF
--- a/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift
@@ -163,7 +163,7 @@ extension Transaction {
                 }
 
             case .executing(let context, let requestStreamState, .finished):
-                // an error occured after full response received, but before the full request was sent
+                // an error occurred after full response received, but before the full request was sent
                 self.state = .finished(error: error)
                 switch requestStreamState {
                 case .paused(let bodyStreamContinuation):

--- a/Sources/AsyncHTTPClient/HTTPHandler.swift
+++ b/Sources/AsyncHTTPClient/HTTPHandler.swift
@@ -802,7 +802,7 @@ public protocol HTTPClientResponseDelegate: AnyObject, Sendable {
     ///
     /// - parameters:
     ///     - task: Current request context.
-    ///     - error: Error that occured during response processing.
+    ///     - error: Error that occurred during response processing.
     func didReceiveError(task: HTTPClient.Task<Response>, _ error: Error)
 
     /// Called when the complete HTTP request is finished. You must return an instance of your ``Response`` associated type. Will be called once, except if an error occurred.

--- a/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
+++ b/Sources/AsyncHTTPClient/RequestBag+StateMachine.swift
@@ -38,7 +38,7 @@ extension RequestBag {
             case queued(HTTPRequestScheduler, RedirectHandler<Delegate.Response>?)
             /// if the deadline was exceeded while in the `.queued(_:)` state,
             /// we wait until the request pool fails the request with a potential more descriptive error message,
-            /// if a connection failure has occured while the request was queued.
+            /// if a connection failure has occurred while the request was queued.
             case deadlineExceededWhileQueued
             case executing(HTTPRequestExecutor, RequestStreamState, ResponseStreamState)
             case finished(error: Error?)
@@ -545,7 +545,7 @@ extension RequestBag.StateMachine {
 
         case .finished(error: .none):
             preconditionFailure(
-                "Invalid state... If no error occured, this must not be called, after the request was finished"
+                "Invalid state... If no error occurred, this must not be called, after the request was finished"
             )
 
         case .modifying:


### PR DESCRIPTION
Fix 4 instances of `occured` → `occurred` across 3 files:

- `Sources/AsyncHTTPClient/HTTPHandler.swift` line 805: Doc comment on `error` parameter
- `Sources/AsyncHTTPClient/RequestBag+StateMachine.swift` lines 41, 548: Comment + internal error message
- `Sources/AsyncHTTPClient/AsyncAwait/Transaction+StateMachine.swift` line 166: Comment

Comment/string-literal-only change.