### PR TITLE
Add allowsExpensiveNetworkAccess/allowsConstrainedNetworkAccess to HTTPClient.Configuration

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -440,9 +440,9 @@ extension HTTPConnectionPool.ConnectionFactory {
     /// closure rather than composing across calls, so every concern that needs `NWParameters` must
     /// be folded into a single call to this method instead of separate `configureNWParameters { }`
     /// invocations. Callers already run under `#available(OSX 10.14, iOS 12.0, tvOS 12.0,
-    /// watchOS 6.0, *)`, the minimum for `NWParameters` itself; fields with a higher minimum
-    /// (`prohibitConstrainedPaths`, `allowUltraConstrainedPaths`) are individually re-checked below
-    /// instead of raising that requirement for the whole method.
+    /// watchOS 6.0, *)`, the minimum for `NWParameters` itself; `prohibitConstrainedPaths`, which
+    /// has a higher minimum, is individually re-checked below instead of raising that requirement
+    /// for the whole method.
     @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
     private func configureNWParameters(_ params: NWParameters, localAddress: String?) {
         if let localAddress {
@@ -451,32 +451,9 @@ extension HTTPConnectionPool.ConnectionFactory {
                 port: .any
             )
         }
-        if !self.clientConfiguration.prohibitedInterfaceTypes.isEmpty {
-            params.prohibitedInterfaceTypes = self.clientConfiguration.prohibitedInterfaceTypes.map {
-                switch $0.backing {
-                case .other: return .other
-                case .wifi: return .wifi
-                case .cellular: return .cellular
-                case .wiredEthernet: return .wiredEthernet
-                case .loopback: return .loopback
-                }
-            }
-        }
-        if let required = self.clientConfiguration.requiredInterfaceType {
-            switch required.backing {
-            case .other: params.requiredInterfaceType = .other
-            case .wifi: params.requiredInterfaceType = .wifi
-            case .cellular: params.requiredInterfaceType = .cellular
-            case .wiredEthernet: params.requiredInterfaceType = .wiredEthernet
-            case .loopback: params.requiredInterfaceType = .loopback
-            }
-        }
         params.prohibitExpensivePaths = !self.clientConfiguration.allowsExpensiveNetworkAccess
         if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
             params.prohibitConstrainedPaths = !self.clientConfiguration.allowsConstrainedNetworkAccess
-        }
-        if #available(OSX 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *) {
-            params.allowUltraConstrainedPaths = self.clientConfiguration.allowsUltraConstrainedPaths
         }
     }
     #endif

--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTPConnectionPool+Factory.swift
@@ -434,6 +434,53 @@ extension HTTPConnectionPool.ConnectionFactory {
         }
     }
 
+    #if canImport(Network)
+    /// Applies every `HTTPClient.Configuration` field that maps onto `NWParameters` in one place.
+    /// `NIOTSConnectionBootstrap.configureNWParameters(_:)` stores only the most recently passed
+    /// closure rather than composing across calls, so every concern that needs `NWParameters` must
+    /// be folded into a single call to this method instead of separate `configureNWParameters { }`
+    /// invocations. Callers already run under `#available(OSX 10.14, iOS 12.0, tvOS 12.0,
+    /// watchOS 6.0, *)`, the minimum for `NWParameters` itself; fields with a higher minimum
+    /// (`prohibitConstrainedPaths`, `allowUltraConstrainedPaths`) are individually re-checked below
+    /// instead of raising that requirement for the whole method.
+    @available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    private func configureNWParameters(_ params: NWParameters, localAddress: String?) {
+        if let localAddress {
+            params.requiredLocalEndpoint = NWEndpoint.hostPort(
+                host: NWEndpoint.Host(localAddress),
+                port: .any
+            )
+        }
+        if !self.clientConfiguration.prohibitedInterfaceTypes.isEmpty {
+            params.prohibitedInterfaceTypes = self.clientConfiguration.prohibitedInterfaceTypes.map {
+                switch $0.backing {
+                case .other: return .other
+                case .wifi: return .wifi
+                case .cellular: return .cellular
+                case .wiredEthernet: return .wiredEthernet
+                case .loopback: return .loopback
+                }
+            }
+        }
+        if let required = self.clientConfiguration.requiredInterfaceType {
+            switch required.backing {
+            case .other: params.requiredInterfaceType = .other
+            case .wifi: params.requiredInterfaceType = .wifi
+            case .cellular: params.requiredInterfaceType = .cellular
+            case .wiredEthernet: params.requiredInterfaceType = .wiredEthernet
+            case .loopback: params.requiredInterfaceType = .loopback
+            }
+        }
+        params.prohibitExpensivePaths = !self.clientConfiguration.allowsExpensiveNetworkAccess
+        if #available(OSX 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+            params.prohibitConstrainedPaths = !self.clientConfiguration.allowsConstrainedNetworkAccess
+        }
+        if #available(OSX 26.0, iOS 26.0, tvOS 26.0, watchOS 26.0, visionOS 26.0, *) {
+            params.allowUltraConstrainedPaths = self.clientConfiguration.allowsUltraConstrainedPaths
+        }
+    }
+    #endif
+
     private func makePlainBootstrap<Requester: HTTPConnectionRequester>(
         requester: Requester,
         connectionID: HTTPConnectionPool.Connection.ID,
@@ -470,13 +517,8 @@ extension HTTPConnectionPool.ConnectionFactory {
                         return channel.eventLoop.makeFailedFuture(error)
                     }
                 }
-            if let localAddress = self.key.localAddress {
-                bootstrap = bootstrap.configureNWParameters { params in
-                    params.requiredLocalEndpoint = NWEndpoint.hostPort(
-                        host: NWEndpoint.Host(localAddress),
-                        port: .any
-                    )
-                }
+            bootstrap = bootstrap.configureNWParameters { params in
+                self.configureNWParameters(params, localAddress: self.key.localAddress)
             }
             return bootstrap
         }
@@ -621,13 +663,8 @@ extension HTTPConnectionPool.ConnectionFactory {
                             return channel.eventLoop.makeFailedFuture(error)
                         }
                     }
-                if let localAddress = localAddr {
-                    bootstrap = bootstrap.configureNWParameters { params in
-                        params.requiredLocalEndpoint = NWEndpoint.hostPort(
-                            host: NWEndpoint.Host(localAddress),
-                            port: .any
-                        )
-                    }
+                bootstrap = bootstrap.configureNWParameters { params in
+                    self.configureNWParameters(params, localAddress: localAddr)
                 }
                 return bootstrap as NIOClientTCPBootstrapProtocol
             }

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -903,19 +903,6 @@ public final class HTTPClient: Sendable {
         /// which is the recommended setting. Only set this to `false` when attempting to trigger a particular error path.
         public var networkFrameworkWaitForConnectivity: Bool
 
-        /// Interface types that connections must not use (e.g. `[.cellular]` to forbid cellular).
-        /// Defaults to empty — no restriction. Mirrors `NWParameters.prohibitedInterfaceTypes`.
-        /// Only applies when Network.framework is used as the transport (Darwin platforms);
-        /// ignored otherwise.
-        public var prohibitedInterfaceTypes: Set<NetworkInterfaceType> = []
-
-        /// The single interface type connections are restricted to (e.g. `.wifi` to forbid
-        /// everything but Wi-Fi). Defaults to `nil` — no restriction. Mirrors
-        /// `NWParameters.requiredInterfaceType`, but as an `Optional` instead of that property's
-        /// non-optional `.other`-means-"unrestricted" sentinel. Only applies when Network.framework
-        /// is used as the transport; ignored otherwise.
-        public var requiredInterfaceType: NetworkInterfaceType?
-
         /// Whether the connection may use an expensive network path (e.g. cellular, personal
         /// hotspot). Defaults to `true`. Mirrors `NWParameters.prohibitExpensivePaths` (inverted).
         /// Only applies when Network.framework is used as the transport; ignored otherwise.
@@ -925,14 +912,6 @@ public final class HTTPClient: Sendable {
         /// Defaults to `true`. Mirrors `NWParameters.prohibitConstrainedPaths` (inverted).
         /// Only applies when Network.framework is used as the transport; ignored otherwise.
         public var allowsConstrainedNetworkAccess: Bool = true
-
-        /// Whether the connection may use an ultra-constrained network path. Defaults to `false`.
-        /// Mirrors `NWParameters.allowUltraConstrainedPaths` directly (same polarity, unlike
-        /// ``allowsExpensiveNetworkAccess`` / ``allowsConstrainedNetworkAccess`` above). Only takes
-        /// effect on OS versions where `NWParameters.allowUltraConstrainedPaths` exists (macOS 26.0 /
-        /// iOS 26.0 / watchOS 26.0 / tvOS 26.0 / visionOS 26.0 and newer); a no-op everywhere else,
-        /// including older Network.framework-capable OS versions, not just non-Darwin platforms.
-        public var allowsUltraConstrainedPaths: Bool = false
 
         /// The maximum number of times each connection can be used before it is replaced with a new one. Use `nil` (the default)
         /// if no limit should be applied to each connection.
@@ -1509,38 +1488,6 @@ extension HTTPClient.Configuration {
         public static let automatic: Self = .init(configuration: .automatic)
 
         var configuration: Configuration
-    }
-
-    /// A network interface category, mirroring `NWInterface.InterfaceType` (`Network.framework`)
-    /// without requiring `Network` to be imported at this declaration site, so it can be declared
-    /// unconditionally like ``HTTPClient/Configuration-swift.struct/networkFrameworkWaitForConnectivity``.
-    /// Only meaningful when Network.framework is used as the transport (Darwin platforms); ignored
-    /// otherwise.
-    public struct NetworkInterfaceType: Sendable, Hashable {
-        enum Backing: Sendable, Hashable {
-            case other
-            case wifi
-            case cellular
-            case wiredEthernet
-            case loopback
-        }
-
-        let backing: Backing
-
-        private init(backing: Backing) {
-            self.backing = backing
-        }
-
-        /// Mirrors `NWInterface.InterfaceType.other`.
-        public static let other: Self = .init(backing: .other)
-        /// Mirrors `NWInterface.InterfaceType.wifi`.
-        public static let wifi: Self = .init(backing: .wifi)
-        /// Mirrors `NWInterface.InterfaceType.cellular`.
-        public static let cellular: Self = .init(backing: .cellular)
-        /// Mirrors `NWInterface.InterfaceType.wiredEthernet`.
-        public static let wiredEthernet: Self = .init(backing: .wiredEthernet)
-        /// Mirrors `NWInterface.InterfaceType.loopback`.
-        public static let loopback: Self = .init(backing: .loopback)
     }
 }
 

--- a/Sources/AsyncHTTPClient/HTTPClient.swift
+++ b/Sources/AsyncHTTPClient/HTTPClient.swift
@@ -903,6 +903,37 @@ public final class HTTPClient: Sendable {
         /// which is the recommended setting. Only set this to `false` when attempting to trigger a particular error path.
         public var networkFrameworkWaitForConnectivity: Bool
 
+        /// Interface types that connections must not use (e.g. `[.cellular]` to forbid cellular).
+        /// Defaults to empty — no restriction. Mirrors `NWParameters.prohibitedInterfaceTypes`.
+        /// Only applies when Network.framework is used as the transport (Darwin platforms);
+        /// ignored otherwise.
+        public var prohibitedInterfaceTypes: Set<NetworkInterfaceType> = []
+
+        /// The single interface type connections are restricted to (e.g. `.wifi` to forbid
+        /// everything but Wi-Fi). Defaults to `nil` — no restriction. Mirrors
+        /// `NWParameters.requiredInterfaceType`, but as an `Optional` instead of that property's
+        /// non-optional `.other`-means-"unrestricted" sentinel. Only applies when Network.framework
+        /// is used as the transport; ignored otherwise.
+        public var requiredInterfaceType: NetworkInterfaceType?
+
+        /// Whether the connection may use an expensive network path (e.g. cellular, personal
+        /// hotspot). Defaults to `true`. Mirrors `NWParameters.prohibitExpensivePaths` (inverted).
+        /// Only applies when Network.framework is used as the transport; ignored otherwise.
+        public var allowsExpensiveNetworkAccess: Bool = true
+
+        /// Whether the connection may use a constrained network path (e.g. Low Data Mode).
+        /// Defaults to `true`. Mirrors `NWParameters.prohibitConstrainedPaths` (inverted).
+        /// Only applies when Network.framework is used as the transport; ignored otherwise.
+        public var allowsConstrainedNetworkAccess: Bool = true
+
+        /// Whether the connection may use an ultra-constrained network path. Defaults to `false`.
+        /// Mirrors `NWParameters.allowUltraConstrainedPaths` directly (same polarity, unlike
+        /// ``allowsExpensiveNetworkAccess`` / ``allowsConstrainedNetworkAccess`` above). Only takes
+        /// effect on OS versions where `NWParameters.allowUltraConstrainedPaths` exists (macOS 26.0 /
+        /// iOS 26.0 / watchOS 26.0 / tvOS 26.0 / visionOS 26.0 and newer); a no-op everywhere else,
+        /// including older Network.framework-capable OS versions, not just non-Darwin platforms.
+        public var allowsUltraConstrainedPaths: Bool = false
+
         /// The maximum number of times each connection can be used before it is replaced with a new one. Use `nil` (the default)
         /// if no limit should be applied to each connection.
         ///
@@ -1478,6 +1509,38 @@ extension HTTPClient.Configuration {
         public static let automatic: Self = .init(configuration: .automatic)
 
         var configuration: Configuration
+    }
+
+    /// A network interface category, mirroring `NWInterface.InterfaceType` (`Network.framework`)
+    /// without requiring `Network` to be imported at this declaration site, so it can be declared
+    /// unconditionally like ``HTTPClient/Configuration-swift.struct/networkFrameworkWaitForConnectivity``.
+    /// Only meaningful when Network.framework is used as the transport (Darwin platforms); ignored
+    /// otherwise.
+    public struct NetworkInterfaceType: Sendable, Hashable {
+        enum Backing: Sendable, Hashable {
+            case other
+            case wifi
+            case cellular
+            case wiredEthernet
+            case loopback
+        }
+
+        let backing: Backing
+
+        private init(backing: Backing) {
+            self.backing = backing
+        }
+
+        /// Mirrors `NWInterface.InterfaceType.other`.
+        public static let other: Self = .init(backing: .other)
+        /// Mirrors `NWInterface.InterfaceType.wifi`.
+        public static let wifi: Self = .init(backing: .wifi)
+        /// Mirrors `NWInterface.InterfaceType.cellular`.
+        public static let cellular: Self = .init(backing: .cellular)
+        /// Mirrors `NWInterface.InterfaceType.wiredEthernet`.
+        public static let wiredEthernet: Self = .init(backing: .wiredEthernet)
+        /// Mirrors `NWInterface.InterfaceType.loopback`.
+        public static let loopback: Self = .init(backing: .loopback)
     }
 }
 

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -189,4 +189,56 @@ class HTTPClientNIOTSTests: XCTestCase {
         }
         #endif
     }
+
+    func testNetworkPathRestrictionFieldsDontBreakRequests() {
+        guard isTestingNIOTS() else { return }
+        #if canImport(Network)
+        let httpBin = HTTPBin(.http1_1(ssl: false))
+        var config = HTTPClient.Configuration()
+        // Loopback isn't cellular/expensive/constrained, so none of these should block the request;
+        // this exercises the field plumbing (Configuration -> ConnectionFactory -> NWParameters)
+        // without needing a real cellular/constrained network path in CI.
+        config.prohibitedInterfaceTypes = [.cellular]
+        config.allowsExpensiveNetworkAccess = false
+        config.allowsConstrainedNetworkAccess = false
+        config.allowsUltraConstrainedPaths = false
+        // Also set localAddress, to cover the case that regressed `configureNWParameters`
+        // composition: local-address binding and interface restriction must both apply, since
+        // `NIOTSConnectionBootstrap.configureNWParameters(_:)` only keeps the most recent closure.
+        config.localAddress = "127.0.0.1"
+
+        let httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(self.clientGroup),
+            configuration: config
+        )
+        defer {
+            XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
+            XCTAssertNoThrow(try httpBin.shutdown())
+        }
+
+        XCTAssertNoThrow(try httpClient.get(url: "http://localhost:\(httpBin.port)/get").wait())
+        #endif
+    }
+
+    func testRequiredInterfaceTypeOtherDoesNotRestrictLoopback() {
+        guard isTestingNIOTS() else { return }
+        #if canImport(Network)
+        let httpBin = HTTPBin(.http1_1(ssl: false))
+        var config = HTTPClient.Configuration()
+        // `.other` mirrors NWParameters' own "unrestricted" default; setting it explicitly should
+        // behave the same as leaving `requiredInterfaceType` `nil`.
+        config.requiredInterfaceType = .other
+
+        let httpClient = HTTPClient(
+            eventLoopGroupProvider: .shared(self.clientGroup),
+            configuration: config
+        )
+        defer {
+            XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
+            XCTAssertNoThrow(try httpBin.shutdown())
+        }
+
+        XCTAssertNoThrow(try httpClient.get(url: "http://localhost:\(httpBin.port)/get").wait())
+        #endif
+    }
 }

--- a/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTPClientNIOTSTests.swift
@@ -195,39 +195,15 @@ class HTTPClientNIOTSTests: XCTestCase {
         #if canImport(Network)
         let httpBin = HTTPBin(.http1_1(ssl: false))
         var config = HTTPClient.Configuration()
-        // Loopback isn't cellular/expensive/constrained, so none of these should block the request;
+        // Loopback isn't expensive/constrained, so neither of these should block the request;
         // this exercises the field plumbing (Configuration -> ConnectionFactory -> NWParameters)
-        // without needing a real cellular/constrained network path in CI.
-        config.prohibitedInterfaceTypes = [.cellular]
+        // without needing a real constrained network path in CI.
         config.allowsExpensiveNetworkAccess = false
         config.allowsConstrainedNetworkAccess = false
-        config.allowsUltraConstrainedPaths = false
         // Also set localAddress, to cover the case that regressed `configureNWParameters`
-        // composition: local-address binding and interface restriction must both apply, since
+        // composition: local-address binding and path restriction must both apply, since
         // `NIOTSConnectionBootstrap.configureNWParameters(_:)` only keeps the most recent closure.
         config.localAddress = "127.0.0.1"
-
-        let httpClient = HTTPClient(
-            eventLoopGroupProvider: .shared(self.clientGroup),
-            configuration: config
-        )
-        defer {
-            XCTAssertNoThrow(try httpClient.syncShutdown(requiresCleanClose: true))
-            XCTAssertNoThrow(try httpBin.shutdown())
-        }
-
-        XCTAssertNoThrow(try httpClient.get(url: "http://localhost:\(httpBin.port)/get").wait())
-        #endif
-    }
-
-    func testRequiredInterfaceTypeOtherDoesNotRestrictLoopback() {
-        guard isTestingNIOTS() else { return }
-        #if canImport(Network)
-        let httpBin = HTTPBin(.http1_1(ssl: false))
-        var config = HTTPClient.Configuration()
-        // `.other` mirrors NWParameters' own "unrestricted" default; setting it explicitly should
-        // behave the same as leaving `requiredInterfaceType` `nil`.
-        config.requiredInterfaceType = .other
 
         let httpClient = HTTPClient(
             eventLoopGroupProvider: .shared(self.clientGroup),


### PR DESCRIPTION
## Context

Follow-up to #915, which was closed with the feedback that it overreached `URLSessionConfiguration` parity and that Apple-platform-specific transport tuning is better left to `URLSession`/`Network.framework` directly, or to the emerging cross-platform HTTP client abstraction ([forum thread](https://forums.swift.org/t/designing-an-http-client-api-for-swift/85254), [apple/swift-http-api-proposal](https://github.com/apple/swift-http-api-proposal/)).

Going back through `URLSessionConfiguration`'s actual surface, only two of the original five fields have a real 1:1 equivalent there:

- `allowsExpensiveNetworkAccess` ↔ `URLSessionConfiguration.allowsExpensiveNetworkAccess`
- `allowsConstrainedNetworkAccess` ↔ `URLSessionConfiguration.allowsConstrainedNetworkAccess`

The other three (`prohibitedInterfaceTypes`, `requiredInterfaceType`, `allowsUltraConstrainedPaths`) go beyond what `URLSessionConfiguration` itself exposes — `URLSession` only has the coarser `allowsCellularAccess` for interface restriction, and nothing for ultra-constrained paths. Adding those wasn't really "parity," so this PR drops them and keeps only the two fields that are genuinely mirroring `URLSession`.

## Modifications

- Add `HTTPClient.Configuration.allowsExpensiveNetworkAccess` / `allowsConstrainedNetworkAccess: Bool`, inverted mirrors of `NWParameters.prohibitExpensivePaths` / `.prohibitConstrainedPaths`, defaulting to `NWParameters`' own defaults (`true`/`true`).
- Wire both into `makePlainBootstrap` and `makeTLSBootstrap` in `HTTPConnectionPool+Factory.swift` via a `configureNWParameters(_:localAddress:)` helper, since `NIOTSConnectionBootstrap.configureNWParameters(_:)` only keeps the most recently passed closure — the existing `requiredLocalEndpoint`-binding closure and the new field wiring had to be folded into one closure to avoid silently dropping local-address binding.
- Add a regression test in `HTTPClientNIOTSTests.swift` exercising both fields together with `localAddress` set, covering the closure-composition issue above.

## Result

`HTTPClient.Configuration` can restrict connections to non-expensive / non-constrained network paths, matching the two fields `URLSessionConfiguration` actually exposes for this, on Darwin platforms using Network.framework as the transport. No-op everywhere else, same as the existing `networkFrameworkWaitForConnectivity` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)