### PR TITLE
Give HTTPClientError meaningful localized descriptions

### DIFF
--- a/Sources/AsyncHTTPClient/FoundationExtensions.swift
+++ b/Sources/AsyncHTTPClient/FoundationExtensions.swift
@@ -21,6 +21,12 @@ import FoundationEssentials
 import Foundation
 #endif
 
+extension HTTPClientError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}
+
 extension HTTPClient.Cookie {
     /// The cookie's expiration date.
     public var expires: Date? {

--- a/Tests/AsyncHTTPClientTests/FoundationExtensionTests.swift
+++ b/Tests/AsyncHTTPClientTests/FoundationExtensionTests.swift
@@ -19,6 +19,21 @@ import Testing
 
 @Suite
 struct FoundationExtensionTests {
+    @Test
+    func httpClientErrorLocalizedDescriptionUsesDescription() {
+        let error = HTTPClientError.cancelled
+
+        #expect(error.localizedDescription == error.description)
+    }
+
+    @Test
+    func httpClientErrorLocalizedDescriptionPreservesAssociatedValues() {
+        let error = HTTPClientError.unsupportedScheme("custom")
+
+        #expect(error.localizedDescription == error.description)
+        #expect(error.localizedDescription.contains("custom"))
+    }
+
     @Test(arguments: [
         // Format: (input, expected)
         ("localhost", "localhost"),  // Alphanumerics (No encoding needed)


### PR DESCRIPTION
### Motivation

HTTPClientError.localizedDescription currently falls back to Foundation’s generic error 1 message, which hides the underlying AsyncHTTPClient failure.

Fixes #797.

### Modifications

- Conform HTTPClientError to LocalizedError in the Foundation extensions layer.
- Return its existing full description from errorDescription.
- Add regression coverage for errors with and without associated values.

### Result

localizedDescription now reports the concrete HTTP client error and preserves diagnostic associated values.

### Testing

- swift test --explicit-target-dependency-import-check error -Xswiftc -warnings-as-errors --filter FoundationExtensionTests
- swift test