### PR TITLE
[Crash] Avoid iOS 16 URL parsing crash in stringWithUserAndPasswordStripped

### DIFF
--- a/Sources/AsyncHTTPClient/TracingSupport.swift
+++ b/Sources/AsyncHTTPClient/TracingSupport.swift
@@ -136,7 +136,12 @@ internal struct HTTPRequestCancellationError: Error {}
 extension URL {
     /// Returns the absolute string of `url` with any embedded credentials (username and password) removed to avoid logging secrets.
     fileprivate var stringWithUserAndPasswordStripped: String? {
-        if #available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *) {
+        // NOTE: Deliberately gated on iOS 17 (not the iOS 16 the percent-encoded `user()`/`password()`
+        // APIs were introduced in). On iOS 16, calling these APIs can crash inside the shared URL
+        // component parsing code (the trap surfaces in `URL.host(percentEncoded:)` even though `host`
+        // is never called here) - see https://forums.swift.org/t/70452. The legacy, non-percent-encoded
+        // `user`/`password` properties below don't hit that bug and are used as a workaround on iOS 16.
+        if #available(macOS 14.0, iOS 17.0, tvOS 17.0, watchOS 10.0, *) {
             guard self.user() != nil || self.password() != nil else {
                 return self.absoluteString
             }


### PR DESCRIPTION
## Summary

`URL.stringWithUserAndPasswordStripped` (added in #906, used by the built-in span attribute support from #857) calls the percent-encoded `URL.user()` / `URL.password()` accessors when `#available(macOS 13.0, iOS 16.0, tvOS 16.0, watchOS 9.0, *)`.

On iOS 16, calling these accessors can crash inside Foundation's URL parsing. The trap surfaces at `URL.host(percentEncoded:)` even though `.host()` is never called from this code path — the new percent-encoded accessors appear to share internal component-parsing code with host parsing on that OS version. Swift Forums has a report of the same crash signature triggered by a different percent-encoded accessor (`URL.query(percentEncoded:)`), also surfacing inside `URL.host(percentEncoded:)`: https://forums.swift.org/t/does-url-query-percentencoded-calls-url-host-percentencoded-under-the-hood/70452

Since `HTTPClient.TracingConfiguration.init()` defaults to `InstrumentationSystem.tracer` (typically a no-op tracer when the app hasn't bootstrapped one), this code path runs on effectively every request made through `HTTPClient`/`HTTP2ClientRequestHandler`, not only when an app has opted into tracing. That makes this a crash-on-every-request risk for any app running on affected iOS 16 devices.

## Fix

Raise the `#available` gate from iOS 16/macOS 13 to iOS 17/macOS 14 (and the corresponding tvOS/watchOS versions), so iOS 16 falls back to the existing legacy branch using the older, non-percent-encoded `user`/`password` properties, which do not hit this bug.

## Testing

- `swift build` succeeds.
- Crash observed and confirmed in a production Crashlytics report on the crashed thread `nio.transportservices.eventloop.taskqueue`, with the trap in `URL.host(percentEncoded:)` reached via `stringWithUserAndPasswordStripped.getter` → `handleRequestTracingAttributes` → `RequestBag.LoopBoundState.startRequestSpan(tracer:)` → `RequestBag.willExecuteRequest0(_:)` → `HTTP2ClientRequestHandler.write(context:data:promise:)`.