### PR TITLE
Fix HTTP/2 error after response completion

### DIFF
--- a/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2ClientRequestHandler.swift
+++ b/Sources/AsyncHTTPClient/ConnectionPool/HTTP2/HTTP2ClientRequestHandler.swift
@@ -244,9 +244,9 @@ final class HTTP2ClientRequestHandler: ChannelDuplexHandler {
             self.request!.receiveResponseBodyParts(parts)
 
         case .failRequest(let error, let finalAction):
-            // We can force unwrap the request here, as we have just validated in the state machine,
-            // that the request object is still present.
-            self.request!.fail(error)
+            // The request may already have completed after receiving a response end while its body
+            // was still streaming. A subsequent stream error must not fail that request twice.
+            self.request?.fail(error)
             self.request = nil
             self.runTimeoutAction(.clearIdleReadTimeoutTimer, context: context)
             self.runTimeoutAction(.clearIdleWriteTimeoutTimer, context: context)

--- a/Tests/AsyncHTTPClientTests/HTTP2ClientRequestHandlerTests.swift
+++ b/Tests/AsyncHTTPClientTests/HTTP2ClientRequestHandlerTests.swift
@@ -622,4 +622,37 @@ class HTTP2ClientRequestHandlerTests: XCTestCase {
         )
     }
 
+    func testErrorAfterResponseEndWhileRequestBodyIsStreamingDoesNotCrash() throws {
+        struct TestError: Error {}
+
+        let eventLoop = EmbeddedEventLoop()
+        let handler = HTTP2ClientRequestHandler(eventLoop: eventLoop)
+        let channel = EmbeddedChannel(handlers: [handler], loop: eventLoop)
+        try channel.connect(to: .init(ipAddress: "127.0.0.1", port: 80)).wait()
+
+        let request = MockHTTPExecutableRequest(
+            head: .init(version: .http1_1, method: .POST, uri: "http://localhost/"),
+            framingMetadata: .init(connectionClose: false, body: .stream),
+            raiseErrorIfUnimplementedMethodIsCalled: false
+        )
+
+        try channel.writeOutbound(request)
+        XCTAssertEqual(try channel.readOutbound(as: HTTPClientRequestPart.self), .head(request.requestHead))
+
+        try channel.writeInbound(HTTPClientResponsePart.head(.init(version: .http1_1, status: .ok)))
+        try channel.writeInbound(HTTPClientResponsePart.end(nil))
+
+        channel.pipeline.fireErrorCaught(TestError())
+        eventLoop.run()
+
+        XCTAssertFalse(channel.isActive)
+        XCTAssertEqual(
+            request.events.map(\.kind),
+            [
+                .willExecuteRequest, .requestHeadSent, .resumeRequestBodyStream, .receiveResponseHead,
+                .receiveResponseEnd,
+            ]
+        )
+    }
+
 }


### PR DESCRIPTION
Motivation:

An HTTP/2 stream error can arrive after a response end has completed the request while its request body is still streaming. `HTTP2ClientRequestHandler` clears the request on response completion and then force-unwraps it while processing the later error, causing the crash reported in #922.

Modifications:

- Only notify the request of failure when it is still present.
- Preserve timeout cancellation and HTTP/2 stream cleanup for the late error.
- Add a regression test for an error after response completion during a streaming upload.

Result:

Late HTTP/2 stream errors no longer crash the handler or fail an already-completed request.

Validation:

- `swift build`
- `swift format lint --strict --configuration .swift-format` on both changed files
- The exact reproducer attached to #922, pointed at this checkout: receives `200 OK`, completes normally, and exits 0 (unmodified 1.36.1 exits 133 at `HTTP2ClientRequestHandler.swift:249`).
- The XCTest suite could not run locally because this Command Line Tools installation does not include the XCTest Swift module; CI will provide that coverage.

Fixes #922