### PR TITLE
Reject the empty header field name

### DIFF
--- a/Sources/AsyncHTTPClient/RequestValidation.swift
+++ b/Sources/AsyncHTTPClient/RequestValidation.swift
@@ -47,6 +47,11 @@ extension HTTPHeaders {
 
     private func validateFieldNames() throws {
         let invalidFieldNames = self.compactMap { name, _ -> String? in
+            // [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names) defines
+            // `field-name = token`, and `token = 1*tchar`, so a field name must contain at least
+            // one character. `allSatisfy` alone is true for the empty name.
+            guard !name.isEmpty else { return name }
+
             let satisfy = name.utf8.allSatisfy { char -> Bool in
                 switch char {
                 case UInt8(ascii: "a")...UInt8(ascii: "z"),

--- a/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
+++ b/Tests/AsyncHTTPClientTests/RequestValidationTests.swift
@@ -82,6 +82,19 @@ class RequestValidationTests: XCTestCase {
         }
     }
 
+    func testEmptyHeaderFieldNameIsRejected() {
+        // RFC 9110 defines `field-name = token` and `token = 1*tchar`, so the empty
+        // name is not a valid field name.
+        var headers = HTTPHeaders([
+            ("", "Haha")
+        ])
+
+        XCTAssertThrowsError(try headers.validateAndSetTransportFraming(method: .GET, bodyLength: .known(0))) {
+            error in
+            XCTAssertEqual(error as? HTTPClientError, HTTPClientError.invalidHeaderFieldNames([""]))
+        }
+    }
+
     func testValidHeaderFieldNames() {
         var headers = HTTPHeaders([
             ("abcdefghijklmnopqrstuvwxyz", "Haha"),


### PR DESCRIPTION
`validateFieldNames` checks each name with `allSatisfy` over the tchar set. `allSatisfy` returns `true` for an empty collection, so a request carrying an empty field name passes validation and is sent.

[RFC 9110 § 5.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names) defines `field-name = token`, and § 5.6.2 defines `token = 1*tchar` — at least one character. The tchar set in this function is correct; I checked all fifteen symbols plus DIGIT and ALPHA against the ABNF. It is the `1*` quantifier that is missing.

### The change

A guard on the empty name before the character check, so it lands in `invalidFieldNames` like any other malformed name.

### Tests

Added `testEmptyHeaderFieldNameIsRejected` to `RequestValidationTests.swift`, next to the existing `testInvalidHeaderFieldNames` and `testValidHeaderFieldNames`, which already pin this function from both sides.

### Verification

**I could not run `swift test` here**: this machine has Command Line Tools without XCTest, so the test target fails at `import XCTest` with `no such module`. Pre-existing and unrelated — it reproduces on an unmodified checkout (126 occurrences). **CI should be the authority; treat my local run as unverified.**

`swift build` succeeds. I linked a throwaway executable against `AsyncHTTPClient` to exercise `validateAndSetTransportFraming` directly:

```
PASS empty field name ""      -> rejected
PASS space "a b"              -> rejected
PASS colon "a:b"              -> rejected
PASS CR "a\rb"                -> rejected
PASS valid "X-Test"           -> accepted
PASS full tchar set           -> accepted
```

Before the change the first case was accepted; the others were already handled.

### Cross-reference

I found the same class of gap — `allSatisfy` standing in for `1*tchar` — in swift-nio-http2 while checking whether this was specific to one implementation, and opened apple/swift-nio-http2#563 for it. Noting it here only so the two are easy to read together; the fixes are independent and neither depends on the other.

### Conflicts

No open PR touches `Sources/AsyncHTTPClient/RequestValidation.swift`. #291 shows up in a filename search but only modifies `Tests/AsyncHTTPClientTests/RequestValidationTests.swift`, in a streamwriter-API change last updated in 2020.